### PR TITLE
fix(headroom): make NFS data volume writable via fsGroup

### DIFF
--- a/k8s/talos/apps/headroom/deployment.yaml
+++ b/k8s/talos/apps/headroom/deployment.yaml
@@ -15,6 +15,18 @@ spec:
       labels:
         app: headroom
     spec:
+      # The headroom image starts as root, fixes /data ownership, then drops to
+      # uid 1000 (node) — but only when that uid can actually write the volume.
+      # On this Synology NFS PVC the in-container chown doesn't stick, so it
+      # falls back to running as root (which the export permits). fsGroup asks
+      # the CSI to make the volume group-writable by gid 1000 so it can run
+      # non-root where the driver supports it; NFS drivers that ignore fsGroup
+      # simply use the root fallback. Do NOT add runAsUser here — starting the
+      # pod non-root removes the entrypoint's ability to escalate for the
+      # fallback and reintroduces the SQLITE_CANTOPEN startup crash.
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: headroom
           image: ghcr.io/mortennordbye/headroom:latest


### PR DESCRIPTION
The headroom app image now drops to a non-root user (uid 1000) at startup. On the Synology NFS PVC (`syno-nfs-csi`) the in-container `chown` doesn't stick, so the app can't write `/data` and crashes on boot with `SQLITE_CANTOPEN`.

This adds a pod-level `securityContext.fsGroup: 1000` so the CSI makes the volume group-writable by the app. Where the NFS driver ignores `fsGroup`, the image entrypoint falls back to running as root — which the export already permits (the pre-audit root-only image wrote there fine) — so the app starts either way.

Note: intentionally no `runAsUser` — starting the pod non-root would remove the entrypoint's ability to escalate for the root fallback.

Pairs with the app-side entrypoint fix in `mortennordbye/headroom` (drop to non-root only when the data volume is writable, else stay root). Roll the deployment after that image reaches `:latest`:

```
kubectl -n headroom rollout restart deployment/headroom
```