### PR TITLE
fix(k8s): use Recreate strategy for deployments with RWO block volumes

### DIFF
--- a/k8s/talos/apps/arr-stack/bazarr.yaml
+++ b/k8s/talos/apps/arr-stack/bazarr.yaml
@@ -31,6 +31,8 @@ metadata:
   namespace: arr-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: bazarr

--- a/k8s/talos/apps/arr-stack/cleanuparr.yaml
+++ b/k8s/talos/apps/arr-stack/cleanuparr.yaml
@@ -31,6 +31,8 @@ metadata:
   namespace: arr-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: cleanuparr

--- a/k8s/talos/apps/arr-stack/flaresolverr.yaml
+++ b/k8s/talos/apps/arr-stack/flaresolverr.yaml
@@ -31,6 +31,8 @@ metadata:
   namespace: arr-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: flaresolverr

--- a/k8s/talos/apps/arr-stack/huntarr.yaml
+++ b/k8s/talos/apps/arr-stack/huntarr.yaml
@@ -31,6 +31,8 @@ metadata:
   namespace: arr-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: huntarr

--- a/k8s/talos/apps/arr-stack/radarr.yaml
+++ b/k8s/talos/apps/arr-stack/radarr.yaml
@@ -31,6 +31,8 @@ metadata:
   namespace: arr-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: radarr

--- a/k8s/talos/apps/arr-stack/sonarr.yaml
+++ b/k8s/talos/apps/arr-stack/sonarr.yaml
@@ -31,6 +31,8 @@ metadata:
   namespace: arr-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sonarr

--- a/k8s/talos/apps/arr-stack/tdarr.yaml
+++ b/k8s/talos/apps/arr-stack/tdarr.yaml
@@ -47,6 +47,8 @@ metadata:
   namespace: arr-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: tdarr

--- a/k8s/talos/apps/audiobookshelf/deployment.yaml
+++ b/k8s/talos/apps/audiobookshelf/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: audiobookshelf
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   revisionHistoryLimit: 3
   selector:
     matchLabels:


### PR DESCRIPTION
## Why
Every image bump on the arr-stack (e.g. today's Renovate merge) triggers Multi-Attach errors: RollingUpdate starts the replacement pod while the old pod still holds its ReadWriteOnce Proxmox CSI config volume. It self-heals after the old pod releases the disk, but stalls the rollout and would deadlock if an old pod ever hung terminating.

## What
Set `strategy: type: Recreate` on the single-replica deployments that mount `proxmox-local` (RWO block) volumes:

- arr-stack: bazarr, cleanuparr, flaresolverr, huntarr, radarr, sonarr, tdarr
- audiobookshelf

This matches the pattern already used by plex, seerr, tautulli and gluetun. NFS-backed apps (headroom, ollama, open-webui, workout-postgres) are unaffected by attach semantics and left unchanged.

## Verification
`kubectl diff` against the live cluster shows only the strategy change per deployment (RollingUpdate 25%/25% -> Recreate). No other fields touched.