### PR TITLE
refactor(dashboards): compact media stack into one bundled section

### DIFF
--- a/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
+++ b/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
@@ -7947,7 +7947,7 @@
     {
       "id": 9200,
       "type": "row",
-      "title": "Media \u2014 Sonarr",
+      "title": "Media Stack",
       "collapsed": true,
       "gridPos": {
         "h": 1,
@@ -7959,7 +7959,7 @@
         {
           "id": 9201,
           "type": "stat",
-          "title": "Status",
+          "title": "Sonarr \u00b7 Status",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8034,7 +8034,7 @@
         {
           "id": 9202,
           "type": "stat",
-          "title": "Queue",
+          "title": "Sonarr \u00b7 Queue",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8090,7 +8090,7 @@
         {
           "id": 9203,
           "type": "stat",
-          "title": "Missing episodes",
+          "title": "Sonarr \u00b7 Missing eps",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8146,7 +8146,7 @@
         {
           "id": 9204,
           "type": "stat",
-          "title": "Health issues",
+          "title": "Sonarr \u00b7 Health",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8206,7 +8206,7 @@
         {
           "id": 9205,
           "type": "stat",
-          "title": "Series",
+          "title": "Sonarr \u00b7 Series",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8262,7 +8262,7 @@
         {
           "id": 9206,
           "type": "stat",
-          "title": "Min free space",
+          "title": "Sonarr \u00b7 Free space",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8326,7 +8326,7 @@
         {
           "id": 9207,
           "type": "timeseries",
-          "title": "Queue size",
+          "title": "Sonarr \u00b7 Queue size",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8387,7 +8387,7 @@
         {
           "id": 9208,
           "type": "timeseries",
-          "title": "Root folder free space",
+          "title": "Sonarr \u00b7 Free space",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8444,25 +8444,11 @@
               "refId": "A"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 9210,
-      "type": "row",
-      "title": "Media \u2014 Radarr",
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "panels": [
+        },
         {
-          "id": 9211,
+          "id": 9209,
           "type": "stat",
-          "title": "Status",
+          "title": "Radarr \u00b7 Status",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8535,9 +8521,9 @@
           ]
         },
         {
-          "id": 9212,
+          "id": 9210,
           "type": "stat",
-          "title": "Queue",
+          "title": "Radarr \u00b7 Queue",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8591,9 +8577,9 @@
           ]
         },
         {
-          "id": 9213,
+          "id": 9211,
           "type": "stat",
-          "title": "Missing movies",
+          "title": "Radarr \u00b7 Missing movies",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8647,9 +8633,9 @@
           ]
         },
         {
-          "id": 9214,
+          "id": 9212,
           "type": "stat",
-          "title": "Health issues",
+          "title": "Radarr \u00b7 Health",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8707,9 +8693,9 @@
           ]
         },
         {
-          "id": 9215,
+          "id": 9213,
           "type": "stat",
-          "title": "Movies",
+          "title": "Radarr \u00b7 Movies",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8763,9 +8749,9 @@
           ]
         },
         {
-          "id": 9216,
+          "id": 9214,
           "type": "stat",
-          "title": "Min free space",
+          "title": "Radarr \u00b7 Free space",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8827,9 +8813,9 @@
           ]
         },
         {
-          "id": 9217,
+          "id": 9215,
           "type": "timeseries",
-          "title": "Queue size",
+          "title": "Radarr \u00b7 Queue size",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8888,9 +8874,9 @@
           ]
         },
         {
-          "id": 9218,
+          "id": 9216,
           "type": "timeseries",
-          "title": "Root folder free space",
+          "title": "Radarr \u00b7 Free space",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8947,25 +8933,11 @@
               "refId": "A"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 9220,
-      "type": "row",
-      "title": "Media \u2014 Bazarr",
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "panels": [
+        },
         {
-          "id": 9221,
+          "id": 9217,
           "type": "stat",
-          "title": "Status",
+          "title": "Bazarr \u00b7 Status",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9038,9 +9010,9 @@
           ]
         },
         {
-          "id": 9222,
+          "id": 9218,
           "type": "stat",
-          "title": "Health issues",
+          "title": "Bazarr \u00b7 Health",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9098,9 +9070,9 @@
           ]
         },
         {
-          "id": 9223,
+          "id": 9219,
           "type": "stat",
-          "title": "Missing subs",
+          "title": "Bazarr \u00b7 Missing subs",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9154,9 +9126,9 @@
           ]
         },
         {
-          "id": 9224,
+          "id": 9220,
           "type": "stat",
-          "title": "Downloaded subs",
+          "title": "Bazarr \u00b7 Downloaded subs",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9210,9 +9182,9 @@
           ]
         },
         {
-          "id": 9225,
+          "id": 9221,
           "type": "stat",
-          "title": "Wanted subs",
+          "title": "Bazarr \u00b7 Wanted subs",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9266,9 +9238,9 @@
           ]
         },
         {
-          "id": 9226,
+          "id": 9222,
           "type": "stat",
-          "title": "Throttled providers",
+          "title": "Bazarr \u00b7 Throttled",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9326,9 +9298,9 @@
           ]
         },
         {
-          "id": 9227,
+          "id": 9223,
           "type": "timeseries",
-          "title": "Subtitles missing",
+          "title": "Bazarr \u00b7 Subtitles missing",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9387,9 +9359,9 @@
           ]
         },
         {
-          "id": 9228,
+          "id": 9224,
           "type": "timeseries",
-          "title": "Subtitles downloaded",
+          "title": "Bazarr \u00b7 Subtitles downloaded",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9446,25 +9418,11 @@
               "refId": "A"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 9230,
-      "type": "row",
-      "title": "Media \u2014 Prowlarr",
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "panels": [
+        },
         {
-          "id": 9231,
+          "id": 9225,
           "type": "stat",
-          "title": "Exporter up",
+          "title": "Prowlarr \u00b7 Up",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9537,9 +9495,9 @@
           ]
         },
         {
-          "id": 9232,
+          "id": 9226,
           "type": "stat",
-          "title": "Indexers",
+          "title": "Prowlarr \u00b7 Indexers",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9593,9 +9551,9 @@
           ]
         },
         {
-          "id": 9233,
+          "id": 9227,
           "type": "stat",
-          "title": "Enabled",
+          "title": "Prowlarr \u00b7 Enabled",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9649,9 +9607,9 @@
           ]
         },
         {
-          "id": 9234,
+          "id": 9228,
           "type": "stat",
-          "title": "Queries",
+          "title": "Prowlarr \u00b7 Queries",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9705,9 +9663,9 @@
           ]
         },
         {
-          "id": 9235,
+          "id": 9229,
           "type": "stat",
-          "title": "Failed queries",
+          "title": "Prowlarr \u00b7 Failed queries",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9765,9 +9723,9 @@
           ]
         },
         {
-          "id": 9236,
+          "id": 9230,
           "type": "stat",
-          "title": "Failed grabs",
+          "title": "Prowlarr \u00b7 Failed grabs",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9825,9 +9783,9 @@
           ]
         },
         {
-          "id": 9237,
+          "id": 9231,
           "type": "timeseries",
-          "title": "Queries by indexer",
+          "title": "Prowlarr \u00b7 Queries by indexer",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9886,9 +9844,9 @@
           ]
         },
         {
-          "id": 9238,
+          "id": 9232,
           "type": "timeseries",
-          "title": "Grabs by indexer",
+          "title": "Prowlarr \u00b7 Grabs by indexer",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9945,25 +9903,11 @@
               "refId": "A"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 9240,
-      "type": "row",
-      "title": "Media \u2014 qBittorrent",
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 22
-      },
-      "panels": [
+        },
         {
-          "id": 9241,
+          "id": 9233,
           "type": "stat",
-          "title": "Status",
+          "title": "qBittorrent \u00b7 Status",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10036,9 +9980,9 @@
           ]
         },
         {
-          "id": 9242,
+          "id": 9234,
           "type": "stat",
-          "title": "Torrents",
+          "title": "qBittorrent \u00b7 Torrents",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10092,9 +10036,9 @@
           ]
         },
         {
-          "id": 9243,
+          "id": 9235,
           "type": "stat",
-          "title": "Downloading",
+          "title": "qBittorrent \u00b7 Downloading",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10148,9 +10092,9 @@
           ]
         },
         {
-          "id": 9244,
+          "id": 9236,
           "type": "stat",
-          "title": "Stalled",
+          "title": "qBittorrent \u00b7 Stalled",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10208,9 +10152,9 @@
           ]
         },
         {
-          "id": 9245,
+          "id": 9237,
           "type": "stat",
-          "title": "DHT nodes",
+          "title": "qBittorrent \u00b7 DHT nodes",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10264,9 +10208,9 @@
           ]
         },
         {
-          "id": 9246,
+          "id": 9238,
           "type": "stat",
-          "title": "Firewalled",
+          "title": "qBittorrent \u00b7 Firewalled",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10339,9 +10283,9 @@
           ]
         },
         {
-          "id": 9247,
+          "id": 9239,
           "type": "timeseries",
-          "title": "Throughput",
+          "title": "qBittorrent \u00b7 Throughput",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10409,9 +10353,9 @@
           ]
         },
         {
-          "id": 9248,
+          "id": 9240,
           "type": "timeseries",
-          "title": "Torrents by status",
+          "title": "qBittorrent \u00b7 Torrents by status",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"

--- a/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
+++ b/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
@@ -7959,14 +7959,14 @@
         {
           "id": 9201,
           "type": "stat",
-          "title": "Sonarr \u00b7 Status",
+          "title": "Service status",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "gridPos": {
             "h": 4,
-            "w": 4,
+            "w": 24,
             "x": 0,
             "y": 340
           },
@@ -8006,9 +8006,9 @@
           },
           "options": {
             "colorMode": "value",
-            "graphMode": "area",
+            "graphMode": "none",
             "justifyMode": "auto",
-            "orientation": "auto",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -8016,7 +8016,7 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "value_and_name"
           },
           "targets": [
             {
@@ -8026,136 +8026,64 @@
               },
               "expr": "sonarr_system_status",
               "instant": true,
-              "legendFormat": "",
+              "legendFormat": "Sonarr",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "radarr_system_status",
+              "instant": true,
+              "legendFormat": "Radarr",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "bazarr_system_status",
+              "instant": true,
+              "legendFormat": "Bazarr",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "up{job=\"exportarr-prowlarr\"}",
+              "instant": true,
+              "legendFormat": "Prowlarr",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "qbittorrent_up",
+              "instant": true,
+              "legendFormat": "qBittorrent",
+              "refId": "E"
             }
           ]
         },
         {
           "id": 9202,
           "type": "stat",
-          "title": "Sonarr \u00b7 Queue",
+          "title": "Health issues",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "gridPos": {
             "h": 4,
-            "w": 4,
-            "x": 4,
-            "y": 340
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(sonarr_queue_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9203,
-          "type": "stat",
-          "title": "Sonarr \u00b7 Missing eps",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 8,
-            "y": 340
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(sonarr_episode_missing_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9204,
-          "type": "stat",
-          "title": "Sonarr \u00b7 Health",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 12,
-            "y": 340
+            "w": 6,
+            "x": 0,
+            "y": 344
           },
           "fieldConfig": {
             "defaults": {
@@ -8178,9 +8106,9 @@
           },
           "options": {
             "colorMode": "value",
-            "graphMode": "area",
+            "graphMode": "none",
             "justifyMode": "auto",
-            "orientation": "auto",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -8188,7 +8116,7 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "value_and_name"
           },
           "targets": [
             {
@@ -8198,24 +8126,124 @@
               },
               "expr": "sum(sonarr_system_health_issues)",
               "instant": true,
-              "legendFormat": "",
+              "legendFormat": "Sonarr",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(radarr_system_health_issues)",
+              "instant": true,
+              "legendFormat": "Radarr",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_system_health_issues)",
+              "instant": true,
+              "legendFormat": "Bazarr",
+              "refId": "C"
             }
           ]
         },
         {
-          "id": 9205,
+          "id": 9203,
           "type": "stat",
-          "title": "Sonarr \u00b7 Series",
+          "title": "Problems",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "gridPos": {
             "h": 4,
-            "w": 4,
-            "x": 16,
-            "y": 340
+            "w": 6,
+            "x": 6,
+            "y": 344
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(qbittorrent_torrents_count{status=~\"stalledDL|stalledUP\"})",
+              "instant": true,
+              "legendFormat": "Stalled torrents",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_failed_queries_total)",
+              "instant": true,
+              "legendFormat": "Failed queries",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_failed_grabs_total)",
+              "instant": true,
+              "legendFormat": "Failed grabs",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "id": 9204,
+          "type": "stat",
+          "title": "Queues",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 344
           },
           "fieldConfig": {
             "defaults": {
@@ -8234,9 +8262,9 @@
           },
           "options": {
             "colorMode": "value",
-            "graphMode": "area",
+            "graphMode": "none",
             "justifyMode": "auto",
-            "orientation": "auto",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -8244,7 +8272,7 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "value_and_name"
           },
           "targets": [
             {
@@ -8252,26 +8280,36 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(sonarr_series_total)",
+              "expr": "sum(sonarr_queue_total)",
               "instant": true,
-              "legendFormat": "",
+              "legendFormat": "Sonarr",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(radarr_queue_total)",
+              "instant": true,
+              "legendFormat": "Radarr",
+              "refId": "B"
             }
           ]
         },
         {
-          "id": 9206,
+          "id": 9205,
           "type": "stat",
-          "title": "Sonarr \u00b7 Free space",
+          "title": "Free space (min)",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
           "gridPos": {
             "h": 4,
-            "w": 4,
-            "x": 20,
-            "y": 340
+            "w": 6,
+            "x": 18,
+            "y": 344
           },
           "fieldConfig": {
             "defaults": {
@@ -8298,9 +8336,9 @@
           },
           "options": {
             "colorMode": "value",
-            "graphMode": "area",
+            "graphMode": "none",
             "justifyMode": "auto",
-            "orientation": "auto",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
@@ -8308,7 +8346,7 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "value_and_name"
           },
           "targets": [
             {
@@ -8318,15 +8356,319 @@
               },
               "expr": "min(sonarr_rootfolder_freespace_bytes)",
               "instant": true,
-              "legendFormat": "",
+              "legendFormat": "Sonarr",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "min(radarr_rootfolder_freespace_bytes)",
+              "instant": true,
+              "legendFormat": "Radarr",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 9206,
+          "type": "stat",
+          "title": "Missing",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 348
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(sonarr_episode_missing_total)",
+              "instant": true,
+              "legendFormat": "Episodes",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(radarr_movie_missing_total)",
+              "instant": true,
+              "legendFormat": "Movies",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_missing_total)",
+              "instant": true,
+              "legendFormat": "Subtitles",
+              "refId": "C"
             }
           ]
         },
         {
           "id": 9207,
+          "type": "stat",
+          "title": "Library",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 348
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(sonarr_series_total)",
+              "instant": true,
+              "legendFormat": "Series",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(radarr_movie_total)",
+              "instant": true,
+              "legendFormat": "Movies",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 9208,
+          "type": "stat",
+          "title": "qBittorrent",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 348
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(qbittorrent_torrents_count)",
+              "instant": true,
+              "legendFormat": "Torrents",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(qbittorrent_torrents_count{status=\"downloading\"})",
+              "instant": true,
+              "legendFormat": "Downloading",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "qbittorrent_dht_nodes",
+              "instant": true,
+              "legendFormat": "DHT nodes",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "id": 9209,
+          "type": "stat",
+          "title": "Prowlarr indexers",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 348
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "value_and_name"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_total)",
+              "instant": true,
+              "legendFormat": "Total",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_enabled_total)",
+              "instant": true,
+              "legendFormat": "Enabled",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(prowlarr_indexer_queries_total)",
+              "instant": true,
+              "legendFormat": "Queries",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "id": 9210,
           "type": "timeseries",
-          "title": "Sonarr \u00b7 Queue size",
+          "title": "Queue size",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8335,7 +8677,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 344
+            "y": 352
           },
           "fieldConfig": {
             "defaults": {
@@ -8379,15 +8721,24 @@
                 "uid": "${datasource}"
               },
               "expr": "sum(sonarr_queue_total)",
-              "legendFormat": "queue",
+              "legendFormat": "Sonarr",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(radarr_queue_total)",
+              "legendFormat": "Radarr",
+              "refId": "B"
             }
           ]
         },
         {
-          "id": 9208,
+          "id": 9211,
           "type": "timeseries",
-          "title": "Sonarr \u00b7 Free space",
+          "title": "Root folder free space",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -8396,7 +8747,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 344
+            "y": 352
           },
           "fieldConfig": {
             "defaults": {
@@ -8440,867 +8791,24 @@
                 "uid": "${datasource}"
               },
               "expr": "sonarr_rootfolder_freespace_bytes",
-              "legendFormat": "{{path}}",
+              "legendFormat": "Sonarr {{path}}",
               "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9209,
-          "type": "stat",
-          "title": "Radarr \u00b7 Status",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 0,
-            "y": 352
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "mappings": [
-                {
-                  "type": "value",
-                  "options": {
-                    "0": {
-                      "text": "DOWN",
-                      "color": "red"
-                    },
-                    "1": {
-                      "text": "UP",
-                      "color": "green"
-                    }
-                  }
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
             },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "radarr_system_status",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9210,
-          "type": "stat",
-          "title": "Radarr \u00b7 Queue",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 4,
-            "y": 352
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(radarr_queue_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9211,
-          "type": "stat",
-          "title": "Radarr \u00b7 Missing movies",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 8,
-            "y": 352
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(radarr_movie_missing_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9212,
-          "type": "stat",
-          "title": "Radarr \u00b7 Health",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 12,
-            "y": 352
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(radarr_system_health_issues)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9213,
-          "type": "stat",
-          "title": "Radarr \u00b7 Movies",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 16,
-            "y": 352
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(radarr_movie_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9214,
-          "type": "stat",
-          "title": "Radarr \u00b7 Free space",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 20,
-            "y": 352
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "bytes",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 53687091200
-                  },
-                  {
-                    "color": "green",
-                    "value": 214748364800
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "min(radarr_rootfolder_freespace_bytes)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9215,
-          "type": "timeseries",
-          "title": "Radarr \u00b7 Queue size",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 356
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "custom": {
-                "drawStyle": "line",
-                "lineInterpolation": "smooth",
-                "fillOpacity": 12,
-                "showPoints": "never",
-                "lineWidth": 2,
-                "axisPlacement": "auto",
-                "spanNulls": true
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "calcs": []
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(radarr_queue_total)",
-              "legendFormat": "queue",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9216,
-          "type": "timeseries",
-          "title": "Radarr \u00b7 Free space",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 356
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "bytes",
-              "custom": {
-                "drawStyle": "line",
-                "lineInterpolation": "smooth",
-                "fillOpacity": 12,
-                "showPoints": "never",
-                "lineWidth": 2,
-                "axisPlacement": "auto",
-                "spanNulls": true
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "calcs": []
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
               "expr": "radarr_rootfolder_freespace_bytes",
-              "legendFormat": "{{path}}",
-              "refId": "A"
+              "legendFormat": "Radarr {{path}}",
+              "refId": "B"
             }
           ]
         },
         {
-          "id": 9217,
-          "type": "stat",
-          "title": "Bazarr \u00b7 Status",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 0,
-            "y": 364
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "mappings": [
-                {
-                  "type": "value",
-                  "options": {
-                    "0": {
-                      "text": "DOWN",
-                      "color": "red"
-                    },
-                    "1": {
-                      "text": "UP",
-                      "color": "green"
-                    }
-                  }
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "bazarr_system_status",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9218,
-          "type": "stat",
-          "title": "Bazarr \u00b7 Health",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 4,
-            "y": 364
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(bazarr_system_health_issues)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9219,
-          "type": "stat",
-          "title": "Bazarr \u00b7 Missing subs",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 8,
-            "y": 364
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(bazarr_subtitles_missing_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9220,
-          "type": "stat",
-          "title": "Bazarr \u00b7 Downloaded subs",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 12,
-            "y": 364
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(bazarr_subtitles_downloaded_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9221,
-          "type": "stat",
-          "title": "Bazarr \u00b7 Wanted subs",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 16,
-            "y": 364
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(bazarr_subtitles_wanted_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9222,
-          "type": "stat",
-          "title": "Bazarr \u00b7 Throttled",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 20,
-            "y": 364
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(bazarr_throttled_providers)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9223,
+          "id": 9212,
           "type": "timeseries",
-          "title": "Bazarr \u00b7 Subtitles missing",
+          "title": "qBittorrent throughput",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -9309,992 +8817,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 368
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "custom": {
-                "drawStyle": "line",
-                "lineInterpolation": "smooth",
-                "fillOpacity": 12,
-                "showPoints": "never",
-                "lineWidth": 2,
-                "axisPlacement": "auto",
-                "spanNulls": true
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "calcs": []
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(bazarr_subtitles_missing_total)",
-              "legendFormat": "missing",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9224,
-          "type": "timeseries",
-          "title": "Bazarr \u00b7 Subtitles downloaded",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 368
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "custom": {
-                "drawStyle": "line",
-                "lineInterpolation": "smooth",
-                "fillOpacity": 12,
-                "showPoints": "never",
-                "lineWidth": 2,
-                "axisPlacement": "auto",
-                "spanNulls": true
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "calcs": []
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(bazarr_subtitles_downloaded_total)",
-              "legendFormat": "downloaded",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9225,
-          "type": "stat",
-          "title": "Prowlarr \u00b7 Up",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 0,
-            "y": 376
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "mappings": [
-                {
-                  "type": "value",
-                  "options": {
-                    "0": {
-                      "text": "DOWN",
-                      "color": "red"
-                    },
-                    "1": {
-                      "text": "UP",
-                      "color": "green"
-                    }
-                  }
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "up{job=\"exportarr-prowlarr\"}",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9226,
-          "type": "stat",
-          "title": "Prowlarr \u00b7 Indexers",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 4,
-            "y": 376
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(prowlarr_indexer_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9227,
-          "type": "stat",
-          "title": "Prowlarr \u00b7 Enabled",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 8,
-            "y": 376
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(prowlarr_indexer_enabled_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9228,
-          "type": "stat",
-          "title": "Prowlarr \u00b7 Queries",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 12,
-            "y": 376
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(prowlarr_indexer_queries_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9229,
-          "type": "stat",
-          "title": "Prowlarr \u00b7 Failed queries",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 16,
-            "y": 376
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(prowlarr_indexer_failed_queries_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9230,
-          "type": "stat",
-          "title": "Prowlarr \u00b7 Failed grabs",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 20,
-            "y": 376
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(prowlarr_indexer_failed_grabs_total)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9231,
-          "type": "timeseries",
-          "title": "Prowlarr \u00b7 Queries by indexer",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 380
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "custom": {
-                "drawStyle": "line",
-                "lineInterpolation": "smooth",
-                "fillOpacity": 12,
-                "showPoints": "never",
-                "lineWidth": 2,
-                "axisPlacement": "auto",
-                "spanNulls": true
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "calcs": []
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum by (indexer) (prowlarr_indexer_queries_total)",
-              "legendFormat": "{{indexer}}",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9232,
-          "type": "timeseries",
-          "title": "Prowlarr \u00b7 Grabs by indexer",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 380
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "custom": {
-                "drawStyle": "line",
-                "lineInterpolation": "smooth",
-                "fillOpacity": 12,
-                "showPoints": "never",
-                "lineWidth": 2,
-                "axisPlacement": "auto",
-                "spanNulls": true
-              },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "calcs": []
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum by (indexer) (prowlarr_indexer_grabs_total)",
-              "legendFormat": "{{indexer}}",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9233,
-          "type": "stat",
-          "title": "qBittorrent \u00b7 Status",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 0,
-            "y": 388
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "mappings": [
-                {
-                  "type": "value",
-                  "options": {
-                    "0": {
-                      "text": "DOWN",
-                      "color": "red"
-                    },
-                    "1": {
-                      "text": "UP",
-                      "color": "green"
-                    }
-                  }
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "qbittorrent_up",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9234,
-          "type": "stat",
-          "title": "qBittorrent \u00b7 Torrents",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 4,
-            "y": 388
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(qbittorrent_torrents_count)",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9235,
-          "type": "stat",
-          "title": "qBittorrent \u00b7 Downloading",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 8,
-            "y": 388
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(qbittorrent_torrents_count{status=\"downloading\"})",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9236,
-          "type": "stat",
-          "title": "qBittorrent \u00b7 Stalled",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 12,
-            "y": 388
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "sum(qbittorrent_torrents_count{status=~\"stalledDL|stalledUP\"})",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9237,
-          "type": "stat",
-          "title": "qBittorrent \u00b7 DHT nodes",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 16,
-            "y": 388
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "qbittorrent_dht_nodes",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9238,
-          "type": "stat",
-          "title": "qBittorrent \u00b7 Firewalled",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 20,
-            "y": 388
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "none",
-              "mappings": [
-                {
-                  "type": "value",
-                  "options": {
-                    "0": {
-                      "text": "OK",
-                      "color": "green"
-                    },
-                    "1": {
-                      "text": "FIREWALLED",
-                      "color": "orange"
-                    }
-                  }
-                }
-              ],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "expr": "qbittorrent_firewalled",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ]
-        },
-        {
-          "id": 9239,
-          "type": "timeseries",
-          "title": "qBittorrent \u00b7 Throughput",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 392
+            "y": 360
           },
           "fieldConfig": {
             "defaults": {
@@ -10348,14 +8871,14 @@
               },
               "expr": "rate(qbittorrent_up_info_data[5m])",
               "legendFormat": "upload",
-              "refId": "A"
+              "refId": "B"
             }
           ]
         },
         {
-          "id": 9240,
+          "id": 9213,
           "type": "timeseries",
-          "title": "qBittorrent \u00b7 Torrents by status",
+          "title": "Torrents by status",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -10364,7 +8887,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 392
+            "y": 360
           },
           "fieldConfig": {
             "defaults": {
@@ -10410,6 +8933,137 @@
               "expr": "sum by (status) (qbittorrent_torrents_count)",
               "legendFormat": "{{status}}",
               "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9214,
+          "type": "timeseries",
+          "title": "Prowlarr queries by indexer",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 368
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by (indexer) (prowlarr_indexer_queries_total)",
+              "legendFormat": "{{indexer}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9215,
+          "type": "timeseries",
+          "title": "Bazarr subtitles",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 368
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "fillOpacity": 12,
+                "showPoints": "never",
+                "lineWidth": 2,
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_missing_total)",
+              "legendFormat": "missing",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(bazarr_subtitles_downloaded_total)",
+              "legendFormat": "downloaded",
+              "refId": "B"
             }
           ]
         }


### PR DESCRIPTION
## Why

#295 shipped the media metrics as five per-service rows (Sonarr, Radarr, Bazarr, Prowlarr, qBittorrent) with 40 panels total — a lot of vertical scrolling. This folds them into a single collapsible section with metrics bundled across services.

## What

`homelab-spog.json` only. The five `Media — *` rows become one collapsed **Media Stack** row of **15 panels** (was 40):

- **Service status** — one wide tile-strip: all five apps UP/DOWN.
- **Health issues** (Sonarr/Radarr/Bazarr) and **Problems** (stalled torrents, Prowlarr failed queries/grabs) — colored thresholds so breakage stands out.
- Bundled counters: **Queues**, **Free space (min)**, **Missing**, **Library**, **qBittorrent**, **Prowlarr indexers**.
- Combined timeseries: queue size, root free space, qBittorrent throughput + torrents-by-status, Prowlarr queries by indexer, Bazarr subtitles.

No exporter/metric changes — same queries, just regrouped. Roughly 40% less vertical space.

## Verification

- `homelab-spog.json` round-trip parsed.
- `kubectl apply --server-side --dry-run=server` accepts both dashboard ConfigMaps (they already apply server-side per #294).