### PR TITLE
docs(diagrams): add external-dns to architecture diagrams

### DIFF
--- a/docs/diagrams/homelab-overview.d2
+++ b/docs/diagrams/homelab-overview.d2
@@ -163,6 +163,10 @@ k8s: Genesis · Talos Kubernetes {
       icon: ${di}/cert-manager.svg
     }
     eso: External Secrets
+    externaldns: external-dns {
+      shape: image
+      icon: ${di}/cloudflare.svg
+    }
     authentik: Authentik {
       shape: image
       icon: ${di}/authentik.svg

--- a/docs/diagrams/network-flow.d2
+++ b/docs/diagrams/network-flow.d2
@@ -51,6 +51,7 @@ net: Ingress & Cluster Networking {
   metallb: MetalLB {shape: image; icon: ${di}/metallb.svg}
   traefik: Traefik {shape: image; icon: ${di}/traefik.svg}
   cert: cert-manager {shape: image; icon: ${di}/cert-manager.svg}
+  externaldns: external-dns {shape: image; icon: ${di}/cloudflare.svg}
   coredns: CoreDNS {shape: image; icon: ${di}/coredns.svg}
   cilium: Cilium {shape: image; icon: ${di}/cilium.svg}
 }
@@ -181,6 +182,7 @@ net.traefik -> obs.grafana {style: {stroke: "#0284c7"}}
 # ── TLS / DNS (cyan dashed) ──
 net.cert -> net.traefik: certs {style: {stroke: "#0891b2"; stroke-dash: 4}}
 net.cert -> cloudflare: DNS-01 {style: {stroke: "#0891b2"; stroke-dash: 4}}
+net.externaldns -> cloudflare: CNAME records {style: {stroke: "#0891b2"; stroke-dash: 4}}
 cloudflare -> letsencrypt: ACME {style: {stroke: "#0891b2"; stroke-dash: 4}}
 
 # ── GitOps (indigo dashed) ──
@@ -201,6 +203,7 @@ ops.eso -> obs.alertmanager {style: {stroke: "#7c3aed"}}
 ops.eso -> sec.authentik {style: {stroke: "#7c3aed"}}
 ops.eso -> sec.sidekick {style: {stroke: "#7c3aed"}}
 ops.eso -> net.cert {style: {stroke: "#7c3aed"}}
+ops.eso -> net.externaldns {style: {stroke: "#7c3aed"}}
 ops.reloader -> sec.sidekick: reload {style: {stroke: "#9333ea"; stroke-dash: 4}}
 ops.reloader -> media.gluetun: reload {style: {stroke: "#9333ea"; stroke-dash: 4}}
 


### PR DESCRIPTION
Adds the newly deployed **external-dns** service to both architecture diagrams.

## Changes
- **homelab-overview.d2** — `external-dns` added to *Platform & Infrastructure* (cloudflare icon; no dedicated external-dns icon exists in the icon repos).
- **network-flow.d2** — `external-dns` added to *Ingress & Cluster Networking*, with flows:
  - `external-dns → Cloudflare: CNAME records` (sits beside cert-manager's DNS-01)
  - `External Secrets → external-dns` (shared Cloudflare token)

## Notes
- Source-only change; the `render-diagram.yaml` pipeline regenerates SVG + PNG on merge to main.
- Could not render locally (Docker daemon was down), so the rendered output is unverified — CI will produce it.