### PR TITLE
fix(portfolio): keep hero earth round on ultrawide viewports

### DIFF
--- a/portfolio/src/components/InlineGlobeScene.tsx
+++ b/portfolio/src/components/InlineGlobeScene.tsx
@@ -239,8 +239,12 @@ function useResponsiveEarthOffset() {
     const vw = vh * (size.width / size.height);
     const halfW = vw / 2;
     const desired = halfW * 0.30;
+    // Perspective anamorphosis: a sphere far off the camera axis projects as
+    // an ellipse, which ultrawide viewports otherwise hit hard. Keep the
+    // earth within ~20 degrees off-axis, where the stretch stays invisible.
+    const maxOffAxis = cam.position.z * Math.tan(THREE.MathUtils.degToRad(20));
     const cap = halfW - RADIUS - 0.25;
-    return Math.max(0, Math.min(desired, cap));
+    return Math.max(0, Math.min(desired, maxOffAxis, cap));
   }, [camera, size]);
 }
 


### PR DESCRIPTION
## Why

On ultrawide screens the hero earth renders as a stretched ellipse. The horizontal offset scales with viewport half-width, which pushes the sphere 35 to 40 degrees off the camera axis, and a perspective projection stretches off-axis spheres.

## What

Cap the earth offset at about 20 degrees off-axis (2.0 world units at the camera distance) in `useResponsiveEarthOffset`. Normal widescreen aspect ratios never reach the cap, so nothing changes below roughly 2.3:1.

## Verification

Checked in the Docker dev stack at 3440x900 (earth round, sits slightly right of center) and 1520x900 (pixel-identical to before). typecheck and lint clean.

Note: this is the one commit that missed the train on #304, which was merged while the fix was being pushed to its branch.