### PR TITLE
ci: add lint and test gates for portfolio and blog

### DIFF
--- a/.github/workflows/build-blog.yaml
+++ b/.github/workflows/build-blog.yaml
@@ -22,7 +22,28 @@ env:
   IMAGE_NAME: ${{ github.repository }}/blog
 
 jobs:
+  ci:
+    # Gates stage deploys on push to main. Manual prod dispatch skips this.
+    # The Hugo render itself is validated by the Docker build below, and
+    # the image is only pushed if that succeeds.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Rule config lives in blog/.markdownlint.yaml
+      - name: Lint markdown content
+        uses: DavidAnson/markdownlint-cli2-action@v24
+        with:
+          globs: "blog/content/**/*.md"
+
   build-and-deploy:
+    needs: ci
+    # success = push with green ci; skipped = manual prod dispatch
+    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed to update manifests

--- a/.github/workflows/build-portfolio.yaml
+++ b/.github/workflows/build-portfolio.yaml
@@ -23,7 +23,40 @@ env:
   IMAGE_NAME: ${{ github.repository }}/portfolio
 
 jobs:
+  ci:
+    # Gates stage deploys on push to main. Manual prod dispatch skips this.
+    # next build is not repeated here: it runs inside the Docker build, and
+    # the image is only pushed if that succeeds.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: portfolio/.nvmrc
+          cache: npm
+          cache-dependency-path: portfolio/package-lock.json
+
+      - name: Install dependencies
+        working-directory: portfolio
+        run: npm ci
+
+      - name: Lint
+        working-directory: portfolio
+        run: npm run lint
+
+      - name: Typecheck
+        working-directory: portfolio
+        run: npm run typecheck
+
   build-and-deploy:
+    needs: ci
+    # success = push with green ci; skipped = manual prod dispatch
+    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci-blog.yaml
+++ b/.github/workflows/ci-blog.yaml
@@ -1,0 +1,46 @@
+name: CI Blog
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "blog/**"
+      - ".github/workflows/ci-blog.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "blog/**"
+      - ".github/workflows/ci-blog.yaml"
+
+jobs:
+  lint-markdown:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Rule config lives in blog/.markdownlint.yaml
+      - name: Lint markdown content
+        uses: DavidAnson/markdownlint-cli2-action@v24
+        with:
+          globs: "blog/content/**/*.md"
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive # Required for Hugo theme
+
+      # Hugo renders inside the image build; this validates templates,
+      # front matter and content before merge. Build only, no push —
+      # build-blog.yaml owns publishing.
+      - name: Build blog image (render check)
+        run: docker build -t blog:ci ./blog

--- a/.github/workflows/ci-blog.yaml
+++ b/.github/workflows/ci-blog.yaml
@@ -1,13 +1,9 @@
 name: CI Blog
 
+# PR gate only. Pushes to main are gated by the ci job in
+# build-blog.yaml before the stage image is built.
 on:
   pull_request:
-    branches:
-      - main
-    paths:
-      - "blog/**"
-      - ".github/workflows/ci-blog.yaml"
-  push:
     branches:
       - main
     paths:

--- a/.github/workflows/ci-portfolio.yaml
+++ b/.github/workflows/ci-portfolio.yaml
@@ -1,0 +1,49 @@
+name: CI Portfolio
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "portfolio/**"
+      - ".github/workflows/ci-portfolio.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "portfolio/**"
+      - ".github/workflows/ci-portfolio.yaml"
+
+jobs:
+  lint-typecheck-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: portfolio/.nvmrc
+          cache: npm
+          cache-dependency-path: portfolio/package-lock.json
+
+      - name: Install dependencies
+        working-directory: portfolio
+        run: npm ci
+
+      - name: Lint
+        working-directory: portfolio
+        run: npm run lint
+
+      - name: Typecheck
+        working-directory: portfolio
+        run: npm run typecheck
+
+      # Static export catches broken MDX content, bad imports and route
+      # errors that lint/typecheck miss. The deploy workflow rebuilds inside
+      # Docker; this run is the pre-merge gate.
+      - name: Build (static export)
+        working-directory: portfolio
+        run: npm run build

--- a/.github/workflows/ci-portfolio.yaml
+++ b/.github/workflows/ci-portfolio.yaml
@@ -1,13 +1,9 @@
 name: CI Portfolio
 
+# PR gate only. Pushes to main are gated by the ci job in
+# build-portfolio.yaml before the stage image is built.
 on:
   pull_request:
-    branches:
-      - main
-    paths:
-      - "portfolio/**"
-      - ".github/workflows/ci-portfolio.yaml"
-  push:
     branches:
       - main
     paths:

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -60,6 +60,18 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Add a `scripts/optimize-images.ts` step that runs `sharp` over `public/images/`.
 - **Where:** `portfolio/public/images/`.
 
+### Fix react-hooks v6 lint findings (currently downgraded to warnings)
+- **What:** `eslint-config-next@16` ships the new react-hooks v6 rules; two of them flag 8 pre-existing errors: `react-hooks/set-state-in-effect` (CommandPalette ×2, FooterStamp, InlineGlobe, ArchitectureDiagram — setState called directly in effect bodies) and `react-hooks/immutability` (InlineGlobeScene — mutating `colorSpace` on textures returned from `useTexture`). Both rules are downgraded to `warn` in `eslint.config.mjs` so lint can gate CI.
+- **Why deferred:** Fixing them means refactoring 5 working components (effect restructuring, moving three.js texture setup into the loader callback) with visual/behavioral risk that needs browser re-verification — out of scope for the CI-wiring change that surfaced them. The R3F texture mutations may be acceptable as-is (idiomatic three.js); decide per-case rather than blanket-refactor.
+- **Unblock:** Refactor each component (or add per-line disables where the pattern is intentional), verify in the browser via `make up`, then remove the two `warn` overrides from `eslint.config.mjs`.
+- **Where:** `portfolio/eslint.config.mjs`, `portfolio/src/components/{CommandPalette,FooterStamp,InlineGlobe,InlineGlobeScene}.tsx`, `portfolio/src/components/work/ArchitectureDiagram.tsx`.
+
+### Playwright smoke test suite for portfolio
+- **What:** A small containerized Playwright suite that builds the prod image, runs the container, and asserts key routes return 200 with expected content plus `/healthz`. Wire into `.github/workflows/ci-portfolio.yaml` as a job after lint/typecheck/build.
+- **Why deferred:** Tier 2 of the linting/testing rollout (2026-07-08); user approved shipping lint + typecheck + build gates first. Adds ~2–3 min to CI and needs a committed Playwright config decision (image, route list).
+- **Unblock:** Decide the route/assertion list, add `portfolio/tests/` with a Playwright config running via `mcr.microsoft.com/playwright` Docker image, add the CI job.
+- **Where:** `.github/workflows/ci-portfolio.yaml`, new `portfolio/tests/`.
+
 ### ESLint 9 → 10 and TypeScript 5 → 6 bump
 - **What:** Bump `eslint` to `^10` and `typescript` to `^6` in `portfolio/package.json`. Held back during the 2026-06-16 dependency-upgrade pass (which shipped Node 22, Next 16.2.9, React 19.2.7, and the patch/minor batch).
 - **Why deferred:** `eslint-config-next@16.2.9` transitively bundles `typescript-eslint@8`, whose ESLint peer range tops out at 9 and which warns on TS 6.x. Forcing either major now risks a peer/plugin mismatch with zero runtime benefit (lint + typecheck only). The two unblock together.

--- a/blog/.markdownlint.yaml
+++ b/blog/.markdownlint.yaml
@@ -1,0 +1,18 @@
+# markdownlint rules for blog content (enforced by ci-blog.yaml via markdownlint-cli2).
+# Tuned for Hugo posts: front matter carries the title and inline HTML (<img>) is idiomatic.
+
+# Long prose lines are fine; posts are not wrapped
+MD013: false
+
+# Inline HTML is used for sized images
+MD033: false
+
+# Posts start with front matter + intro/image, not an H1 (title comes from front matter)
+MD041: false
+
+# Posts repeat the title as a body H1; don't count the front matter title as one
+MD025:
+  front_matter_title: ""
+
+# Bold pseudo-headings (e.g. "Step 1: ...") are an established pattern in the posts
+MD036: false

--- a/blog/content/blog/kubernetes-quick-start/index.md
+++ b/blog/content/blog/kubernetes-quick-start/index.md
@@ -234,7 +234,7 @@ kubectl port-forward service/whoami-service 8080:80
 
 Keep that terminal running and open your browser to `http://localhost:8080`. You should see output like this:
 
-```
+```text
 Hostname: whoami-deployment-7d8f9c5b4-x9k2l
 IP: 127.0.0.1
 IP: ::1

--- a/portfolio/Makefile
+++ b/portfolio/Makefile
@@ -4,7 +4,7 @@ PROD_NAME  ?= portfolio-prod
 DEV_PORT   ?= 3000
 SHA        := $(shell git rev-parse --short HEAD 2>/dev/null || echo dev)
 
-.PHONY: help up build down logs sh image run-prod clean
+.PHONY: help up build down logs sh lint typecheck image run-prod clean
 
 help:  ## Show this help
 	@awk 'BEGIN{FS=":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*##/ {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -29,6 +29,12 @@ logs:  ## Tail dev container logs
 
 sh:  ## Shell into the dev container
 	docker compose exec dev sh
+
+lint:  ## Run ESLint in Docker (same check as CI)
+	docker run --rm -v $(PWD):/app -w /app node:24-alpine sh -c "npm ci --no-audit --no-fund && npm run lint"
+
+typecheck:  ## Run tsc --noEmit in Docker (same check as CI)
+	docker run --rm -v $(PWD):/app -w /app node:24-alpine sh -c "npm ci --no-audit --no-fund && npm run typecheck"
 
 image:  ## Build the production Docker image (multi-stage node→nginx; same path as CI)
 	docker build --build-arg BUILD_SHA=$(SHA) -t $(IMAGE) .

--- a/portfolio/eslint.config.mjs
+++ b/portfolio/eslint.config.mjs
@@ -13,6 +13,15 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    // New react-hooks v6 rules (via eslint-config-next 16) flag pre-existing
+    // component patterns (setState-in-effect guards, three.js texture mutation
+    // in R3F). Downgraded to warnings so lint can gate CI; see BACKLOG.md.
+    rules: {
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/immutability": "warn",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Why

Neither subtree had any pre-merge or pre-deploy validation. Lint, type and render errors only surfaced after landing on main, and the stage image built and deployed regardless.

## What

- `ci-portfolio.yaml` (new, PR-only): eslint, `tsc --noEmit` and `next build` on PRs touching `portfolio/**`.
- `ci-blog.yaml` (new, PR-only): markdownlint over `blog/content/**` plus a build-only Docker render check.
- `build-portfolio.yaml` / `build-blog.yaml`: new `ci` job (eslint + tsc / markdownlint) that the stage image build depends on. A failing check stops the build on push to main. Manual prod dispatch skips the gate.
- Portfolio gets a `typecheck` script and docker-wrapped `make lint` / `make typecheck`.
- The two new react-hooks v6 rules from eslint-config-next 16 are downgraded to warnings; the 8 pre-existing findings are tracked in BACKLOG.md.
- Blog markdownlint config tuned to the existing post style; one code fence was missing its language.

## Verification

- Portfolio lint + typecheck + build chain exits 0 in `node:24-alpine` (21 pages exported).
- markdownlint exits 0 across all 6 content files.
- All four touched workflows pass actionlint (only pre-existing SC2086 info notes in untouched deploy scripts remain).

Follow-ups (react-hooks cleanup, Playwright smoke suite) are tracked in BACKLOG.md.