### PR TITLE
fix(headroom): allow the gateway hostname (ALLOWED_HOSTS)

### DIFF
--- a/k8s/talos/apps/headroom/deployment.yaml
+++ b/k8s/talos/apps/headroom/deployment.yaml
@@ -31,6 +31,13 @@ spec:
         - name: headroom
           image: ghcr.io/mortennordbye/headroom:latest
           imagePullPolicy: Always
+          env:
+            # The app enforces a Host-header allowlist (DNS-rebinding guard) that
+            # defaults to loopback only, so it 403s ("host not allowed") behind
+            # the gateway. List the external hostname(s) it's served on. Loopback
+            # is kept for any in-cluster/localhost checks.
+            - name: ALLOWED_HOSTS
+              value: "headroom.local.bigd.no,localhost,127.0.0.1"
           ports:
             - containerPort: 3001
           volumeMounts:


### PR DESCRIPTION
The app enforces a Host-header allowlist (a DNS-rebinding guard from the recent security audit) that defaults to loopback only. Reached via the gateway at `headroom.local.bigd.no`, it returns `403 {"error":"host not allowed"}`.

Sets `ALLOWED_HOSTS` to the external hostname (plus loopback) so legitimate traffic is accepted while keeping the guard active. Add more comma-separated hosts here if the app is served on additional names.

After merge: `kubectl -n headroom rollout restart deployment/headroom`.