### PR TITLE
feat(portfolio): infrastructure page polish, uptime strip, honest status

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,11 +12,11 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Infrastructure page
 
-### 30-day availability strip
-- **What:** The `/infrastructure` page design mockup included a 30-day availability tick strip with an uptime percentage. Dropped from the implemented page because nothing external probes the site today, and self-reported uptime from inside the cluster proves nothing when the cluster is what fails.
-- **Why deferred:** Needs an external prober (Uptime Kuma on another host, healthchecks.io, or a GitHub Actions schedule hitting the site) publishing daily results somewhere the static page can fetch.
-- **Unblock:** Pick the prober, publish daily results as JSON (could ride along in `status.json` or a second file), add the strip section back to `portfolio/src/app/infrastructure/page.tsx`.
-- **Where:** `portfolio/src/app/infrastructure/page.tsx`, `k8s/talos/apps/portfolio/status-publisher.yaml`.
+### Outside-in probing for the 30-day health strip
+- **What:** The `/infrastructure` page now renders a 30-day health strip from per-day sample counts the status publisher accumulates in `status.json` (`history` array). It is labelled "observed in-cluster" because that is all it is: days where the publisher never ran show as gaps, but the strip cannot see the site being unreachable from the internet while the cluster is fine, and self-reported health proves less than an external probe.
+- **Why deferred:** True availability needs an external prober (Uptime Kuma on another host, healthchecks.io, or a GitHub Actions schedule hitting the site) publishing daily results somewhere the static page can fetch.
+- **Unblock:** Pick the prober, publish daily results as JSON the page can fetch (second file next to `status.json`, or merged into it), then swap the strip's data source and drop the "observed in-cluster" qualifier.
+- **Where:** `portfolio/src/components/infrastructure/LiveStatus.tsx` (`buildUptime`), `k8s/talos/apps/portfolio/status-publisher.yaml` (history merge step).
 
 ## Portfolio modern — items deferred during initial build
 

--- a/k8s/talos/apps/portfolio/status-publisher.yaml
+++ b/k8s/talos/apps/portfolio/status-publisher.yaml
@@ -134,6 +134,17 @@ spec:
 
                   NOT_AFTER=$(kubectl get certificate nordbye-it -n cert-manager -o jsonpath='{.status.notAfter}')
 
+                  # Previous payload carries the per-day uptime history; keep it.
+                  kubectl get configmap portfolio-status -n portfolio \
+                    -o jsonpath='{.data.status\.json}' > /tmp/prev.json 2>/dev/null || true
+                  jq -e . /tmp/prev.json > /dev/null 2>&1 || echo '{}' > /tmp/prev.json
+
+                  if [ "$READY" = "$TOTAL" ] && [ "$SYNC" = "Synced" ] && [ "$HEALTH" = "Healthy" ]; then
+                    OK=1
+                  else
+                    OK=0
+                  fi
+
                   jq -n \
                     --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
                     --arg build "$BUILD" \
@@ -154,7 +165,20 @@ spec:
                       nodes: {ready: $ready, total: $total},
                       versions: {kubernetes: $k8s, talos: $talos},
                       cert: {notAfter: $notAfter}
-                    }' > /tmp/status.json
+                    }' > /tmp/new.json
+
+                  # Fold this run into today's uptime bucket, keep 30 days.
+                  jq -s \
+                    --arg today "$(date -u +%Y-%m-%d)" \
+                    --argjson ok "$OK" \
+                    '
+                    (.[0].history // []) as $h
+                    | (if ($h | length) > 0 and $h[-1].d == $today
+                       then $h[:-1] + [{d: $today, ok: ($h[-1].ok + $ok), total: ($h[-1].total + 1)}]
+                       else $h + [{d: $today, ok: $ok, total: 1}]
+                       end) as $merged
+                    | .[1] + {history: ($merged | sort_by(.d) | .[-30:])}
+                    ' /tmp/prev.json /tmp/new.json > /tmp/status.json
 
                   kubectl create configmap portfolio-status -n portfolio \
                     --from-file=status.json=/tmp/status.json \

--- a/portfolio/src/app/globals.css
+++ b/portfolio/src/app/globals.css
@@ -66,9 +66,12 @@ body {
   color: var(--selection-fg);
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
+/* In @layer base so color/decoration utilities on links win the cascade */
+@layer base {
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -231,7 +234,7 @@ a {
   100% { left: calc(100% - 10px); opacity: 0; }
 }
 .packet {
-  animation: packet-flow 2.8s linear infinite;
+  animation: packet-flow var(--packet-duration, 2.8s) linear infinite;
   animation-delay: var(--packet-delay, 0s);
 }
 

--- a/portfolio/src/app/infrastructure/page.tsx
+++ b/portfolio/src/app/infrastructure/page.tsx
@@ -14,13 +14,50 @@ export const metadata: Metadata = {
 const dotTints = ["bg-accent", "bg-accent-3", "bg-accent-2", "bg-copper"];
 
 const statusJsonExample = `{
-  "generatedAt": "2026-07-12T09:14:02Z",
-  "build":      "286dd6c",
-  "argocd":     { "sync": "Synced", "health": "Healthy" },
-  "nodes":      { "ready": 6, "total": 6 },
-  "versions":   { "talos": "v1.11.6", "kubernetes": "v1.34.0" },
-  "cert":       { "notAfter": "2026-09-04T08:11:39Z" }
+  "generatedAt": "2026-07-13T05:55:03Z",
+  "build": "72088b9",
+  "deployedAt": "2026-07-12T19:33:47Z",
+  "argocd": {
+    "sync": "Synced",
+    "health": "Healthy",
+    "syncedAt": "2026-07-12T19:32:48Z"
+  },
+  "nodes": { "ready": 6, "total": 6 },
+  "versions": { "talos": "v1.11.6", "kubernetes": "v1.34.0" },
+  "cert": { "notAfter": "2026-09-25T11:41:28Z" },
+  "history": [{ "d": "2026-07-13", "ok": 71, "total": 71 }, ...]
 }`;
+
+function JsonCode({ code }: { code: string }) {
+  return (
+    <>
+      {code.split(/("[^"]*":|"[^"]*"|\d+)/g).map((part, i) => {
+        if (part.endsWith('":')) {
+          return (
+            <span key={i}>
+              <span className="text-accent">{part.slice(0, -1)}</span>:
+            </span>
+          );
+        }
+        if (part.startsWith('"')) {
+          return (
+            <span key={i} className="text-accent-3">
+              {part}
+            </span>
+          );
+        }
+        if (/^\d+$/.test(part)) {
+          return (
+            <span key={i} className="text-copper">
+              {part}
+            </span>
+          );
+        }
+        return part;
+      })}
+    </>
+  );
+}
 
 export default function InfrastructurePage() {
   return (
@@ -61,7 +98,7 @@ export default function InfrastructurePage() {
         }
         className="border-t border-line"
       >
-        <Pipeline hops={deployPath} />
+        <Pipeline hops={deployPath} variant="steps" />
       </Section>
 
       <Section
@@ -86,14 +123,29 @@ export default function InfrastructurePage() {
               fall back to a build-time snapshot and say so. The page never
               breaks because the homelab is having a bad day.
             </p>
+            <div className="space-y-4 border-t border-line pt-5 text-sm">
+              <p className="eyebrow text-[0.65rem]">design decisions</p>
+              <p>
+                The pod serving this page has no Kubernetes API access. A
+                status API would be fresher, but it would put cluster
+                credentials behind a public endpoint for data that changes
+                every few minutes at most. The publisher&apos;s RBAC reads the
+                objects it reports on, pinned to resource names where the API
+                allows it, and writes one ConfigMap.
+              </p>
+              <p>
+                The pill checks the timestamp too. Data older than 15 minutes
+                is reported as stale rather than shown as operational.
+              </p>
+            </div>
           </div>
           <Reveal className="overflow-hidden rounded-lg border border-line bg-bg-2">
             <div className="flex items-center justify-between border-b border-line px-4 py-2.5 font-mono text-xs">
               <span className="text-fg-2">GET /status.json</span>
               <span className="text-fg-3">refreshed every 5 min</span>
             </div>
-            <pre className="overflow-x-auto p-4 font-mono text-[0.78rem] leading-relaxed text-fg-2">
-              {statusJsonExample}
+            <pre className="overflow-x-auto p-4 font-mono text-[0.78rem] leading-relaxed text-fg-3">
+              <JsonCode code={statusJsonExample} />
             </pre>
           </Reveal>
         </div>
@@ -116,10 +168,10 @@ export default function InfrastructurePage() {
         }
         className="border-t border-line"
       >
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-x-8 gap-y-8 sm:grid-cols-2 lg:grid-cols-4">
           {platform.map((p, i) => (
             <Reveal key={p.name} delay={i * 0.05}>
-              <div className="h-full rounded-md border border-line bg-surface p-4 transition-colors hover:border-line-2">
+              <div className="border-t border-line pt-4">
                 <p className="flex items-center gap-2 font-mono text-sm font-semibold text-fg">
                   <span
                     aria-hidden

--- a/portfolio/src/components/infrastructure/LiveStatus.tsx
+++ b/portfolio/src/components/infrastructure/LiveStatus.tsx
@@ -13,11 +13,16 @@ type ClusterStatus = {
   nodes: { ready: number; total: number };
   versions: { kubernetes?: string; talos?: string };
   cert?: { notAfter: string };
+  /** One entry per UTC day: healthy samples vs samples taken. */
+  history?: { d: string; ok: number; total: number }[];
 };
 
 type FeedState = "loading" | "live" | "snapshot";
 
 const buildSha = (process.env.NEXT_PUBLIC_BUILD_SHA ?? "dev").slice(0, 7);
+
+/** Publisher runs every 5 min; three missed runs means the feed can't be trusted. */
+const STALE_AFTER_MS = 15 * 60_000;
 
 function relative(iso: string | undefined): string | null {
   if (!iso) return null;
@@ -29,6 +34,43 @@ function relative(iso: string | undefined): string | null {
   const h = Math.round(min / 60);
   if (h < 48) return `${h} h ago`;
   return `${Math.round(h / 24)} d ago`;
+}
+
+type UptimeDay = { d: string; pct: number | null };
+
+/**
+ * Last 30 UTC days from the publisher's per-day sample counts. Health is as
+ * sampled: days with no samples at all render as gaps instead of green, and
+ * a silent publisher already trips the stale pill above.
+ */
+function buildUptime(
+  history: ClusterStatus["history"],
+): { days: UptimeDay[]; overall: string | null } | null {
+  if (!history?.length) return null;
+  const byDay = new Map(history.map((h) => [h.d, h]));
+  const now = Date.now();
+  const days: UptimeDay[] = [];
+  let okSum = 0;
+  let totalSum = 0;
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(now - i * 86_400_000).toISOString().slice(0, 10);
+    const entry = byDay.get(d);
+    if (!entry || entry.total < 1) {
+      days.push({ d, pct: null });
+      continue;
+    }
+    days.push({ d, pct: Math.min(1, entry.ok / entry.total) });
+    okSum += entry.ok;
+    totalSum += entry.total;
+  }
+  const overall = totalSum ? `${((okSum / totalSum) * 100).toFixed(2)}%` : null;
+  return { days, overall };
+}
+
+function isStale(generatedAt: string | undefined): boolean {
+  if (!generatedAt) return true;
+  const ageMs = Date.now() - new Date(generatedAt).getTime();
+  return Number.isNaN(ageMs) || ageMs > STALE_AFTER_MS;
 }
 
 function certDaysLeft(notAfter: string | undefined): number | null {
@@ -101,6 +143,10 @@ export function LiveStatus() {
     nodes.ready === nodes.total &&
     argocd.sync === "Synced" &&
     argocd.health === "Healthy";
+  // A green light on old data is a lie: refuse "operational" when the feed is stale.
+  const stale = isStale(status?.generatedAt);
+  const ok = healthy && !stale;
+  const uptime = buildUptime(status?.history);
   const updated = relative(status?.generatedAt);
   const deployed = relative(status?.deployedAt);
   const certDays = certDaysLeft(status?.cert?.notAfter);
@@ -115,29 +161,35 @@ export function LiveStatus() {
     <div>
       <div className="inline-flex items-center gap-2.5 rounded-full border border-line-2 bg-surface/60 py-2 pl-3.5 pr-4 font-mono text-xs text-fg-2">
         <span className="relative flex h-2 w-2">
-          {feed === "live" && (
+          {feed === "live" && !stale && (
             <span
               className={cn(
                 "absolute inline-flex h-full w-full animate-ping rounded-full opacity-60",
-                healthy ? "bg-success" : "bg-warn",
+                ok ? "bg-success" : "bg-warn",
               )}
             />
           )}
           <span
             className={cn(
               "relative inline-flex h-2 w-2 rounded-full",
-              feed === "live" && healthy && "bg-success",
-              feed === "live" && !healthy && "bg-warn",
+              feed === "live" && ok && "bg-success",
+              feed === "live" && !ok && "bg-warn",
               feed === "loading" && "bg-fg-3",
               feed === "snapshot" && "bg-fg-3",
             )}
           />
         </span>
         {feed === "loading" && <span>checking the cluster…</span>}
-        {feed === "live" && (
+        {feed === "live" && stale && (
           <span>
-            <b className={cn("font-semibold", healthy ? "text-success" : "text-warn")}>
-              {healthy ? "All systems operational" : "Partially degraded"}
+            <b className="font-semibold text-warn">Live feed stale</b>
+            {updated && <span className="text-fg-3"> · last update {updated}</span>}
+          </span>
+        )}
+        {feed === "live" && !stale && (
+          <span>
+            <b className={cn("font-semibold", ok ? "text-success" : "text-warn")}>
+              {ok ? "All systems operational" : "Partially degraded"}
             </b>
             {updated && <span className="text-fg-3"> · updated {updated}</span>}
           </span>
@@ -185,6 +237,35 @@ export function LiveStatus() {
           sub="auto-renews · Let's Encrypt"
         />
       </div>
+
+      {uptime && (
+        <div className="mt-8">
+          <div className="flex items-baseline justify-between font-mono text-xs text-fg-3">
+            <span>last 30 days · observed in-cluster</span>
+            {uptime.overall && (
+              <span>
+                <span className="text-success">{uptime.overall}</span> healthy
+              </span>
+            )}
+          </div>
+          <div className="mt-3 flex h-10 items-stretch justify-between gap-[3px]">
+            {uptime.days.map((day) => (
+              <span
+                key={day.d}
+                title={`${day.d} · ${
+                  day.pct === null ? "no data" : `${(day.pct * 100).toFixed(1)}% healthy`
+                }`}
+                className={cn(
+                  "w-full max-w-[9px] flex-1 rounded-full transition-transform duration-150 hover:scale-y-110",
+                  day.pct === null && "bg-line-2",
+                  day.pct !== null && day.pct >= 0.995 && "bg-success",
+                  day.pct !== null && day.pct < 0.995 && "bg-danger",
+                )}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/portfolio/src/components/infrastructure/Pipeline.tsx
+++ b/portfolio/src/components/infrastructure/Pipeline.tsx
@@ -10,59 +10,112 @@ import {
   Server,
   User,
 } from "lucide-react";
+import { cn } from "@/lib/cn";
 import { Reveal } from "@/components/primitives/Reveal";
 import type { PipelineHop } from "@/content/infrastructure";
 
 const hopIcon: Record<PipelineHop["icon"], React.ReactNode> = {
-  user: <User size={20} />,
-  globe: <Globe size={20} />,
-  network: <Network size={20} />,
-  route: <Route size={20} />,
-  package: <Package size={20} />,
-  commit: <GitCommitHorizontal size={20} />,
-  cog: <Cog size={20} />,
-  registry: <Database size={20} />,
-  sync: <RefreshCw size={20} />,
-  server: <Server size={20} />,
+  user: <User size={18} />,
+  globe: <Globe size={18} />,
+  network: <Network size={18} />,
+  route: <Route size={18} />,
+  package: <Package size={18} />,
+  commit: <GitCommitHorizontal size={18} />,
+  cog: <Cog size={18} />,
+  registry: <Database size={18} />,
+  sync: <RefreshCw size={18} />,
+  server: <Server size={18} />,
 };
 
-function Connector({ delay }: { delay: number }) {
+/**
+ * stream: a continuous flow — round nodes on a solid wire with packets
+ * travelling it (the request path). steps: discrete events — numbered square
+ * nodes on a dashed wire, no packets (the deploy path).
+ */
+export function Pipeline({
+  hops,
+  variant = "stream",
+}: {
+  hops: readonly PipelineHop[];
+  variant?: "stream" | "steps";
+}) {
+  const steps = variant === "steps";
   return (
-    <div
-      aria-hidden
-      className="relative hidden w-11 shrink-0 items-center md:flex"
-    >
-      <span className="absolute inset-x-1 top-1/2 h-px bg-line-2" />
-      <span className="absolute right-0.5 top-1/2 h-1.5 w-1.5 -translate-y-1/2 rotate-45 border-r border-t border-line-2" />
+    <div className="relative">
+      {/* the wire: vertical through the icons on mobile, horizontal on md+ */}
       <span
-        className="packet absolute top-1/2 h-[5px] w-[5px] -translate-y-1/2 rounded-full bg-accent shadow-[0_0_8px_var(--accent)]"
-        style={{ "--packet-delay": `${delay}s` } as React.CSSProperties}
+        aria-hidden
+        className={cn(
+          "absolute bottom-8 left-[20px] top-8 md:bottom-auto md:left-20 md:right-20 md:top-[20px]",
+          steps
+            ? "border-l border-dashed border-line-2 md:border-l-0 md:border-t"
+            : "w-px bg-line-2 md:h-px md:w-auto",
+        )}
       />
-    </div>
-  );
-}
-
-export function Pipeline({ hops }: { hops: readonly PipelineHop[] }) {
-  return (
-    <div className="flex flex-col gap-3 md:flex-row md:items-stretch md:gap-0">
-      {hops.map((hop, i) => (
-        <div key={hop.name} className="contents">
-          {i > 0 && <Connector delay={i * 0.45} />}
+      {/* packets travelling the wire, stream variant on md+ only */}
+      {!steps && (
+        <span
+          aria-hidden
+          className="absolute left-20 right-20 top-[20px] hidden h-px md:block"
+        >
+          <span
+            className="packet absolute top-1/2 h-[5px] w-[5px] -translate-y-1/2 rounded-full bg-accent shadow-[0_0_8px_var(--accent)]"
+            style={{ "--packet-duration": "5.5s" } as React.CSSProperties}
+          />
+          <span
+            className="packet absolute top-1/2 h-[5px] w-[5px] -translate-y-1/2 rounded-full bg-accent shadow-[0_0_8px_var(--accent)]"
+            style={
+              {
+                "--packet-duration": "5.5s",
+                "--packet-delay": "2.75s",
+              } as React.CSSProperties
+            }
+          />
+        </span>
+      )}
+      <div className="relative flex flex-col gap-8 md:flex-row md:justify-between">
+        {hops.map((hop, i) => (
           <Reveal
+            key={hop.name}
             delay={i * 0.08}
-            className="min-w-0 flex-1 rounded-md border border-line bg-surface p-4 transition-colors hover:border-accent"
+            className="flex items-start gap-5 md:w-40 md:flex-col md:items-center md:gap-4 md:text-center"
           >
-            <span className="mb-3 block text-accent">{hopIcon[hop.icon]}</span>
-            <p className="font-mono text-sm font-semibold text-fg">{hop.name}</p>
-            <p className="mt-1 text-xs leading-relaxed text-fg-3">{hop.desc}</p>
-            {hop.meta && (
-              <p className="mt-2 truncate font-mono text-[0.68rem] text-accent">
-                {hop.meta}
+            <span
+              className={cn(
+                "flex h-10 w-10 shrink-0 items-center justify-center border bg-surface",
+                steps
+                  ? "rounded-md border-line-2 text-accent-3"
+                  : "rounded-full border-line-2 text-accent",
+              )}
+            >
+              {hopIcon[hop.icon]}
+            </span>
+            <div className="min-w-0 pt-2 md:pt-0">
+              {steps && (
+                <p className="font-mono text-[0.65rem] tracking-widest text-fg-3">
+                  0{i + 1}
+                </p>
+              )}
+              <p className="font-mono text-sm font-semibold text-fg">
+                {hop.name}
               </p>
-            )}
+              <p className="mt-1 text-xs leading-relaxed text-fg-3">
+                {hop.desc}
+              </p>
+              {hop.meta && (
+                <p
+                  className={cn(
+                    "mt-1.5 truncate font-mono text-[0.68rem]",
+                    steps ? "text-accent-3" : "text-accent",
+                  )}
+                >
+                  {hop.meta}
+                </p>
+              )}
+            </div>
           </Reveal>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/portfolio/src/components/layout/Footer.tsx
+++ b/portfolio/src/components/layout/Footer.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { site } from "@/content/site";
 import { FooterStamp } from "@/components/FooterStamp";
 
@@ -15,13 +16,13 @@ export function Footer() {
           </h2>
           <p className="mt-4 max-w-md text-fg-2">
             Next.js, Tailwind, served by hardened nginx in Kubernetes.
-            Reconciled by ArgoCD from{" "}
-            <a
-              href="https://github.com/mortennordbye/Homelab"
+            Reconciled by ArgoCD.{" "}
+            <Link
+              href="/infrastructure"
               className="focus-ring text-fg underline decoration-accent decoration-2 underline-offset-4 hover:text-accent"
             >
-              this repo
-            </a>
+              See how this page reaches you
+            </Link>
             .
           </p>
         </div>

--- a/portfolio/src/content/infrastructure.ts
+++ b/portfolio/src/content/infrastructure.ts
@@ -35,9 +35,9 @@ export const requestPath: readonly PipelineHop[] = [
   },
   {
     icon: "globe",
-    name: "DNS + edge",
-    desc: "Resolves to the cluster's public entry point",
-    meta: "proxied",
+    name: "DNS",
+    desc: "Cloudflare DNS points straight at the cluster's public IP",
+    meta: "no CDN in front",
   },
   {
     icon: "network",
@@ -68,7 +68,7 @@ export const deployPath: readonly PipelineHop[] = [
   {
     icon: "cog",
     name: "GitHub Actions",
-    desc: "Builds the image, scans it, updates the manifest tag in the same run",
+    desc: "Builds the image and updates the manifest tag in the same run",
   },
   {
     icon: "registry",


### PR DESCRIPTION
## Why

Follow-up to #301. The page had three near-identical card grids that read as repetitive, the status pill could show green on stale data, and a few claims in the copy did not match reality (the site is not behind a CDN proxy, the build run does not scan images, and the RBAC name-scoping claim overstated what the nodes rule allows).

## What

- Status publisher folds each run into a per-day `history` bucket in `status.json` (30 days, about 1.5 KB). The page renders it as an UptimeRobot-style bar strip labelled "observed in-cluster": green day, red day, gray gap for days with no samples. BACKLOG entry rewritten; outside-in probing stays deferred.
- Status pill treats data older than 15 minutes (three missed publisher runs) as stale instead of claiming all systems operational.
- Pipelines redesigned from card rows to nodes on a wire. Request path is a stream: round nodes, solid wire, travelling packets. Deploy path is a sequence: numbered square nodes on a dashed wire. One `variant` prop, not a second component.
- Platform grid de-boxed to a borderless list with hairline tops. The `status.json` example card got syntax colors and now shows the real payload shape including `deployedAt`, `argocd.syncedAt`, and `history`.
- Short design-decisions prose next to the example card (no credentials on the public pod, RBAC pinning, degrade-over-lying).
- Footer colophon links to `/infrastructure` instead of the repo (the page links to the repo).
- Global anchor reset moved into `@layer base` so link color/underline utilities actually apply; they were silently overridden site-wide.
- Copy fact fixes verified against manifests and the live edge: DNS hop says "no CDN in front" (Cloudflare hosts DNS only, record points at the public IP), GitHub Actions hop drops "scans it" (scanning lives in the scheduled `container-vulnerability-scan.yaml`), RBAC sentence says name-pinning applies where the API allows it (nodes cannot be name-scoped).

## Verification

- Publisher history merge logic dry-run locally with jq against the live `status.json`: first run, same-day increment, day rollover, 30-day trim, and empty previous payload all behave. `kubectl kustomize k8s/talos/apps/portfolio` renders.
- All pill states exercised in the browser with mocked feeds: fresh healthy, stale (3 h old), degraded (5/6 nodes), and no feed (snapshot fallback).
- Uptime strip verified with a mocked 30-day history containing a red day and a no-data gap; today renders from partial samples.
- Desktop and 390px mobile checked with no horizontal overflow; homepage swept after the CSS layer change (nav, socials, buttons, card links unchanged).
- `typecheck` and `lint` clean in the Docker dev stack (9 pre-existing warnings in untouched files).
- Live production behavior unchanged until merge; the strip appears after the first publisher run with the new manifest and fills one bar per day.