### PR TITLE
feat(portfolio): Fraunces display face, slash-path nav, faded section rules

### DIFF
--- a/portfolio/src/app/error.tsx
+++ b/portfolio/src/app/error.tsx
@@ -15,7 +15,7 @@ export default function Error({
       <p className="font-display text-xs uppercase tracking-[0.3em] text-accent">
         500 — something broke
       </p>
-      <h1 className="mt-6 text-display-lg font-display text-fg leading-[1]">
+      <h1 className="mt-6 text-display-lg text-fg leading-[1]">
         That didn&apos;t go{" "}
         <span className="gradient-text">according to plan.</span>
       </h1>

--- a/portfolio/src/app/globals.css
+++ b/portfolio/src/app/globals.css
@@ -102,14 +102,33 @@ body {
 }
 
 /* Utilities */
-.text-display-xl { font-size: var(--text-display-xl); line-height: 0.92; letter-spacing: -0.035em; font-weight: var(--font-weight-semibold); }
-.text-display-lg { font-size: var(--text-display-lg); line-height: 0.95; letter-spacing: -0.03em; font-weight: var(--font-weight-semibold); }
-.text-h1 { font-size: var(--text-h1); line-height: 1.05; letter-spacing: -0.02em; font-weight: var(--font-weight-semibold); }
-.text-h2 { font-size: var(--text-h2); line-height: 1.12; letter-spacing: -0.015em; font-weight: var(--font-weight-semibold); }
-.text-h3 { font-size: var(--text-h3); line-height: 1.25; letter-spacing: -0.01em; font-weight: var(--font-weight-semibold); }
+/* Headings render in the Fraunces display face; body/UI text stays on Inter.
+   Tracking is looser than the old Inter values — negative tracking that tight
+   cramps a serif — and the large display sizes drop to 500 so Fraunces doesn't
+   read heavy. */
+.text-display-xl { font-family: var(--font-display-face), ui-serif, Georgia, serif; font-size: var(--text-display-xl); line-height: 0.95; letter-spacing: -0.015em; font-weight: 500; }
+.text-display-lg { font-family: var(--font-display-face), ui-serif, Georgia, serif; font-size: var(--text-display-lg); line-height: 0.98; letter-spacing: -0.012em; font-weight: 500; }
+.text-h1 { font-family: var(--font-display-face), ui-serif, Georgia, serif; font-size: var(--text-h1); line-height: 1.08; letter-spacing: -0.01em; font-weight: 500; }
+.text-h2 { font-family: var(--font-display-face), ui-serif, Georgia, serif; font-size: var(--text-h2); line-height: 1.15; letter-spacing: -0.005em; font-weight: var(--font-weight-semibold); }
+.text-h3 { font-family: var(--font-display-face), ui-serif, Georgia, serif; font-size: var(--text-h3); line-height: 1.25; letter-spacing: 0; font-weight: var(--font-weight-semibold); }
 
 .font-display { font-family: var(--font-body), ui-sans-serif, system-ui, sans-serif; }
 .font-mono, .mono { font-family: var(--font-mono), ui-monospace, monospace; }
+
+/* Section separator — replaces the full-bleed border-t. A hairline capped at
+   content width, fading out at both ends so it never touches the viewport
+   edges. */
+.section-rule { position: relative; }
+.section-rule::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(100% - 2.5rem, calc(var(--container-wide) - 4rem));
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--line-2) 14%, var(--line-2) 86%, transparent);
+}
 
 /* Eyebrow — small caps mono label used above section headings */
 .eyebrow {

--- a/portfolio/src/app/layout.tsx
+++ b/portfolio/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Fraunces, Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 import { Header } from "@/components/layout/Header";
@@ -27,6 +27,15 @@ const mono = JetBrains_Mono({
   subsets: ["latin"],
   display: "swap",
   weight: ["400", "500", "700"],
+});
+
+// Serif display face for headings only (text-display-* / text-h*); body and
+// UI labels stay on Inter. opsz keeps optical sizing across heading sizes.
+const displayFace = Fraunces({
+  variable: "--font-display-face",
+  subsets: ["latin"],
+  display: "swap",
+  axes: ["opsz"],
 });
 
 export const metadata: Metadata = {
@@ -157,7 +166,7 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${body.variable} ${mono.variable} antialiased`}
+      className={`${body.variable} ${mono.variable} ${displayFace.variable} antialiased`}
     >
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeBoot }} />

--- a/portfolio/src/app/not-found.tsx
+++ b/portfolio/src/app/not-found.tsx
@@ -7,7 +7,7 @@ export default function NotFound() {
       <p className="font-display text-xs uppercase tracking-[0.3em] text-accent">
         404 — page not found
       </p>
-      <h1 className="mt-6 text-display-lg font-display text-fg leading-[1]">
+      <h1 className="mt-6 text-display-lg text-fg leading-[1]">
         Took a wrong{" "}
         <span className="gradient-text">turn somewhere.</span>
       </h1>

--- a/portfolio/src/components/PaletteLauncher.tsx
+++ b/portfolio/src/components/PaletteLauncher.tsx
@@ -33,16 +33,12 @@ export function PaletteLauncher({ className, compact = false }: { className?: st
       aria-label="Open command palette (⌘K)"
       onClick={onClick}
       className={cn(
-        "focus-ring inline-flex items-center gap-2 rounded-md border border-line-2 bg-surface/50 px-3 py-1.5 text-sm text-fg-3 transition-colors hover:border-accent/60 hover:text-fg",
+        "focus-ring inline-flex items-center gap-1 text-fg-3 transition-colors hover:text-fg",
         className,
       )}
     >
-      <Search size={14} aria-hidden />
-      <span>Search</span>
-      <span className="ml-3 inline-flex items-center gap-1">
-        <Kbd>⌘</Kbd>
-        <Kbd>K</Kbd>
-      </span>
+      <Kbd>⌘</Kbd>
+      <Kbd>K</Kbd>
     </button>
   );
 }

--- a/portfolio/src/components/layout/Footer.tsx
+++ b/portfolio/src/components/layout/Footer.tsx
@@ -7,7 +7,7 @@ const buildYear = new Date().getFullYear();
 
 export function Footer() {
   return (
-    <footer className="mt-32 border-t border-line bg-bg-2">
+    <footer className="mt-32 section-rule bg-bg-2">
       <div className="mx-auto grid max-w-[var(--container-wide)] gap-12 px-6 py-16 md:grid-cols-12 md:gap-8 md:px-8">
         <div className="md:col-span-7">
           <p className="eyebrow">colophon</p>
@@ -54,7 +54,7 @@ export function Footer() {
         </div>
       </div>
 
-      <div className="border-t border-line">
+      <div className="section-rule">
         <div className="mx-auto flex max-w-[var(--container-wide)] flex-col gap-2 px-6 py-6 font-mono text-xs text-fg-3 md:flex-row md:items-center md:justify-between md:px-8">
           <p>
             © {buildYear} {site.name}. {site.location}.

--- a/portfolio/src/components/layout/Header.tsx
+++ b/portfolio/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { Menu, X } from "lucide-react";
 import { site } from "@/content/site";
 import { cn } from "@/lib/cn";
@@ -48,38 +48,39 @@ export function Header() {
           : "border-b border-transparent",
       )}
     >
-      <div className="mx-auto flex max-w-[var(--container-wide)] items-center justify-between px-5 py-4 md:px-8">
-        <Link
-          href="/"
-          className="focus-ring flex items-center gap-2 text-sm tracking-wide"
-        >
-          <span className="inline-block h-2 w-2 rounded-full bg-accent shadow-[0_0_18px_var(--accent)]" />
-          <span className="text-fg font-medium">morten</span>
-          <span className="text-fg-3">/</span>
-          <span className="text-fg-2">nordbye.it</span>
-        </Link>
-
-        <nav className="hidden items-center gap-7 md:flex">
+      <div className="mx-auto flex max-w-[var(--container-wide)] items-center px-5 py-4 md:px-8">
+        <nav className="hidden flex-1 items-baseline gap-2.5 font-mono text-[13px] md:flex">
+          <Link
+            href="/"
+            aria-label="Home"
+            className="focus-ring text-fg-3 transition-colors hover:text-fg"
+          >
+            ~
+          </Link>
           {site.nav.map((item) => {
             const active = pathname === item.href || pathname?.startsWith(item.href + "/");
             return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={(e) => onAnchorClick(e, item.href)}
-                className={cn(
-                  "focus-ring text-sm transition-colors hover:text-fg",
-                  active ? "text-fg" : "text-fg-2",
-                )}
-              >
-                {item.label}
-              </Link>
+              <Fragment key={item.href}>
+                <span aria-hidden className="text-line-2">
+                  /
+                </span>
+                <Link
+                  href={item.href}
+                  onClick={(e) => onAnchorClick(e, item.href)}
+                  className={cn(
+                    "focus-ring lowercase transition-colors hover:text-fg",
+                    active ? "text-accent" : "text-fg-2",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </Fragment>
             );
           })}
-          <PaletteLauncher className="ml-2" />
+          <PaletteLauncher className="ml-auto" />
         </nav>
 
-        <div className="flex items-center gap-2 md:hidden">
+        <div className="ml-auto flex items-center gap-2 md:hidden">
           <PaletteLauncher compact />
           <button
             type="button"

--- a/portfolio/src/components/sections/AboutSection.tsx
+++ b/portfolio/src/components/sections/AboutSection.tsx
@@ -24,7 +24,7 @@ export function AboutSection() {
     <Section
       id="about"
       heading="About me."
-      className="border-t border-line"
+      className="section-rule"
     >
       <div className="grid gap-8 md:grid-cols-[300px_1fr] md:items-start md:gap-12">
         <PortraitCard />

--- a/portfolio/src/components/sections/CtaContact.tsx
+++ b/portfolio/src/components/sections/CtaContact.tsx
@@ -6,7 +6,7 @@ export function CtaContact() {
   return (
     <section
       id="contact"
-      className="scroll-mt-24 border-t border-line"
+      className="scroll-mt-24 section-rule"
       style={{ paddingTop: "var(--space-section-y)", paddingBottom: "var(--space-section-y)" }}
     >
       <div className="mx-auto grid max-w-[var(--container-wide)] gap-12 px-6 md:grid-cols-12 md:gap-8 md:px-8">

--- a/portfolio/src/components/sections/LatestWriting.tsx
+++ b/portfolio/src/components/sections/LatestWriting.tsx
@@ -14,7 +14,7 @@ export async function LatestWriting() {
       heading="Blog."
       description="Long-form notes from running cloud infrastructure, including migrations, post-mortems and the occasional hot take. Lives at blog.nordbye.it."
       align="between"
-      className="border-t border-line"
+      className="section-rule"
       cta={
         <Button href="https://blog.nordbye.it" variant="ghost" iconLeft={<Rss size={14} aria-hidden />} iconRight={<ArrowUpRight size={16} aria-hidden />}>
           Read the blog

--- a/portfolio/src/components/sections/ResumeSection.tsx
+++ b/portfolio/src/components/sections/ResumeSection.tsx
@@ -7,7 +7,7 @@ export function ResumeSection() {
     <Section
       id="resume"
       heading="Resume."
-      className="border-t border-line bg-bg-2/40"
+      className="section-rule bg-bg-2/40"
     >
       <ResumePdfButtons />
       <div className="mt-16">

--- a/portfolio/src/components/sections/ServicesGrid.tsx
+++ b/portfolio/src/components/sections/ServicesGrid.tsx
@@ -24,7 +24,7 @@ export function ServicesGrid() {
       id="services"
       heading="Services I provide."
       description="Three engagement shapes. Each one is grounded in something that has already shipped — case studies linked from each card."
-      className="border-t border-line bg-bg-2/40"
+      className="section-rule bg-bg-2/40"
     >
       <div className="grid gap-6 md:grid-cols-3">
         {services.map((s, i) => {


### PR DESCRIPTION
## Why

The site's visual fingerprint (Inter everywhere, template header with brand link and Search pill, full-bleed section borders) matched the default look of generated/template portfolios. This is the first batch of restyling to make it distinct.

## What

- Load Fraunces (variable, opsz axis) via next/font and point the five heading utility classes at it. Body text and UI labels stay on Inter; letter-spacing loosened and the display sizes drop to weight 500 to suit the serif. The error/404 headings lose a redundant `font-display` class that would have overridden the serif.
- Remove the header brand link. The nav becomes a lowercase JetBrains Mono slash path (`~ / about / resume / ...`) anchored left, with `~` as the home link and the active page in accent blue. The Search pill shrinks to bare `⌘ K` key hints (still opens the palette). Mobile hamburger unchanged.
- Replace full-bleed `border-t border-line` separators with a `.section-rule` utility: a 1px hairline capped at content width, fading to transparent at both ends. Applied to About, Resume, Services, Latest Writing, Contact and both footer dividers.

## Verification

- Docker dev stack builds and renders; verified in browser at 1440px+ across home, header, section boundaries, and footer.
- `make typecheck` passes.
- Only console error is Cloudflare Insights being unreachable locally (pre-existing).
- Not verified: mobile viewport rendering of the new nav (hamburger path unchanged, desktop nav hidden below md).