### PR TITLE
feat(arr-stack): add LazyLibrarian for audiobook automation

### DIFF
--- a/k8s/talos/apps/arr-stack/ciliumnetworkpolicies.yaml
+++ b/k8s/talos/apps/arr-stack/ciliumnetworkpolicies.yaml
@@ -47,6 +47,28 @@ spec:
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
+  name: lazylibrarian-policy
+  namespace: arr-stack
+spec:
+  endpointSelector:
+    matchLabels:
+      app: lazylibrarian
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": traefik
+            "k8s:app.kubernetes.io/instance": traefik-traefik
+      toPorts:
+        - ports:
+            - port: "5299"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - health
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
   name: radarr-policy
   namespace: arr-stack
 spec:

--- a/k8s/talos/apps/arr-stack/httproutes.yaml
+++ b/k8s/talos/apps/arr-stack/httproutes.yaml
@@ -96,6 +96,32 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  name: lazylibrarian
+  namespace: arr-stack
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-private
+      namespace: traefik
+      sectionName: local-bigd-no
+  hostnames:
+    - "lazylibrarian.local.bigd.no"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: lazylibrarian
+          port: 5299
+          weight: 1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
   name: flaresolverr
   namespace: arr-stack
 spec:

--- a/k8s/talos/apps/arr-stack/kustomization.yaml
+++ b/k8s/talos/apps/arr-stack/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - sonarr.yaml
   - radarr.yaml
   - bazarr.yaml
+  - lazylibrarian.yaml
   - flaresolverr.yaml
   - unpackerr.yaml
   - exportarr.yaml

--- a/k8s/talos/apps/arr-stack/lazylibrarian.yaml
+++ b/k8s/talos/apps/arr-stack/lazylibrarian.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lazylibrarian-config
+  namespace: arr-stack
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: proxmox-local
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lazylibrarian
+  namespace: arr-stack
+spec:
+  selector:
+    app: lazylibrarian
+  ports:
+    - name: http
+      port: 5299
+      targetPort: 5299
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lazylibrarian
+  namespace: arr-stack
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: lazylibrarian
+  template:
+    metadata:
+      labels:
+        app: lazylibrarian
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - hyper1
+      containers:
+        - name: lazylibrarian
+          image: ghcr.io/linuxserver/lazylibrarian:version-40a389ea
+          ports:
+            - containerPort: 5299
+              name: http
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: "Europe/Oslo"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: audiobooks
+              mountPath: /audiobooks
+            - name: torrents
+              mountPath: /torrents
+              readOnly: true
+            - name: torrents-download
+              mountPath: /torrents/download
+            - name: downloads
+              mountPath: /downloads
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          startupProbe:
+            tcpSocket:
+              port: 5299
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 40
+          livenessProbe:
+            tcpSocket:
+              port: 5299
+            periodSeconds: 60
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: 5299
+            periodSeconds: 20
+            failureThreshold: 5
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: lazylibrarian-config
+        - name: audiobooks
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data/media/audiobooks
+        - name: torrents
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data/media/torrents
+        - name: torrents-download
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data/media/torrents/download
+        - name: downloads
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data/media/torrents/completed

--- a/k8s/talos/apps/homepage/values.yaml
+++ b/k8s/talos/apps/homepage/values.yaml
@@ -173,6 +173,10 @@ config:
               type: bazarr
               url: https://bazarr.local.bigd.no
               key: "{{HOMEPAGE_VAR_BAZARR_API_KEY}}"
+        - LazyLibrarian:
+            icon: lazylibrarian.png
+            href: https://lazylibrarian.local.bigd.no
+            description: Audiobook automation
         - Plex:
             icon: plex.png
             href: http://10.3.10.101:32400/web


### PR DESCRIPTION
## Why

Readarr is retired, leaving a gap in the audiobook pipeline: Audiobookshelf plays and organizes the library but doesn't acquire anything, and Prowlarr + qBittorrent are just plumbing. LazyLibrarian is the maintained, purpose-built book/audiobook automation layer that ties them together.

## What

- **LazyLibrarian** (linuxserver image, pinned `version-40a389ea`) in `arr-stack`. WebUI on 5299, config on a `proxmox-local` PVC.
- Mounts:
  - `media/audiobooks` (writable) — the same NFS tree Audiobookshelf serves, so finished books land straight in the library (organized per author, matching the existing `audiobooks/<Author>/<Book>` layout).
  - `torrents` (ro) + `torrents/download` + `torrents/completed` — to import finished qBittorrent grabs.
- **HTTPRoute** `lazylibrarian.local.bigd.no` and a **Cilium ingress policy** (traefik → 5299), matching the other arr-stack apps. Egress to Prowlarr (9696) and qBittorrent (8080) in `gluetun-vpn` is already permitted for the arr-stack namespace by the gluetun policy — no network change needed.

## How it fits together

Prowlarr (indexers) → LazyLibrarian (search/grab) → qBittorrent (download) → LazyLibrarian imports into `media/audiobooks/<Author>` → Audiobookshelf ingests. LazyLibrarian's indexers, download client, and audiobook destination are set once in its web UI after deploy (same pattern as Bazarr/Cleanuparr).

## Verification

- `kubectl kustomize k8s/talos/apps/arr-stack` builds.
- `kubectl apply --dry-run=server` accepts all five objects (PVC, Service, Deployment, HTTPRoute, CiliumNetworkPolicy). The PodSecurity warning is the same non-blocking warn-level notice every arr-stack app emits (nfs volumes, linuxserver image).
- Image tag `version-40a389ea` confirmed as the current linuxserver build (pushed 2026-07-11).

## Follow-up

Optional: add LazyLibrarian to the Prowlarr "Apps" sync and to the homepage dashboard.