### PR TITLE
chore(deps): update @types/node to ^24 and typescript to ^6

### DIFF
--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.1",
-        "@types/node": "^22",
+        "@types/node": "^24.0.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/three": "^0.185.0",
@@ -30,7 +30,7 @@
         "eslint-config-next": "16.2.10",
         "sharp": "^0.35.1",
         "tailwindcss": "^4.3.1",
-        "typescript": "^5"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">=22"
@@ -1472,13 +1472,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -9222,9 +9222,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9279,9 +9279,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.1",
-    "@types/node": "^22",
+    "@types/node": "^24.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/three": "^0.185.0",
@@ -34,6 +34,6 @@
     "eslint-config-next": "16.2.10",
     "sharp": "^0.35.1",
     "tailwindcss": "^4.3.1",
-    "typescript": "^5"
+    "typescript": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Why
Renovate PR #256 bundles three major dev-dependency bumps for the portfolio. Two are safe, but the eslint ^9 to ^10 bump breaks linting: eslint-plugin-react (pulled in by the pinned eslint-config-next 16.2.10) calls `context.getFilename()`, which ESLint 10 removed. This PR takes the safe two and holds eslint at ^9 until eslint-config-next supports ESLint 10.

## What
- `@types/node` ^22 to ^24.0.0
- `typescript` ^5 to ^6.0.0
- Lockfile regenerated; eslint stays at ^9

## Verification
- Docker image builds: `next build` compiles with TypeScript 6.0.3 and the static export serves (HTTP 200)
- `npm run lint` runs without crashing; it reports the same 9 pre-existing issues as unmodified main

Supersedes the safe part of #256.