### PR TITLE
feat(logeverylift): new app on private gateway

### DIFF
--- a/k8s/talos/apps/logeverylift/README.md
+++ b/k8s/talos/apps/logeverylift/README.md
@@ -1,0 +1,48 @@
+# logeverylift
+
+Mobile-first workout-tracking PWA (Next.js standalone + PostgreSQL). Runs behind
+the **private** Traefik gateway with its own Postgres and Bitwarden-sourced
+secrets.
+
+- **Source / image build:** [`mortennordbye/logeverylift`](https://github.com/mortennordbye/logeverylift)
+- **Image:** `ghcr.io/mortennordbye/logeverylift`, pinned to an immutable `sha-<commit>` tag
+- **Namespace:** `logeverylift`
+- **URL:** `https://logeverylift.local.bigd.no` (private gateway)
+
+> **New app, migrating off `workout`.** This is a fresh deployment; the old
+> `workout` app (public `logeverylift.com`) stays untouched until cutover. During
+> the transition both share the same Bitwarden secret items (see
+> `externalsecret.yaml`) — give logeverylift its own items if you want them
+> isolated.
+
+## Deployment flow
+
+Source lives in a separate repo, so it uses the cross-repo
+[external-app deploy pattern](../../../../docs/gitops-external-app-deploys.md):
+
+1. Push to `main` in the logeverylift repo builds and pushes `ghcr.io/mortennordbye/logeverylift:sha-<short>`.
+2. Its CI calls this repo's reusable [`bump-image.yml`](../../../../.github/workflows/bump-image.yml)
+   with `manifest: app.yaml`, which rewrites the `image:` line in [`app.yaml`](app.yaml) and **opens a PR** here.
+3. Merging the PR updates the pinned tag; ArgoCD auto-syncs it.
+
+## Manifests
+
+| File | Resource | Notes |
+| --- | --- | --- |
+| [`namespace.yaml`](namespace.yaml) | Namespace | `logeverylift`, privileged PodSecurity |
+| [`externalsecret.yaml`](externalsecret.yaml) | ExternalSecret | Pulls app + DB secrets from Bitwarden (`logeverylift-secret`) |
+| [`postgres.yaml`](postgres.yaml) | PVC + Deployment + Service | `postgres:16-alpine`, DB `logeverylift_db`, `1Gi` NFS |
+| [`app.yaml`](app.yaml) | Deployment + Service | Next.js app, port `3000`, `/api/health` probes — **CI bumps the image here** |
+| [`httproute.yaml`](httproute.yaml) | HTTPRoute | Binds `logeverylift.local.bigd.no` to `traefik-gateway-private` |
+| [`ciliumnetworkpolicy.yaml`](ciliumnetworkpolicy.yaml) | CiliumNetworkPolicy | App ingress from Traefik; Postgres ingress only from the app |
+| [`kustomization.yaml`](kustomization.yaml) | Kustomization | Bundles the resources above |
+
+## Operational notes
+
+- **Secrets.** `logeverylift-secret` is materialized by External Secrets from
+  Bitwarden Secrets Manager (`ClusterSecretStore/bitwarden-secretsmanager`).
+  Reloader restarts the app when the secret changes.
+- **Database.** Self-contained `postgres` Deployment with a `1Gi` NFS PVC;
+  `DATABASE_URL` points at `postgres.logeverylift.svc.cluster.local`.
+- **Auth URL.** `BETTER_AUTH_URL` is set to the private hostname; update it (and
+  the HTTPRoute) when cutting over to the public domain.

--- a/k8s/talos/apps/logeverylift/app.yaml
+++ b/k8s/talos/apps/logeverylift/app.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logeverylift-app
+  namespace: logeverylift
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: logeverylift-app
+  template:
+    metadata:
+      labels:
+        app: logeverylift-app
+    spec:
+      containers:
+        - name: logeverylift-app
+          # Pinned to an immutable commit SHA. CI (bump-image.yml) rewrites this
+          # line to the freshly-built SHA and opens a PR. Never :latest.
+          image: ghcr.io/mortennordbye/logeverylift:sha-2042b0a
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: HOSTNAME
+              value: "0.0.0.0"
+            - name: NEXT_TELEMETRY_DISABLED
+              value: "1"
+            - name: BETTER_AUTH_URL
+              value: "https://logeverylift.local.bigd.no"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: POSTGRES_PASSWORD
+            - name: DATABASE_URL
+              value: "postgresql://postgres:$(POSTGRES_PASSWORD)@postgres.logeverylift.svc.cluster.local:5432/logeverylift_db"
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: BETTER_AUTH_SECRET
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: ADMIN_EMAIL
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: ADMIN_PASSWORD
+            - name: ADMIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: ADMIN_NAME
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: OPENROUTER_API_KEY
+            - name: GOOGLE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: GOOGLE_API_KEY
+            - name: NEXT_PRIVATE_SERVER_ACTIONS_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: NEXT_PRIVATE_SERVER_ACTIONS_ENCRYPTION_KEY
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logeverylift-app
+  namespace: logeverylift
+spec:
+  selector:
+    app: logeverylift-app
+  ports:
+    - port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/k8s/talos/apps/logeverylift/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/logeverylift/ciliumnetworkpolicy.yaml
@@ -1,0 +1,43 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: logeverylift-app-policy
+  namespace: logeverylift
+spec:
+  endpointSelector:
+    matchLabels:
+      app: logeverylift-app
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": traefik
+            "k8s:app.kubernetes.io/instance": traefik-traefik
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - health
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: logeverylift-postgres-policy
+  namespace: logeverylift
+spec:
+  endpointSelector:
+    matchLabels:
+      app: postgres
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": logeverylift
+            app: logeverylift-app
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - health

--- a/k8s/talos/apps/logeverylift/externalsecret.yaml
+++ b/k8s/talos/apps/logeverylift/externalsecret.yaml
@@ -1,0 +1,68 @@
+# NOTE: these remoteRef keys point at the SAME Bitwarden Secrets Manager items
+# as the workout app — logeverylift is migrating off workout, so it shares the
+# app secrets and admin credentials during the transition. If logeverylift
+# should have isolated secrets, create new Bitwarden items and swap the UUIDs.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: logeverylift-secret
+  namespace: logeverylift
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: logeverylift-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: "fbae7327-2f9c-4881-91cb-b421013834f8"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: BETTER_AUTH_SECRET
+      remoteRef:
+        key: "5f016738-76c5-414b-9aa1-b42200a17f2e"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: ADMIN_EMAIL
+      remoteRef:
+        key: "996ed837-7adf-4e13-b929-b42200a1aeb0"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: ADMIN_PASSWORD
+      remoteRef:
+        key: "9c280f50-f4b6-44b9-b9c4-b42200a1ceea"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: ADMIN_NAME
+      remoteRef:
+        key: "37af512a-c74e-4693-a17e-b42200a1fb55"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: OPENROUTER_API_KEY
+      remoteRef:
+        key: "674d439e-814d-4e06-bea0-b42e014f84be"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: GOOGLE_API_KEY
+      remoteRef:
+        key: "dae733f4-2b60-48fc-bbe6-b42f00f000a7"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: NEXT_PRIVATE_SERVER_ACTIONS_ENCRYPTION_KEY
+      remoteRef:
+        key: "414f5947-b258-450a-a478-b437011ae1d0"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/k8s/talos/apps/logeverylift/httproute.yaml
+++ b/k8s/talos/apps/logeverylift/httproute.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: logeverylift
+  namespace: logeverylift
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-private
+      namespace: traefik
+  hostnames:
+    - "logeverylift.local.bigd.no"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: logeverylift-app
+          port: 3000
+          weight: 1

--- a/k8s/talos/apps/logeverylift/kustomization.yaml
+++ b/k8s/talos/apps/logeverylift/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "0"
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - postgres.yaml
+  - app.yaml
+  - httproute.yaml
+  - ciliumnetworkpolicy.yaml

--- a/k8s/talos/apps/logeverylift/namespace.yaml
+++ b/k8s/talos/apps/logeverylift/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logeverylift
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"

--- a/k8s/talos/apps/logeverylift/postgres.yaml
+++ b/k8s/talos/apps/logeverylift/postgres.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: logeverylift
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: syno-nfs-csi
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: logeverylift
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: logeverylift_db
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: logeverylift-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres", "-d", "logeverylift_db"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: logeverylift
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP


### PR DESCRIPTION
## Why
Stand up logeverylift as its own app in the cluster (separate from the legacy `workout` app, which is left untouched and will be migrated from later). Wires it into the SHA-pinned external-app deploy pattern.

## What
New `k8s/talos/apps/logeverylift/` (auto-registered by the `apps` ApplicationSet):
- `namespace`, `postgres` (own PVC + Deployment + Service, DB `logeverylift_db`), `externalsecret` (`logeverylift-secret`).
- `app.yaml`: Next.js Deployment + Service, port 3000, `/api/health` probes, image `ghcr.io/mortennordbye/logeverylift` pinned to `sha-2042b0a` (current HEAD image). **CI bumps the image here.**
- `httproute`: `logeverylift.local.bigd.no` on `traefik-gateway-private`.
- `ciliumnetworkpolicy`: app ingress from Traefik; Postgres reachable only from the app.
- `README.md` for the app.

## Verification
- `kustomize build k8s/talos/apps/logeverylift` renders 10 resources with `image: ghcr.io/mortennordbye/logeverylift:sha-2042b0a`.
- The CI `sed` rewrites only the app image line (Postgres image untouched).

## Notes / needs your attention
- **Shared secrets:** `externalsecret.yaml` reuses the **same** Bitwarden items as `workout` (shared admin/app creds during migration). Create separate Bitwarden items and swap the UUIDs if you want isolation.
- **DNS:** `logeverylift.local.bigd.no` must resolve to the private gateway.
- **Depends on** homelab#276 (adds `bump-image.yml` + the manifest-editing pipeline the logeverylift repo calls). The two README links resolve once #276 is merged.
- The logeverylift repo gets a matching `deploy` job + secrets (separate PR).