### PR TITLE
fix(portfolio-modern): correct PDF COPY source paths in Dockerfile

### DIFF
--- a/portfolio-modern/Dockerfile
+++ b/portfolio-modern/Dockerfile
@@ -40,9 +40,12 @@ COPY tsconfig.json next.config.ts postcss.config.mjs eslint.config.mjs ./
 COPY public ./public
 COPY src ./src
 
-# Bake freshly-built PDFs into public/ so the static export includes them
-COPY --from=pdfbuild /work/latex/output/Morten-Nordbye-Resume.pdf ./public/resume.pdf
-COPY --from=pdfbuild /work/latex/output/Morten-Nordbye-CV.pdf ./public/cv.pdf
+# Bake freshly-built PDFs into public/ so the static export includes them.
+# xelatex writes output/<input>.pdf — the Makefile renames these to
+# Morten-Nordbye-{Resume,CV}.pdf on the host, but inside this Dockerfile
+# we copy them straight to their public/ destinations.
+COPY --from=pdfbuild /work/latex/output/resume.pdf ./public/resume.pdf
+COPY --from=pdfbuild /work/latex/output/cv.pdf ./public/cv.pdf
 
 # Surface the commit SHA into the bundle so the footer can show it
 ARG BUILD_SHA=dev


### PR DESCRIPTION
The pdfbuild stage runs xelatex which writes output/resume.pdf and output/cv.pdf, but the build stage's COPY referenced Morten-Nordbye-*.pdf — a name that only exists when `make cv` (running outside the container) renames the PDFs on the host. The Dockerfile-only flow was never exercised before CI ran, so the mismatch was latent.

Drop the prefix from the COPY source paths; destination paths in public/ are unchanged.