### PR TITLE
feat(arr-stack): add Unpackerr to auto-extract archived downloads

### DIFF
--- a/k8s/talos/apps/arr-stack/kustomization.yaml
+++ b/k8s/talos/apps/arr-stack/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - radarr.yaml
   - bazarr.yaml
   - flaresolverr.yaml
+  - unpackerr.yaml
  # - tdarr.yaml
  # - huntarr.yaml
  # - cleanuparr.yaml

--- a/k8s/talos/apps/arr-stack/unpackerr.yaml
+++ b/k8s/talos/apps/arr-stack/unpackerr.yaml
@@ -1,0 +1,99 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: unpackerr-api-keys
+  namespace: arr-stack
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: unpackerr-api-keys
+    creationPolicy: Owner
+  data:
+    - secretKey: UN_SONARR_0_API_KEY
+      remoteRef:
+        key: 0350d8a3-05eb-4201-859a-b3c200a15fc4
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: UN_RADARR_0_API_KEY
+      remoteRef:
+        key: 453e06b8-66bc-4d5b-94ac-b3c200a12c85
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unpackerr
+  namespace: arr-stack
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: unpackerr
+  template:
+    metadata:
+      labels:
+        app: unpackerr
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - hyper1
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: unpackerr
+          image: ghcr.io/unpackerr/unpackerr:0.15.2
+          env:
+            - name: TZ
+              value: "Europe/Oslo"
+            - name: UN_SONARR_0_URL
+              value: "http://sonarr:8989"
+            - name: UN_SONARR_0_PATHS_0
+              value: "/torrents"
+            - name: UN_SONARR_0_PATHS_1
+              value: "/downloads"
+            - name: UN_RADARR_0_URL
+              value: "http://radarr:7878"
+            - name: UN_RADARR_0_PATHS_0
+              value: "/torrents"
+            - name: UN_RADARR_0_PATHS_1
+              value: "/downloads"
+          envFrom:
+            - secretRef:
+                name: unpackerr-api-keys
+          volumeMounts:
+            - name: torrents
+              mountPath: /torrents
+            - name: downloads
+              mountPath: /downloads
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: torrents
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data/media/torrents
+        - name: downloads
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data/media/torrents/completed


### PR DESCRIPTION
## Why

Sonarr and Radarr stall on releases delivered as RAR/ZIP archives. The download completes but sits in the queue showing "Found archive file, might need to be extracted" and never imports, because the *arr import step only looks for playable media, not archives.

## What

Adds Unpackerr to the arr-stack. It watches the Sonarr and Radarr queues over their APIs, extracts archived downloads in place, and removes the extracted files after import so the *arr can proceed. The original archive stays put so qBittorrent keeps seeding.

- `ExternalSecret` pulls the Sonarr/Radarr API keys from Bitwarden via ESO, reusing the same secret IDs the homepage app already uses. No secrets in git.
- Mounts the torrents NFS writable at `/torrents` and `/downloads` (the *arr apps mount it read-only), and lists both as paths per app so extraction works regardless of which path form the download client reports.
- Headless, stateless Deployment pinned to `ghcr.io/unpackerr/unpackerr:0.15.2`, `hyper1` node affinity, runs as UID/GID 1000 to match the rest of the stack. No Service, PVC, or network policy needed (no inbound port; existing arr-stack egress to sonarr/radarr already allowed).

## Verification

- `kubectl kustomize k8s/talos/apps/arr-stack` renders cleanly.
- `kubectl diff` against the live cluster shows both resources would be created and valid.
- Verified the pinned GHCR image tag exists.
- PodSecurity warning in the diff is non-blocking: the arr-stack namespace has no enforce label, and the existing sonarr deployment trips the identical warn-level notice (nfs volumes). Matched the neighbors' style rather than hardening this pod in isolation.

Once merged, the currently stuck queue items extract and import on Unpackerr's next scan; no re-downloading needed.