### PR TITLE
chore(ci): keep workflows from running in forks

### DIFF
--- a/.github/workflows/30-days-backup-reminder.yml
+++ b/.github/workflows/30-days-backup-reminder.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   notify:
+    if: github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     steps:
       - name: Get Discord Webhook URL from Bitwarden

--- a/.github/workflows/30-days-k8s-update-reminder.yml
+++ b/.github/workflows/30-days-k8s-update-reminder.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   notify:
+    if: github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     steps:
       - name: Get Discord Webhook URL from Bitwarden

--- a/.github/workflows/30-days-server-update-reminder.yml
+++ b/.github/workflows/30-days-server-update-reminder.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   notify:
+    if: github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-blog.yaml
+++ b/.github/workflows/build-blog.yaml
@@ -26,7 +26,7 @@ jobs:
     # Gates stage deploys on push to main. Manual prod dispatch skips this.
     # The Hugo render itself is validated by the Docker build below, and
     # the image is only pushed if that succeeds.
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,7 +43,7 @@ jobs:
   build-and-deploy:
     needs: ci
     # success = push with green ci; skipped = manual prod dispatch
-    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') }}
+    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') && github.repository_owner == 'mortennordbye' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed to update manifests

--- a/.github/workflows/build-portfolio.yaml
+++ b/.github/workflows/build-portfolio.yaml
@@ -27,7 +27,7 @@ jobs:
     # Gates stage deploys on push to main. Manual prod dispatch skips this.
     # next build is not repeated here: it runs inside the Docker build, and
     # the image is only pushed if that succeeds.
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,7 +56,7 @@ jobs:
   build-and-deploy:
     needs: ci
     # success = push with green ci; skipped = manual prod dispatch
-    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') }}
+    if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') && github.repository_owner == 'mortennordbye' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/container-vulnerability-scan.yaml
+++ b/.github/workflows/container-vulnerability-scan.yaml
@@ -18,6 +18,7 @@ on:
 
 jobs:
     scan-blog:
+        if: github.repository_owner == 'mortennordbye'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -50,6 +51,7 @@ jobs:
                   category: "blog-container"
 
     scan-portfolio:
+        if: github.repository_owner == 'mortennordbye'
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/render-diagram.yaml
+++ b/.github/workflows/render-diagram.yaml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   render:
+    if: github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed to commit the re-rendered diagram


### PR DESCRIPTION
## Why

A fork of this repo currently inherits live workflows: pushing to a fork's main would run the image builds (pushing images to the fork owner's GHCR and committing tag bumps in their fork), and enabling schedules there would fire the reminder and scan jobs. None of it touches this repo or its secrets, but the workflows should not run outside it at all.

## What

Job-level `if: github.repository_owner == 'mortennordbye'` guards on every push- and schedule-triggered workflow: build-portfolio, build-blog (both ci and build-and-deploy, since build-and-deploy also runs when ci is skipped on the manual prod dispatch path), render-diagram, container-vulnerability-scan (both scan jobs), and the three 30-day reminder workflows.

The two `pull_request` CI workflows are intentionally left unguarded so PRs against this repo still get checks; fork PR runs are gated by the repo setting below. `bump-image.yml` needs no guard: callers must supply their own GitHub App secrets.

## Verification

actionlint passes (pre-existing shellcheck info notes in untouched scripts remain). Repo setting changed alongside this PR: fork PR workflow approval policy raised from first-time contributors to all outside collaborators, and default token permissions confirmed read-only.