### PR TITLE
ci: rebase before pushing manifest updates to main

### DIFF
--- a/.github/workflows/build-blog.yaml
+++ b/.github/workflows/build-blog.yaml
@@ -130,6 +130,11 @@ jobs:
           if [[ -n $(git status -s) ]]; then
             git add $MANIFEST
             git commit -m "chore(blog): deploy ${TAG} to ${ENV}"
+            # main may have advanced while the image built (e.g. the portfolio
+            # deploy pushing its manifest commit); rebase so the push is
+            # fast-forward instead of getting rejected.
+            git fetch origin main
+            git rebase origin/main
             git push origin HEAD:main
           else
             echo "Manifest already up to date."

--- a/.github/workflows/build-portfolio.yaml
+++ b/.github/workflows/build-portfolio.yaml
@@ -150,6 +150,11 @@ jobs:
           if [[ -n $(git status -s) ]]; then
             git add $MANIFEST
             git commit -m "chore(portfolio): deploy ${TAG} to ${ENV}"
+            # main may have advanced while the image built (e.g. the blog
+            # deploy pushing its manifest commit); rebase so the push is
+            # fast-forward instead of getting rejected.
+            git fetch origin main
+            git rebase origin/main
             git push origin HEAD:main
           else
             echo "Manifest already up to date."


### PR DESCRIPTION
## Why

When a commit triggers both deploy workflows (like the merge of #267), both build an image and then commit a manifest tag bump to main. The slower one pushed from a checkout pinned to the pre-build commit and was rejected as non-fast-forward. This failed the portfolio deploy twice today; the image was fine, only the manifest push died.

## What

In the Update Kubernetes Manifest step of both build workflows, fetch and rebase onto origin/main before `git push`. Works on the detached HEAD that actions/checkout leaves.

## Verification

actionlint passes; only the pre-existing SC2086 info notes remain. Real-world check is the next merge that touches both subtrees.