### PR TITLE
feat(media): add Bazarr, Prowlarr, and qBittorrent metrics to the SPOG

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -111,12 +111,6 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Media stack observability (arr-stack)
 
-### qBittorrent exporter
-- **What:** Add a qBittorrent exporter for download-client throughput/stall metrics and fold a row into the SPOG dashboard. Sonarr, Radarr, Bazarr, and Prowlarr are now covered by Exportarr (all deployed in `arr-stack`; Prowlarr scrapes `prowlarr.gluetun-vpn:9696`, which the existing gluetun CNP already permits from `arr-stack`).
-- **Why deferred:** qBittorrent has no API key — its exporter (`ghcr.io/esanchezm/prometheus-qbittorrent-exporter`) authenticates with the WebUI username/password (already in Bitwarden as `HOMEPAGE_VAR_QBITTORRENT_*`), so it needs its own ExternalSecret and a slightly different config. qBittorrent lives in `gluetun-vpn` behind the VPN pod.
-- **Unblock:** Decide placement (exporter in `gluetun-vpn` next to qBittorrent, or in `arr-stack` reaching `qbittorrent.gluetun-vpn:8080` — the gluetun CNP would need an ingress allow on 8080 from `arr-stack`, currently only 9696 is open). Add an ExternalSecret pulling the qBittorrent user/pass, the exporter Deployment/Service/ServiceMonitor, and a "Media — qBittorrent" row in `homelab-spog.json`.
-- **Where:** `k8s/talos/apps/gluetun-vpn/` or `k8s/talos/apps/arr-stack/exportarr.yaml`, `k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json`.
-
 ### Discord alert rules for the media stack
 - **What:** PrometheusRules that page Discord on actionable media-stack conditions — e.g. an *arr queue item stuck (no progress) for >2h, a root folder under a free-space threshold, or an exporter/target down.
 - **Why deferred:** Scope of this change was graphs, not alerting. The metrics now exist, so the rules are a clean follow-up; thresholds want a little live baseline first.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -111,11 +111,11 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Media stack observability (arr-stack)
 
-### Exportarr coverage for Prowlarr, Bazarr, qBittorrent
-- **What:** Extend the media-stack metrics/dashboard beyond Sonarr + Radarr. Add Exportarr instances for Prowlarr (indexer grab/fail rates — directly relevant to spotting bad/fake releases) and Bazarr, plus a qBittorrent exporter for download-client throughput/stall metrics.
-- **Why deferred:** Sonarr + Radarr shipped first because both live in `arr-stack`, their API keys are already in Bitwarden, and same-namespace scraping is trivial. Prowlarr and Bazarr run in the `gluetun-vpn` namespace behind the VPN pod, so scraping them cross-namespace needs a CiliumNetworkPolicy allowing ingress from `arr-stack` (or the exporters deployed into `gluetun-vpn`). qBittorrent has no API key — its exporter (`ghcr.io/esanchezm/prometheus-qbittorrent-exporter`) authenticates with the WebUI username/password (already in Bitwarden as `HOMEPAGE_VAR_QBITTORRENT_*`).
-- **Unblock:** Decide placement (exporters in `gluetun-vpn` next to the targets vs. in `arr-stack` with a cross-namespace allow rule). Prowlarr/Bazarr API keys already exist in Bitwarden (see `k8s/talos/apps/homepage/secrets.yaml`: Prowlarr `72898bab-…`, Bazarr `384c2a48-…`). Add exporter Deployments/Services/ServiceMonitors and extend `arr-stack.json` with Prowlarr/Bazarr/qBittorrent rows.
-- **Where:** `k8s/talos/apps/arr-stack/exportarr.yaml` (or a new manifest under `k8s/talos/apps/gluetun-vpn/`), `k8s/talos/infra/kube-prometheus-stack/dashboards/arr-stack.json`.
+### qBittorrent exporter
+- **What:** Add a qBittorrent exporter for download-client throughput/stall metrics and fold a row into the SPOG dashboard. Sonarr, Radarr, Bazarr, and Prowlarr are now covered by Exportarr (all deployed in `arr-stack`; Prowlarr scrapes `prowlarr.gluetun-vpn:9696`, which the existing gluetun CNP already permits from `arr-stack`).
+- **Why deferred:** qBittorrent has no API key — its exporter (`ghcr.io/esanchezm/prometheus-qbittorrent-exporter`) authenticates with the WebUI username/password (already in Bitwarden as `HOMEPAGE_VAR_QBITTORRENT_*`), so it needs its own ExternalSecret and a slightly different config. qBittorrent lives in `gluetun-vpn` behind the VPN pod.
+- **Unblock:** Decide placement (exporter in `gluetun-vpn` next to qBittorrent, or in `arr-stack` reaching `qbittorrent.gluetun-vpn:8080` — the gluetun CNP would need an ingress allow on 8080 from `arr-stack`, currently only 9696 is open). Add an ExternalSecret pulling the qBittorrent user/pass, the exporter Deployment/Service/ServiceMonitor, and a "Media — qBittorrent" row in `homelab-spog.json`.
+- **Where:** `k8s/talos/apps/gluetun-vpn/` or `k8s/talos/apps/arr-stack/exportarr.yaml`, `k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json`.
 
 ### Discord alert rules for the media stack
 - **What:** PrometheusRules that page Discord on actionable media-stack conditions — e.g. an *arr queue item stuck (no progress) for >2h, a root folder under a free-space threshold, or an exporter/target down.

--- a/k8s/talos/apps/arr-stack/exportarr.yaml
+++ b/k8s/talos/apps/arr-stack/exportarr.yaml
@@ -24,6 +24,18 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+    - secretKey: BAZARR_APIKEY
+      remoteRef:
+        key: 384c2a48-332f-4d6b-8175-b3c200a75a98
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: PROWLARR_APIKEY
+      remoteRef:
+        key: 72898bab-76d9-4aa9-9c3a-b3c200a71c16
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
 ---
 apiVersion: v1
 kind: Service
@@ -206,6 +218,192 @@ spec:
   selector:
     matchLabels:
       app: exportarr-radarr
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: exportarr-bazarr
+  namespace: arr-stack
+  labels:
+    app: exportarr-bazarr
+spec:
+  selector:
+    app: exportarr-bazarr
+  ports:
+    - name: metrics
+      port: 9707
+      targetPort: 9707
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exportarr-bazarr
+  namespace: arr-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: exportarr-bazarr
+  template:
+    metadata:
+      labels:
+        app: exportarr-bazarr
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - hyper1
+      containers:
+        - name: exportarr
+          image: ghcr.io/onedr0p/exportarr:v2.3.0
+          args:
+            - bazarr
+          env:
+            - name: PORT
+              value: "9707"
+            - name: URL
+              value: "http://bazarr:6767"
+            - name: APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: exportarr-api-keys
+                  key: BAZARR_APIKEY
+          ports:
+            - containerPort: 9707
+              name: metrics
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: exportarr-bazarr
+  namespace: arr-stack
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: exportarr-bazarr
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: exportarr-prowlarr
+  namespace: arr-stack
+  labels:
+    app: exportarr-prowlarr
+spec:
+  selector:
+    app: exportarr-prowlarr
+  ports:
+    - name: metrics
+      port: 9707
+      targetPort: 9707
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exportarr-prowlarr
+  namespace: arr-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: exportarr-prowlarr
+  template:
+    metadata:
+      labels:
+        app: exportarr-prowlarr
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - hyper1
+      containers:
+        - name: exportarr
+          image: ghcr.io/onedr0p/exportarr:v2.3.0
+          args:
+            - prowlarr
+          env:
+            - name: PORT
+              value: "9707"
+            - name: URL
+              value: "http://prowlarr.gluetun-vpn:9696"
+            - name: APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: exportarr-api-keys
+                  key: PROWLARR_APIKEY
+          ports:
+            - containerPort: 9707
+              name: metrics
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9707
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: exportarr-prowlarr
+  namespace: arr-stack
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: exportarr-prowlarr
   endpoints:
     - port: metrics
       path: /metrics

--- a/k8s/talos/apps/arr-stack/kustomization.yaml
+++ b/k8s/talos/apps/arr-stack/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - flaresolverr.yaml
   - unpackerr.yaml
   - exportarr.yaml
+  - qbittorrent-exporter.yaml
  # - tdarr.yaml
  # - huntarr.yaml
  # - cleanuparr.yaml

--- a/k8s/talos/apps/arr-stack/qbittorrent-exporter.yaml
+++ b/k8s/talos/apps/arr-stack/qbittorrent-exporter.yaml
@@ -1,0 +1,122 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: qbittorrent-exporter-creds
+  namespace: arr-stack
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: qbittorrent-exporter-creds
+    creationPolicy: Owner
+  data:
+    - secretKey: QBITTORRENT_USER
+      remoteRef:
+        key: 7d9a94e9-a067-4302-bda0-b3c40101aa9d
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: QBITTORRENT_PASS
+      remoteRef:
+        key: b4b0041d-0e5a-4358-825b-b3c40101c3e3
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent-exporter
+  namespace: arr-stack
+  labels:
+    app: qbittorrent-exporter
+spec:
+  selector:
+    app: qbittorrent-exporter
+  ports:
+    - name: metrics
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qbittorrent-exporter
+  namespace: arr-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qbittorrent-exporter
+  template:
+    metadata:
+      labels:
+        app: qbittorrent-exporter
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - hyper1
+      containers:
+        - name: exporter
+          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.7.0
+          env:
+            - name: QBITTORRENT_HOST
+              value: "qbittorrent.gluetun-vpn"
+            - name: QBITTORRENT_PORT
+              value: "8080"
+            - name: EXPORTER_PORT
+              value: "8000"
+            - name: QBITTORRENT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: qbittorrent-exporter-creds
+                  key: QBITTORRENT_USER
+            - name: QBITTORRENT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: qbittorrent-exporter-creds
+                  key: QBITTORRENT_PASS
+          ports:
+            - containerPort: 8000
+              name: metrics
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: qbittorrent-exporter
+  namespace: arr-stack
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: qbittorrent-exporter
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/k8s/talos/apps/gluetun-vpn/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/gluetun-vpn/ciliumnetworkpolicy.yaml
@@ -19,13 +19,16 @@ spec:
               protocol: TCP
             - port: "9696"
               protocol: TCP
-    # arr-stack pods query prowlarr for indexers.
+    # arr-stack pods query prowlarr for indexers (9696) and the qbittorrent
+    # WebUI (8080) — the *arr download client and the qbittorrent exporter.
     - fromEndpoints:
         - matchLabels:
             "k8s:io.kubernetes.pod.namespace": arr-stack
       toPorts:
         - ports:
             - port: "9696"
+              protocol: TCP
+            - port: "8080"
               protocol: TCP
     - fromEntities:
         - host

--- a/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
+++ b/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
@@ -9947,6 +9947,529 @@
           ]
         }
       ]
+    },
+    {
+      "id": 9240,
+      "type": "row",
+      "title": "Media \u2014 qBittorrent",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": [
+        {
+          "id": 9241,
+          "type": "stat",
+          "title": "Status",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 388
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "text": "DOWN",
+                      "color": "red"
+                    },
+                    "1": {
+                      "text": "UP",
+                      "color": "green"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "qbittorrent_up",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9242,
+          "type": "stat",
+          "title": "Torrents",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 388
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(qbittorrent_torrents_count)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9243,
+          "type": "stat",
+          "title": "Downloading",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 388
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(qbittorrent_torrents_count{status=\"downloading\"})",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9244,
+          "type": "stat",
+          "title": "Stalled",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 388
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(qbittorrent_torrents_count{status=~\"stalledDL|stalledUP\"})",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9245,
+          "type": "stat",
+          "title": "DHT nodes",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 388
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "qbittorrent_dht_nodes",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9246,
+          "type": "stat",
+          "title": "Firewalled",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 388
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "text": "OK",
+                      "color": "green"
+                    },
+                    "1": {
+                      "text": "FIREWALLED",
+                      "color": "orange"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "qbittorrent_firewalled",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9247,
+          "type": "timeseries",
+          "title": "Throughput",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 392
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "rate(qbittorrent_dl_info_data[5m])",
+              "legendFormat": "download",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "rate(qbittorrent_up_info_data[5m])",
+              "legendFormat": "upload",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9248,
+          "type": "timeseries",
+          "title": "Torrents by status",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 392
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by (status) (qbittorrent_torrents_count)",
+              "legendFormat": "{{status}}",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
     }
   ],
   "preload": false,

--- a/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
+++ b/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
@@ -8949,6 +8949,1004 @@
           ]
         }
       ]
+    },
+    {
+      "id": 9220,
+      "type": "row",
+      "title": "Media \u2014 Bazarr",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "panels": [
+        {
+          "id": 9221,
+          "type": "stat",
+          "title": "Status",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 364
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "text": "DOWN",
+                      "color": "red"
+                    },
+                    "1": {
+                      "text": "UP",
+                      "color": "green"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "bazarr_system_status",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9222,
+          "type": "stat",
+          "title": "Health issues",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 364
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_system_health_issues)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9223,
+          "type": "stat",
+          "title": "Missing subs",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 364
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_missing_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9224,
+          "type": "stat",
+          "title": "Downloaded subs",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 364
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_downloaded_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9225,
+          "type": "stat",
+          "title": "Wanted subs",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 364
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_wanted_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9226,
+          "type": "stat",
+          "title": "Throttled providers",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 364
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_throttled_providers)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9227,
+          "type": "timeseries",
+          "title": "Subtitles missing",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 368
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_missing_total)",
+              "legendFormat": "missing",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9228,
+          "type": "timeseries",
+          "title": "Subtitles downloaded",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 368
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_downloaded_total)",
+              "legendFormat": "downloaded",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 9230,
+      "type": "row",
+      "title": "Media \u2014 Prowlarr",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "panels": [
+        {
+          "id": 9231,
+          "type": "stat",
+          "title": "Exporter up",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 376
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "text": "DOWN",
+                      "color": "red"
+                    },
+                    "1": {
+                      "text": "UP",
+                      "color": "green"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "up{job=\"exportarr-prowlarr\"}",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9232,
+          "type": "stat",
+          "title": "Indexers",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 376
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9233,
+          "type": "stat",
+          "title": "Enabled",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 376
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_enabled_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9234,
+          "type": "stat",
+          "title": "Queries",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 376
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_queries_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9235,
+          "type": "stat",
+          "title": "Failed queries",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 376
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_failed_queries_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9236,
+          "type": "stat",
+          "title": "Failed grabs",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 376
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_failed_grabs_total)",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9237,
+          "type": "timeseries",
+          "title": "Queries by indexer",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 380
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by (indexer) (prowlarr_indexer_queries_total)",
+              "legendFormat": "{{indexer}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9238,
+          "type": "timeseries",
+          "title": "Grabs by indexer",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 380
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by (indexer) (prowlarr_indexer_grabs_total)",
+              "legendFormat": "{{indexer}}",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
     }
   ],
   "preload": false,


### PR DESCRIPTION
## Why

Extends the media-stack metrics (Sonarr/Radarr landed in #294) to the remaining apps running here, so the SPOG dashboard covers the whole stack.

## What

**Exporters** (all in `arr-stack`):
- **Bazarr** (Exportarr) → `http://bazarr:6767`.
- **Prowlarr** (Exportarr) → `http://prowlarr.gluetun-vpn:9696` — the gluetun CNP already allowed `arr-stack → 9696`.
- **qBittorrent** (`ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.7.0`) → `qbittorrent.gluetun-vpn:8080`. WebUI user/pass from Bitwarden via a new `qbittorrent-exporter-creds` ExternalSecret.
- Bazarr/Prowlarr API keys added to the existing `exportarr-api-keys` ExternalSecret. No secrets in git.

**Network policy** — opens `arr-stack → gluetun:8080` in the gluetun CiliumNetworkPolicy (previously only `9696` was allowed from arr-stack). This is what the qBittorrent exporter needs, and it also covers the *arr download-client path to qBittorrent.

**Dashboard** — three collapsed rows added to `homelab-spog.json`:
- `Media — Bazarr`: status, health, subtitles missing/downloaded/wanted, throttled providers.
- `Media — Prowlarr`: indexers, enabled, queries, failed queries/grabs, per-indexer query/grab timeseries. No `system_status` in the collector, so up/down uses `up{job="exportarr-prowlarr"}`.
- `Media — qBittorrent`: status, torrents (total/downloading/stalled), DHT nodes, firewalled, download/upload throughput (`rate()` of the `*_info_data` counters), and torrents-by-status timeseries.

**BACKLOG** — exporter coverage is now complete; only the media Discord alert rules remain.

## Verification

- Metric names taken from each exporter's collector source (Exportarr and prometheus-qbittorrent-exporter, main branches).
- `kubectl kustomize k8s/talos/apps/arr-stack` builds (5 ServiceMonitors); `k8s/talos/apps/gluetun-vpn` builds.
- `kubectl apply --dry-run=server` accepts the exporters, the new ExternalSecrets, and the updated CNP; `--server-side --dry-run=server` accepts both dashboard ConfigMaps.
- `homelab-spog.json` round-trip parsed.

## Follow-up (BACKLOG)

Media-stack Discord alert rules (queue stuck, low free space, target down).