### PR TITLE
fix(portfolio-modern): widen typewriter state type to string

### DIFF
--- a/portfolio-modern/src/components/sections/Hero.tsx
+++ b/portfolio-modern/src/components/sections/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
 
   const roles = site.hero.rotating;
   const [roleIndex, setRoleIndex] = useState(0);
-  const [text, setText] = useState(roles[0]);
+  const [text, setText] = useState<string>(roles[0]);
   type Phase = "pausing-full" | "deleting" | "pausing-empty" | "typing";
   const [phase, setPhase] = useState<Phase>("pausing-full");
 


### PR DESCRIPTION
`site.hero.rotating` is declared `as const`, so `roles[0]` carries the literal type "Cloud Engineer". useState inferred the state as that literal, then setText((t) => t.slice(...)) returned a plain string — not assignable back to the literal type.

Dev mode tolerated it; Next's production tsc didn't. Explicit useState<string>(roles[0]) fixes the build.