### PR TITLE
fix(bump-image): check out homelab, not the caller repo

### DIFF
--- a/.github/workflows/bump-image.yml
+++ b/.github/workflows/bump-image.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Checkout homelab
         uses: actions/checkout@v4
         with:
+          # In a reusable (workflow_call) run, github.repository is the CALLER
+          # (the app repo), so checkout would grab that without this. Pin to
+          # homelab, which is where the manifests live.
+          repository: ${{ github.repository_owner }}/homelab
           token: ${{ steps.token.outputs.token }}
 
       - name: Bump image tag in manifest


### PR DESCRIPTION
## Why
The first real runs of the deploy pipeline failed with `manifest not found`. In a reusable (`workflow_call`) run, `github.repository` is the **calling** app repo, so `actions/checkout` without `repository:` checked out the app repo (which has no manifests) instead of homelab.

## What
Pin the checkout to `${{ github.repository_owner }}/homelab`. The App token is already scoped to homelab.

## Verification
Re-run the headroom/logeverylift deploy jobs; they should open bump PRs here.