### PR TITLE
fix(media): fix empty panels and misleading stalled count

### DIFF
--- a/k8s/talos/apps/arr-stack/exportarr.yaml
+++ b/k8s/talos/apps/arr-stack/exportarr.yaml
@@ -312,9 +312,13 @@ spec:
     matchLabels:
       app: exportarr-bazarr
   endpoints:
+    # Bazarr's collector crawls the whole library each scrape (slow on large
+    # libraries), so give it a long interval and matching scrape timeout to
+    # avoid the scrape timing out and marking the target down.
     - port: metrics
       path: /metrics
-      interval: 30s
+      interval: 2m
+      scrapeTimeout: 110s
 ---
 apiVersion: v1
 kind: Service
@@ -360,6 +364,9 @@ spec:
           image: ghcr.io/onedr0p/exportarr:v2.3.0
           args:
             - prowlarr
+            # Pull historical indexer stats so query/grab metrics populate
+            # immediately instead of only counting activity after startup.
+            - --backfill
           env:
             - name: PORT
               value: "9707"

--- a/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
+++ b/k8s/talos/infra/kube-prometheus-stack/dashboards/homelab-spog.json
@@ -8204,9 +8204,9 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(qbittorrent_torrents_count{status=~\"stalledDL|stalledUP\"})",
+              "expr": "sum(qbittorrent_torrents_count{status=\"stalledDL\"})",
               "instant": true,
-              "legendFormat": "Stalled torrents",
+              "legendFormat": "Stalled DL",
               "refId": "A"
             },
             {
@@ -8860,7 +8860,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "rate(qbittorrent_dl_info_data[5m])",
+              "expr": "rate(qbittorrent_dl_info_data_total[5m])",
               "legendFormat": "download",
               "refId": "A"
             },
@@ -8869,7 +8869,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "rate(qbittorrent_up_info_data[5m])",
+              "expr": "rate(qbittorrent_up_info_data_total[5m])",
               "legendFormat": "upload",
               "refId": "B"
             }


### PR DESCRIPTION
## Why

With the exporters live, four issues showed up on the Media Stack dashboard: three "No data" panels and one misleading number.

## What

- **qBittorrent throughput** ("No data") — the exporter names its byte counters `qbittorrent_dl_info_data_total` / `qbittorrent_up_info_data_total` (prometheus_client appends `_total`). Fixed the `rate()` queries.
- **Problems "267 stalled"** — that counted `stalledUP`, i.e. idle completed seeds, which is normal. Changed to `status="stalledDL"` (actually stuck downloads) and relabeled the tile "Stalled DL".
- **Bazarr** (target down, no `bazarr_*` metrics) — the Bazarr collector crawls the entire library (1393 movies) on every scrape and blew past the scrape timeout, so `up=0`. Set the Bazarr ServiceMonitor to `interval: 2m`, `scrapeTimeout: 110s`.
- **Prowlarr queries/grabs** (empty) — the collector only emits per-indexer stats for activity since startup. Added `--backfill` so historical stats populate immediately.

## Verification

- Metric names confirmed against live Prometheus (`qbittorrent_*` list, `bazarr_*` absent + `up{job="exportarr-bazarr"}=0`, `prowlarr_indexer_queries_total` 0 series).
- `kubectl kustomize k8s/talos/apps/arr-stack` builds; `kubectl apply --dry-run=server` accepts the exporter changes; `--server-side --dry-run=server` accepts the dashboard ConfigMaps.
- Dashboard JSON round-trip parsed.

After merge: Bazarr's target should go green within a couple of scrape cycles, qBittorrent throughput and Prowlarr query panels populate.