### PR TITLE
docs: add code of conduct and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Why
+
+<!-- The problem this solves. Link any related issue. -->
+
+## What
+
+<!-- What changed. -->
+
+## Verification
+
+<!-- There is no test suite; validation is the tooling below. Delete the rows that don't apply. -->
+
+- [ ] Kubernetes manifests: `kubectl diff -f <path>` or `kustomize build <dir>` renders clean, and the ArgoCD `Application` still points at the correct path
+- [ ] Terraform: `terraform fmt -check`, `terraform validate`, and `terraform plan` reviewed (no `apply`)
+- [ ] Portfolio / blog: Docker image builds, affected route and one unrelated route load
+- [ ] GitHub Actions: `actionlint` clean, or workflow read end-to-end
+- [ ] Docs only, no verification needed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at morten@nordbye.it. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/ai/skills/setup-github-repo/SKILL.md
+++ b/ai/skills/setup-github-repo/SKILL.md
@@ -58,7 +58,8 @@ change request to push to its default branch.
 | Core files: README, LICENSE, SECURITY.md, .gitignore, .gitattributes, .editorconfig, dependabot.yml | yes | yes |
 | CI workflow | yes, informational | yes, required check |
 | Default-branch ruleset | block deletion + force-push only; direct pushes to the default branch keep working | PRs required, review count from team size, required status checks |
-| Community files: CONTRIBUTING, CODE_OF_CONDUCT, SUPPORT, issue forms, PR template, CODEOWNERS | no | yes |
+| PR template | yes | yes |
+| Community files: CONTRIBUTING, CODE_OF_CONDUCT, SUPPORT, issue forms, CODEOWNERS | no | yes |
 | Conventional-Commits PR title check | no | yes |
 | Dependabot auto-merge | no (no required checks to gate it) | opt-in |
 | Release automation + tag protection | ask | ask |
@@ -212,10 +213,12 @@ and keep it on disk until Phase 7 deletes it.
 GitHub scores these via `gh api /repos/{owner}/{repo}/community/profile` — that endpoint
 is the built-in verification for this section.
 
-**Light profile:** generate only LICENSE, README.md, and SECURITY.md from this section.
-The rest (CONTRIBUTING, CODE_OF_CONDUCT, SUPPORT, issue forms, PR template, CODEOWNERS)
-is strict-profile; a personal project doesn't need contribution process scaffolding, and
-its health score staying below 100 is by design.
+**Light profile:** generate only LICENSE, README.md, SECURITY.md, and the PR template from
+this section. The rest (CONTRIBUTING, CODE_OF_CONDUCT, SUPPORT, issue forms, CODEOWNERS) is
+strict-profile; a personal project doesn't need contribution process scaffolding, and its
+health score staying below 100 is by design. The PR template is the exception because it is
+not contribution scaffolding — it is a self-review checklist the solo maintainer fills in
+for their own changes, and it costs one file with no process attached.
 
 - **`LICENSE`** — fetch the chosen license: `gh api /licenses/mit -q .body`, substitute
   year and full name.
@@ -450,17 +453,30 @@ body:
 blank_issues_enabled: false
 ```
 
-- **`.github/PULL_REQUEST_TEMPLATE.md`**:
+- **`.github/PULL_REQUEST_TEMPLATE.md`** — both profiles. Fill the Verification list with the
+  *real* detected checks, one row per gate a contributor can actually run; the same rule as
+  CONTRIBUTING and CI applies, so a repo with no test suite gets its actual validation
+  commands (`terraform plan`, `kubectl diff`, an image build) rather than a "tests pass"
+  box that nothing backs. Drop the CONTRIBUTING.md row in the light profile, where that
+  file doesn't exist.
 
 ```markdown
 ## Why
 
+<!-- The problem this solves. Link any related issue. -->
+
 ## What
+
+<!-- What changed. -->
 
 ## Verification
 
-- [ ] Tests pass locally
-- [ ] I have read CONTRIBUTING.md
+<!-- Delete the rows that don't apply. -->
+
+- [ ] <real detected test command> passes locally
+- [ ] <real detected lint command> is clean
+- [ ] Docs only, no verification needed
+- [ ] I have read CONTRIBUTING.md   <!-- strict only -->
 ```
 
 - **`.github/CODEOWNERS`**:


### PR DESCRIPTION
## Why

The GitHub community standards checklist flagged two gaps: no code of conduct, no pull request template.

## What

- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1 fetched upstream, attribution footer intact, enforcement contact set.
- `.github/PULL_REQUEST_TEMPLATE.md` — Why / What / Verification, with the checklist built from this repo's real gates rather than a test suite it doesn't have.
- `ai/skills/setup-github-repo` — the PR template moves from strict-only to both profiles, since it's a self-review checklist rather than contribution scaffolding. Its body also hardcoded a tests-pass box and pointed at a CONTRIBUTING.md the light profile never writes; both fixed.

## Verification

Docs only. Community profile goes to 100%; the rest of the light profile still skips CoC, SUPPORT, issue forms and CODEOWNERS by design.
