### PR TITLE
feat(portfolio): /infrastructure page with live cluster status

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,6 +10,14 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Author 15–25 QA pairs against the four fixtures (single-doc + cross-doc questions, plus a handful of out-of-corpus refusals), pick the metric, wire `make eval` to the existing chain.
 - **Where:** `ai/projects/local-rag-poc/main.py`, `ai/projects/local-rag-poc/Makefile`, plus a new `ai/projects/local-rag-poc/evals/` directory.
 
+## Infrastructure page
+
+### 30-day availability strip
+- **What:** The `/infrastructure` page design mockup included a 30-day availability tick strip with an uptime percentage. Dropped from the implemented page because nothing external probes the site today, and self-reported uptime from inside the cluster proves nothing when the cluster is what fails.
+- **Why deferred:** Needs an external prober (Uptime Kuma on another host, healthchecks.io, or a GitHub Actions schedule hitting the site) publishing daily results somewhere the static page can fetch.
+- **Unblock:** Pick the prober, publish daily results as JSON (could ride along in `status.json` or a second file), add the strip section back to `portfolio/src/app/infrastructure/page.tsx`.
+- **Where:** `portfolio/src/app/infrastructure/page.tsx`, `k8s/talos/apps/portfolio/status-publisher.yaml`.
+
 ## Portfolio modern — items deferred during initial build
 
 ### Brotli precompression for nginx static assets

--- a/k8s/talos/apps/portfolio/deployment.yaml
+++ b/k8s/talos/apps/portfolio/deployment.yaml
@@ -56,6 +56,11 @@ spec:
           volumeMounts:
             - name: nginx-cache
               mountPath: /var/cache/nginx
+            # Live cluster status written by the status-publisher CronJob.
+            # Served at /status.json; optional so pods start without it.
+            - name: status
+              mountPath: /usr/share/nginx/html/status
+              readOnly: true
           resources:
             requests: { cpu: 50m, memory: 64Mi }
             limits: { cpu: 200m, memory: 256Mi }
@@ -79,3 +84,7 @@ spec:
         - name: nginx-cache
           emptyDir:
             medium: Memory
+        - name: status
+          configMap:
+            name: portfolio-status
+            optional: true

--- a/k8s/talos/apps/portfolio/kustomization.yaml
+++ b/k8s/talos/apps/portfolio/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - service.yaml
   - ciliumnetworkpolicy.yaml
   - scaledobject.yaml
+  - status-publisher.yaml

--- a/k8s/talos/apps/portfolio/status-publisher.yaml
+++ b/k8s/talos/apps/portfolio/status-publisher.yaml
@@ -1,0 +1,180 @@
+# Publishes live cluster facts to the portfolio-status ConfigMap every five
+# minutes. The portfolio deployment mounts that ConfigMap and nginx serves it
+# as /status.json, which the /infrastructure page fetches client-side.
+#
+# The ConfigMap itself is created by the CronJob, not by Git — ArgoCD ignores
+# it because it carries no tracking label, so automated prune never touches it.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: status-publisher
+  namespace: portfolio
+---
+# Cluster-scoped reads: nodes for readiness + versions, plus single named
+# objects (the ArgoCD Application and the site certificate) in other
+# namespaces. resourceNames limits get to exactly those objects.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: portfolio-status-publisher
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    resourceNames: ["portfolio"]
+    verbs: ["get"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    resourceNames: ["nordbye-it"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: portfolio-status-publisher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: portfolio-status-publisher
+subjects:
+  - kind: ServiceAccount
+    name: status-publisher
+    namespace: portfolio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: status-publisher
+  namespace: portfolio
+rules:
+  # create cannot be restricted by resourceName (the name doesn't exist yet);
+  # the rest is pinned to the one ConfigMap this job owns.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["portfolio-status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["portfolio"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: status-publisher
+  namespace: portfolio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: status-publisher
+subjects:
+  - kind: ServiceAccount
+    name: status-publisher
+    namespace: portfolio
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: status-publisher
+  namespace: portfolio
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            app: status-publisher
+        spec:
+          serviceAccountName: status-publisher
+          restartPolicy: Never
+          enableServiceLinks: false
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+          containers:
+            - name: publish
+              # kubectl + jq in one small image; tag tracks the cluster minor.
+              image: docker.io/alpine/k8s:1.34.1
+              env:
+                # kubectl writes discovery cache under $HOME
+                - name: HOME
+                  value: /tmp
+              command: ["/bin/sh", "-ec"]
+              args:
+                - |
+                  kubectl get nodes -o json > /tmp/nodes.json
+                  READY=$(jq '[.items[] | select(any(.status.conditions[]; .type=="Ready" and .status=="True"))] | length' /tmp/nodes.json)
+                  TOTAL=$(jq '.items | length' /tmp/nodes.json)
+                  K8S=$(jq -r '.items[0].status.nodeInfo.kubeletVersion' /tmp/nodes.json)
+                  TALOS=$(jq -r '.items[0].status.nodeInfo.osImage | capture("\\((?<v>v[0-9][0-9.]*)\\)").v // empty' /tmp/nodes.json)
+
+                  kubectl get application portfolio -n argocd -o json > /tmp/app.json
+                  SYNC=$(jq -r '.status.sync.status // "Unknown"' /tmp/app.json)
+                  HEALTH=$(jq -r '.status.health.status // "Unknown"' /tmp/app.json)
+                  SYNCED_AT=$(jq -r '.status.operationState.finishedAt // empty' /tmp/app.json)
+
+                  kubectl get deployment portfolio -n portfolio -o json > /tmp/deploy.json
+                  BUILD=$(jq -r '.spec.template.spec.containers[0].image | split(":") | last' /tmp/deploy.json)
+                  DEPLOYED_AT=$(jq -r '[.status.conditions[] | select(.type=="Progressing")][0].lastUpdateTime // empty' /tmp/deploy.json)
+
+                  NOT_AFTER=$(kubectl get certificate nordbye-it -n cert-manager -o jsonpath='{.status.notAfter}')
+
+                  jq -n \
+                    --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                    --arg build "$BUILD" \
+                    --arg deployedAt "$DEPLOYED_AT" \
+                    --arg sync "$SYNC" \
+                    --arg health "$HEALTH" \
+                    --arg syncedAt "$SYNCED_AT" \
+                    --argjson ready "$READY" \
+                    --argjson total "$TOTAL" \
+                    --arg k8s "$K8S" \
+                    --arg talos "$TALOS" \
+                    --arg notAfter "$NOT_AFTER" \
+                    '{
+                      generatedAt: $generatedAt,
+                      build: $build,
+                      deployedAt: $deployedAt,
+                      argocd: {sync: $sync, health: $health, syncedAt: $syncedAt},
+                      nodes: {ready: $ready, total: $total},
+                      versions: {kubernetes: $k8s, talos: $talos},
+                      cert: {notAfter: $notAfter}
+                    }' > /tmp/status.json
+
+                  kubectl create configmap portfolio-status -n portfolio \
+                    --from-file=status.json=/tmp/status.json \
+                    --dry-run=client -o yaml | kubectl apply -f -
+              securityContext:
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                privileged: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/portfolio/nginx/default.conf
+++ b/portfolio/nginx/default.conf
@@ -36,6 +36,16 @@ server {
         add_header Cache-Control "public, max-age=86400";
     }
 
+    # Live cluster status, published by the status-publisher CronJob into a
+    # ConfigMap the deployment mounts outside the baked docroot. Exact match
+    # wins over the .json regex above, so the 1d cache never applies. 404s
+    # when the ConfigMap is absent (stage, local) — the page falls back.
+    location = /status.json {
+        access_log off;
+        alias /usr/share/nginx/html/status/status.json;
+        add_header Cache-Control "no-store";
+    }
+
     location /healthz {
         access_log off;
         return 200 "ok\n";

--- a/portfolio/src/app/globals.css
+++ b/portfolio/src/app/globals.css
@@ -223,6 +223,18 @@ a {
   .oslo-marker::after { animation: none; opacity: 0; }
 }
 
+/* Infrastructure page — packet dot travelling along a pipeline connector */
+@keyframes packet-flow {
+  0%   { left: 4px; opacity: 0; }
+  12%  { opacity: 1; }
+  88%  { opacity: 1; }
+  100% { left: calc(100% - 10px); opacity: 0; }
+}
+.packet {
+  animation: packet-flow 2.8s linear infinite;
+  animation-delay: var(--packet-delay, 0s);
+}
+
 /* Marquee animation */
 @keyframes marquee {
   from { transform: translateX(0); }

--- a/portfolio/src/app/infrastructure/page.tsx
+++ b/portfolio/src/app/infrastructure/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from "next";
+import { Section } from "@/components/primitives/Section";
+import { Reveal } from "@/components/primitives/Reveal";
+import { LiveStatus } from "@/components/infrastructure/LiveStatus";
+import { Pipeline } from "@/components/infrastructure/Pipeline";
+import { deployPath, platform, requestPath } from "@/content/infrastructure";
+
+export const metadata: Metadata = {
+  title: "Infrastructure",
+  description:
+    "This site runs on a self-hosted Talos Kubernetes cluster, reconciled by ArgoCD. The request path, the deploy pipeline, and live cluster status.",
+};
+
+const dotTints = ["bg-accent", "bg-accent-3", "bg-accent-2", "bg-copper"];
+
+const statusJsonExample = `{
+  "generatedAt": "2026-07-12T09:14:02Z",
+  "build":      "286dd6c",
+  "argocd":     { "sync": "Synced", "health": "Healthy" },
+  "nodes":      { "ready": 6, "total": 6 },
+  "versions":   { "talos": "v1.11.6", "kubernetes": "v1.34.0" },
+  "cert":       { "notAfter": "2026-09-04T08:11:39Z" }
+}`;
+
+export default function InfrastructurePage() {
+  return (
+    <main className="pt-32">
+      <Section
+        eyebrow="infrastructure"
+        heading="This site is the case study."
+        description={
+          <>
+            No Vercel, no Netlify. The page you are reading was built by CI,
+            pushed to a registry, and reconciled by ArgoCD onto a self-hosted
+            Talos Kubernetes cluster in Oslo. The status below is read from
+            that cluster.
+          </>
+        }
+      >
+        <LiveStatus />
+      </Section>
+
+      <Section
+        eyebrow="the request path"
+        heading="How this page reached you."
+        description="Every request crosses this chain. Each hop maps to a manifest in the repo."
+        className="border-t border-line"
+      >
+        <Pipeline hops={requestPath} />
+      </Section>
+
+      <Section
+        eyebrow="the deploy path"
+        heading="How a commit becomes this page."
+        description={
+          <>
+            Nothing is applied by hand. A push to{" "}
+            <span className="font-mono text-sm text-fg">main</span> is the only
+            deploy action that exists. ArgoCD reconciles the rest.
+          </>
+        }
+        className="border-t border-line"
+      >
+        <Pipeline hops={deployPath} />
+      </Section>
+
+      <Section
+        eyebrow="how the numbers get here"
+        heading="A static site with a live pulse."
+        className="border-t border-line"
+      >
+        <div className="grid gap-10 md:grid-cols-2 md:gap-12">
+          <div className="space-y-4 text-fg-2 leading-relaxed">
+            <p>
+              This site is a static export served by nginx. There is no
+              server-side code to query the cluster. Instead, a small CronJob
+              inside the cluster gathers the facts every few minutes, from the
+              Kubernetes API, ArgoCD, and cert-manager, and publishes a single{" "}
+              <code className="rounded border border-line bg-surface px-1.5 py-0.5 font-mono text-[0.82em] text-fg">
+                status.json
+              </code>{" "}
+              through the same gateway.
+            </p>
+            <p>
+              The page fetches it client-side. If the fetch fails, the tiles
+              fall back to a build-time snapshot and say so. The page never
+              breaks because the homelab is having a bad day.
+            </p>
+          </div>
+          <Reveal className="overflow-hidden rounded-lg border border-line bg-bg-2">
+            <div className="flex items-center justify-between border-b border-line px-4 py-2.5 font-mono text-xs">
+              <span className="text-fg-2">GET /status.json</span>
+              <span className="text-fg-3">refreshed every 5 min</span>
+            </div>
+            <pre className="overflow-x-auto p-4 font-mono text-[0.78rem] leading-relaxed text-fg-2">
+              {statusJsonExample}
+            </pre>
+          </Reveal>
+        </div>
+      </Section>
+
+      <Section
+        eyebrow="the platform underneath"
+        heading="What keeps it honest."
+        description={
+          <>
+            The moving parts behind the diagrams above. Every manifest lives in{" "}
+            <a
+              href="https://github.com/mortennordbye/Homelab"
+              className="focus-ring text-fg underline decoration-accent decoration-2 underline-offset-4 hover:text-accent"
+            >
+              the homelab repo
+            </a>
+            .
+          </>
+        }
+        className="border-t border-line"
+      >
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {platform.map((p, i) => (
+            <Reveal key={p.name} delay={i * 0.05}>
+              <div className="h-full rounded-md border border-line bg-surface p-4 transition-colors hover:border-line-2">
+                <p className="flex items-center gap-2 font-mono text-sm font-semibold text-fg">
+                  <span
+                    aria-hidden
+                    className={`h-1.5 w-1.5 rounded-[2px] ${dotTints[i % dotTints.length]}`}
+                  />
+                  {p.name}
+                </p>
+                <p className="mt-2 text-xs leading-relaxed text-fg-3">{p.role}</p>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </Section>
+    </main>
+  );
+}

--- a/portfolio/src/components/infrastructure/LiveStatus.tsx
+++ b/portfolio/src/components/infrastructure/LiveStatus.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/cn";
+import { statusSnapshot } from "@/content/infrastructure";
+
+/** Shape published to /status.json by the in-cluster CronJob. */
+type ClusterStatus = {
+  generatedAt: string;
+  build: string;
+  deployedAt?: string;
+  argocd: { sync: string; health: string; syncedAt?: string };
+  nodes: { ready: number; total: number };
+  versions: { kubernetes?: string; talos?: string };
+  cert?: { notAfter: string };
+};
+
+type FeedState = "loading" | "live" | "snapshot";
+
+const buildSha = (process.env.NEXT_PUBLIC_BUILD_SHA ?? "dev").slice(0, 7);
+
+function relative(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms) || ms < 0) return null;
+  const min = Math.round(ms / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min} min ago`;
+  const h = Math.round(min / 60);
+  if (h < 48) return `${h} h ago`;
+  return `${Math.round(h / 24)} d ago`;
+}
+
+function certDaysLeft(notAfter: string | undefined): number | null {
+  if (!notAfter) return null;
+  const days = Math.floor((new Date(notAfter).getTime() - Date.now()) / 86_400_000);
+  return Number.isNaN(days) ? null : days;
+}
+
+function Tile({
+  label,
+  value,
+  sub,
+  subTone = "muted",
+  mono = false,
+}: {
+  label: string;
+  value: React.ReactNode;
+  sub: string;
+  subTone?: "muted" | "ok";
+  mono?: boolean;
+}) {
+  return (
+    <div className="bg-surface p-6">
+      <p className="eyebrow text-[0.65rem]">{label}</p>
+      <p
+        className={cn(
+          "mt-2 text-2xl font-semibold tabular-nums leading-tight tracking-tight text-fg",
+          mono && "font-mono text-xl",
+        )}
+      >
+        {value}
+      </p>
+      <p
+        className={cn(
+          "mt-1.5 font-mono text-xs",
+          subTone === "ok" ? "text-success" : "text-fg-3",
+        )}
+      >
+        {sub}
+      </p>
+    </div>
+  );
+}
+
+export function LiveStatus() {
+  const [feed, setFeed] = useState<FeedState>("loading");
+  const [status, setStatus] = useState<ClusterStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/status.json", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+      .then((data: ClusterStatus) => {
+        if (cancelled) return;
+        setStatus(data);
+        setFeed("live");
+      })
+      .catch(() => {
+        if (!cancelled) setFeed("snapshot");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const nodes = status?.nodes ?? statusSnapshot.nodes;
+  const argocd = status?.argocd ?? statusSnapshot.argocd;
+  const sha = status?.build ?? buildSha;
+  const healthy =
+    nodes.ready === nodes.total &&
+    argocd.sync === "Synced" &&
+    argocd.health === "Healthy";
+  const updated = relative(status?.generatedAt);
+  const deployed = relative(status?.deployedAt);
+  const certDays = certDaysLeft(status?.cert?.notAfter);
+  const versions = [
+    status?.versions?.talos && `talos ${status.versions.talos}`,
+    status?.versions?.kubernetes && `k8s ${status.versions.kubernetes}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div>
+      <div className="inline-flex items-center gap-2.5 rounded-full border border-line-2 bg-surface/60 py-2 pl-3.5 pr-4 font-mono text-xs text-fg-2">
+        <span className="relative flex h-2 w-2">
+          {feed === "live" && (
+            <span
+              className={cn(
+                "absolute inline-flex h-full w-full animate-ping rounded-full opacity-60",
+                healthy ? "bg-success" : "bg-warn",
+              )}
+            />
+          )}
+          <span
+            className={cn(
+              "relative inline-flex h-2 w-2 rounded-full",
+              feed === "live" && healthy && "bg-success",
+              feed === "live" && !healthy && "bg-warn",
+              feed === "loading" && "bg-fg-3",
+              feed === "snapshot" && "bg-fg-3",
+            )}
+          />
+        </span>
+        {feed === "loading" && <span>checking the cluster…</span>}
+        {feed === "live" && (
+          <span>
+            <b className={cn("font-semibold", healthy ? "text-success" : "text-warn")}>
+              {healthy ? "All systems operational" : "Partially degraded"}
+            </b>
+            {updated && <span className="text-fg-3"> · updated {updated}</span>}
+          </span>
+        )}
+        {feed === "snapshot" && (
+          <span>live feed unreachable · showing the build-time snapshot</span>
+        )}
+      </div>
+
+      <div className="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-line bg-line lg:grid-cols-4">
+        <Tile
+          label="Serving build"
+          value={sha}
+          mono
+          sub={deployed ? `deployed ${deployed}` : "pinned to commit SHA"}
+        />
+        <Tile
+          label="ArgoCD app"
+          value={argocd.sync}
+          sub={`${argocd.health.toLowerCase()} · auto-sync`}
+          subTone={argocd.health === "Healthy" ? "ok" : "muted"}
+        />
+        <Tile
+          label="Cluster nodes"
+          value={
+            <>
+              {nodes.ready}
+              <span className="text-base font-medium text-fg-3"> / {nodes.total} ready</span>
+            </>
+          }
+          sub={versions || "Talos Linux · Kubernetes"}
+        />
+        <Tile
+          label="TLS certificate"
+          value={
+            certDays !== null ? (
+              <>
+                {certDays}
+                <span className="text-base font-medium text-fg-3"> days</span>
+              </>
+            ) : (
+              "auto"
+            )
+          }
+          sub="auto-renews · Let's Encrypt"
+        />
+      </div>
+    </div>
+  );
+}

--- a/portfolio/src/components/infrastructure/Pipeline.tsx
+++ b/portfolio/src/components/infrastructure/Pipeline.tsx
@@ -1,0 +1,68 @@
+import {
+  Cog,
+  Database,
+  GitCommitHorizontal,
+  Globe,
+  Network,
+  Package,
+  RefreshCw,
+  Route,
+  Server,
+  User,
+} from "lucide-react";
+import { Reveal } from "@/components/primitives/Reveal";
+import type { PipelineHop } from "@/content/infrastructure";
+
+const hopIcon: Record<PipelineHop["icon"], React.ReactNode> = {
+  user: <User size={20} />,
+  globe: <Globe size={20} />,
+  network: <Network size={20} />,
+  route: <Route size={20} />,
+  package: <Package size={20} />,
+  commit: <GitCommitHorizontal size={20} />,
+  cog: <Cog size={20} />,
+  registry: <Database size={20} />,
+  sync: <RefreshCw size={20} />,
+  server: <Server size={20} />,
+};
+
+function Connector({ delay }: { delay: number }) {
+  return (
+    <div
+      aria-hidden
+      className="relative hidden w-11 shrink-0 items-center md:flex"
+    >
+      <span className="absolute inset-x-1 top-1/2 h-px bg-line-2" />
+      <span className="absolute right-0.5 top-1/2 h-1.5 w-1.5 -translate-y-1/2 rotate-45 border-r border-t border-line-2" />
+      <span
+        className="packet absolute top-1/2 h-[5px] w-[5px] -translate-y-1/2 rounded-full bg-accent shadow-[0_0_8px_var(--accent)]"
+        style={{ "--packet-delay": `${delay}s` } as React.CSSProperties}
+      />
+    </div>
+  );
+}
+
+export function Pipeline({ hops }: { hops: readonly PipelineHop[] }) {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-stretch md:gap-0">
+      {hops.map((hop, i) => (
+        <div key={hop.name} className="contents">
+          {i > 0 && <Connector delay={i * 0.45} />}
+          <Reveal
+            delay={i * 0.08}
+            className="min-w-0 flex-1 rounded-md border border-line bg-surface p-4 transition-colors hover:border-accent"
+          >
+            <span className="mb-3 block text-accent">{hopIcon[hop.icon]}</span>
+            <p className="font-mono text-sm font-semibold text-fg">{hop.name}</p>
+            <p className="mt-1 text-xs leading-relaxed text-fg-3">{hop.desc}</p>
+            {hop.meta && (
+              <p className="mt-2 truncate font-mono text-[0.68rem] text-accent">
+                {hop.meta}
+              </p>
+            )}
+          </Reveal>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/portfolio/src/content/infrastructure.ts
+++ b/portfolio/src/content/infrastructure.ts
@@ -1,0 +1,125 @@
+export type PipelineHop = {
+  icon:
+    | "user"
+    | "globe"
+    | "network"
+    | "route"
+    | "package"
+    | "commit"
+    | "cog"
+    | "registry"
+    | "sync"
+    | "server";
+  name: string;
+  desc: string;
+  meta?: string;
+};
+
+export type PlatformComponent = {
+  name: string;
+  role: string;
+};
+
+/** Baked snapshot shown when /status.json is unreachable (local dev, feed down). */
+export const statusSnapshot = {
+  argocd: { sync: "Synced", health: "Healthy" },
+  nodes: { ready: 6, total: 6 },
+} as const;
+
+export const requestPath: readonly PipelineHop[] = [
+  {
+    icon: "user",
+    name: "You",
+    desc: "HTTPS request to nordbye.it",
+    meta: "TLS 1.3",
+  },
+  {
+    icon: "globe",
+    name: "DNS + edge",
+    desc: "Resolves to the cluster's public entry point",
+    meta: "proxied",
+  },
+  {
+    icon: "network",
+    name: "Cilium LB",
+    desc: "L2-announced VIP, eBPF load-balancing into the cluster",
+    meta: "LoadBalancer IPAM",
+  },
+  {
+    icon: "route",
+    name: "Traefik",
+    desc: "Gateway API HTTPRoute, certificate from cert-manager",
+    meta: "gateway.networking.k8s.io",
+  },
+  {
+    icon: "package",
+    name: "portfolio pod",
+    desc: "Hardened nginx serving the static export",
+    meta: "read-only rootfs",
+  },
+];
+
+export const deployPath: readonly PipelineHop[] = [
+  {
+    icon: "commit",
+    name: "git push",
+    desc: "Commit to main in the homelab monorepo",
+  },
+  {
+    icon: "cog",
+    name: "GitHub Actions",
+    desc: "Builds the image, scans it, updates the manifest tag in the same run",
+  },
+  {
+    icon: "registry",
+    name: "GHCR",
+    desc: "Image pushed and pinned to the commit SHA, never :latest",
+  },
+  {
+    icon: "sync",
+    name: "ArgoCD",
+    desc: "Detects the manifest change in Git and syncs the Application",
+    meta: "app-of-apps",
+  },
+  {
+    icon: "server",
+    name: "Talos cluster",
+    desc: "Rolling update, zero downtime. You're looking at the result.",
+    meta: "genesis",
+  },
+];
+
+export const platform: readonly PlatformComponent[] = [
+  {
+    name: "Talos Linux",
+    role: "Immutable, API-managed Kubernetes OS. No SSH, no shell, no drift.",
+  },
+  {
+    name: "Cilium",
+    role: "eBPF CNI, L2 announcements and LB-IPAM for bare-metal VIPs.",
+  },
+  {
+    name: "Traefik",
+    role: "Gateway API implementation. HTTPRoutes, not Ingress annotations.",
+  },
+  {
+    name: "ArgoCD",
+    role: "App-of-apps GitOps. Git is the only write path to the cluster.",
+  },
+  {
+    name: "cert-manager",
+    role: "ACME certificates issued and rotated without human hands.",
+  },
+  {
+    name: "External Secrets",
+    role: "Secrets synced from an upstream store. None live in Git.",
+  },
+  {
+    name: "Prometheus + Grafana",
+    role: "kube-prometheus-stack, with dashboards versioned as code.",
+  },
+  {
+    name: "Loki + OTel",
+    role: "Log aggregation and traces via the OpenTelemetry collector.",
+  },
+];

--- a/portfolio/src/content/site.ts
+++ b/portfolio/src/content/site.ts
@@ -47,6 +47,7 @@ export const site = {
     { label: "About", href: "/#about" },
     { label: "Resume", href: "/#resume" },
     { label: "Work", href: "/#portfolio" },
+    { label: "Infrastructure", href: "/infrastructure" },
     { label: "Blog", href: "/#blog" },
     { label: "Contact", href: "/#contact" },
   ] as readonly { href: string; label: string }[],


### PR DESCRIPTION
## Why

The portfolio claims platform skills; this page proves them. The site already runs on the Talos cluster via ArgoCD, so it can show its own request path, deploy pipeline, and live cluster status instead of describing them.

## What

- New `/infrastructure` page: live status tiles, request-path and deploy-path diagrams, a status.json explainer, and a platform grid. "Infrastructure" added to the nav (and thereby the command palette).
- `LiveStatus` fetches `/status.json` client-side. Three states: operational (green), partially degraded (amber), and an explicit build-time-snapshot fallback when the feed is unreachable, so the static page never breaks with the cluster.
- `status-publisher` CronJob (portfolio namespace, every 5 min) reads node readiness and versions, ArgoCD app sync/health, deployment image tag, and cert expiry, and applies them as the `portfolio-status` ConfigMap. RBAC is resource-name-scoped where the API allows. The ConfigMap carries no ArgoCD tracking label, so automated prune ignores it.
- The deployment mounts that ConfigMap (optional) and nginx serves it at `/status.json` with `Cache-Control: no-store` via an exact-match location, overriding the 1-day JSON cache rule.

## Verification

- `make typecheck` and `make lint` pass; the 9 lint warnings are pre-existing and in untouched files.
- Publisher script read-only steps dry-run against the live cluster; output matches the frontend schema (6/6 nodes, Talos v1.11.6, k8s v1.34.0).
- `kubectl diff -k k8s/talos/apps/portfolio` shows only the expected changes: ConfigMap mount on the deployment plus six new publisher objects.
- Browser-checked via the dev stack: live state (mocked fetch with the dry-run JSON), fallback state, mobile (no horizontal overflow), and the home page for nav regressions.
- Production nginx image not built locally (TeX Live stage); the new nginx location ships with the next CI image build. Until that image rolls out, /status.json 404s and the page shows the snapshot state, so ordering is safe.

The 30-day availability strip from the design mockup is deferred; see BACKLOG.md (needs an external prober to be honest data).