### PR TITLE
seo(blog): noindex thin tag pages and cross-link posts

### DIFF
--- a/blog/content/blog/cilium-network-policy-rollout/index.md
+++ b/blog/content/blog/cilium-network-policy-rollout/index.md
@@ -73,7 +73,7 @@ This gives you three things:
 
 1. **Hubble Relay**. A gRPC service that aggregates per-node flow data into a cluster-wide view.
 2. **Hubble UI**. A web app that draws a live service map, with red lines for drops and green for allowed flows.
-3. **Hubble metrics**. Prometheus-scrapeable flow counts, broken down by protocol, verdict, identity. The accompanying Grafana dashboards are worth installing.
+3. **Hubble metrics**. Prometheus-scrapeable flow counts, broken down by protocol, verdict, identity. The accompanying Grafana dashboards are worth installing, and they land in the [single dashboard I check first](/blog/observability-stack/).
 
 If you also use Gateway API or Traefik like I do, expose Hubble UI through an HTTPRoute behind whatever dashboard URL you use.
 

--- a/blog/content/blog/i-have-a-blog/index.md
+++ b/blog/content/blog/i-have-a-blog/index.md
@@ -205,7 +205,7 @@ spec:
 
 The image tag (`2694c9b` in this example) is the short SHA of the commit. Every time I push to the blog, GitHub Actions updates this line. That's the entire trick.
 
-You'll also need a Service to expose the deployment and an HTTPRoute for ingress (I use Traefik with Gateway API, but that's a topic for another post).
+You'll also need a Service to expose the deployment and an HTTPRoute for ingress (I use Traefik with Gateway API, which is [a topic for another post](/blog/surviving-nginx-eol/)).
 
 ## ArgoCD: The Closer
 

--- a/blog/content/blog/kubernetes-quick-start/index.md
+++ b/blog/content/blog/kubernetes-quick-start/index.md
@@ -605,7 +605,7 @@ Full config in my [Cilium setup](https://github.com/mortennordbye/Homelab/tree/m
 
 - Better performance (eBPF vs iptables)
 - Native Gateway API support
-- Built-in network policies
+- Built-in [network policies](/blog/cilium-network-policy-rollout/)
 - Hubble observability
 
 **Downside:** More complex to set up and troubleshoot.
@@ -614,7 +614,7 @@ Full config in my [Cilium setup](https://github.com/mortennordbye/Homelab/tree/m
 
 Creating a LoadBalancer service for every app is wasteful (cloud costs) or uses up IPs (bare metal). Use an Ingress controller instead.
 
-**Note:** Kubernetes is moving away from traditional Ingress to [Gateway API](https://gateway-api.sigs.k8s.io/), which offers more flexibility and better role-oriented design. Gateway API is the future, but that's a topic for another blog post. For now, traditional Ingress is still widely used and perfectly fine for learning.
+**Note:** Kubernetes is moving away from traditional Ingress to [Gateway API](https://gateway-api.sigs.k8s.io/), which offers more flexibility and better role-oriented design. Gateway API is the future, and I wrote up [a zero-downtime migration to Traefik and Gateway API](/blog/surviving-nginx-eol/) if you want the real-world version. For now, traditional Ingress is still widely used and perfectly fine for learning.
 
 **How it works:**
 

--- a/blog/content/blog/observability-stack/index.md
+++ b/blog/content/blog/observability-stack/index.md
@@ -285,7 +285,7 @@ I have made every one of these.
 
 <img src="/images/homelab-spog-cilium.webp" alt="Cilium dashboard section with three panels reading No data next to a working network drops graph" title="Panels committed before their metrics were wired up" style="width:100%;" />
 
-Three "No data" panels next to a working one. The fix is to wire up the Hubble metrics they expect. The panel is a to-do list in git, and I would rather see the gap than pretend it is not there.
+Three "No data" panels next to a working one. The fix is to wire up the Hubble metrics they expect, the same ones I turn on in the [Cilium network policy rollout](/blog/cilium-network-policy-rollout/). The panel is a to-do list in git, and I would rather see the gap than pretend it is not there.
 
 **Alerting on everything.** The instinct is to alert on every rule the internet hands you. Resist it. A channel you have learned to ignore is worse than none, because it feels like coverage while giving you nothing.
 

--- a/blog/content/blog/surviving-nginx-eol/index.md
+++ b/blog/content/blog/surviving-nginx-eol/index.md
@@ -185,6 +185,6 @@ While this workaround works, it is verbose. I didn't want to leave it at that, s
 
 ## Summary
 
-The end of `ingress-nginx` isn't a disaster. It's an opportunity to modernize. By moving to Traefik, we got a more capable proxy and a bridge to the Gateway API future without breaking our production environment.
+The end of `ingress-nginx` isn't a disaster. It's an opportunity to modernize. By moving to Traefik, we got a more capable proxy and a bridge to the Gateway API future without breaking our production environment. With the front door swapped, the next job is locking down what can reach what behind it, which is where [Cilium network policies](/blog/cilium-network-policy-rollout/) come in.
 
 Start with a parallel migration, stick to standard Ingress for speed, and adopt Gateway API when you are ready. Just watch out for those sticky sessions!

--- a/blog/content/series/_index.md
+++ b/blog/content/series/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Series"
+cascade:
+  robots: "noindex, follow"
+robots: "noindex, follow"
+---

--- a/blog/content/tags/_index.md
+++ b/blog/content/tags/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Tags"
+cascade:
+  robots: "noindex, follow"
+robots: "noindex, follow"
+---


### PR DESCRIPTION
## Why

Google Search Console reports the blog posts as "Crawled - currently not indexed". The technical SEO is already clean (correct canonicals, valid sitemap, no noindex, good structured data), so the fix is not a broken setting. This concentrates crawl signal on the real articles and strengthens internal linking, while the actual speed levers (backlinks, request-indexing, time) happen outside the repo.

## What

- noindex,follow the auto-generated `/tags/` and `/series/` taxonomy pages via a front-matter cascade (`blog/content/tags/_index.md`, `blog/content/series/_index.md`). These thin, near-empty pages are what Google labels "Crawled - not indexed"; `follow` keeps link equity flowing to the posts. The 5 posts, homepage and `/blog/` stay fully indexable.
- Add contextual cross-links between the five related posts (natural prose, no "Related posts" block), including fulfilling the two existing "topic for another post" placeholders in `i-have-a-blog` and `kubernetes-quick-start`.

## Verification

Rendered locally with Hugo 0.161.1 extended (the CI version):

- `/tags/`, every `/tags/<term>/`, and `/series/` emit `<meta name=robots content="noindex, follow">`.
- Blog posts emit no robots meta (stay indexable); canonicals unchanged.
- Cross-links render in all 5 posts; all targets resolve to existing posts.
- `sitemap.xml` unchanged: 7 URLs (5 posts + homepage + /blog/), no taxonomy.

Note: `docker build blog/` fails locally under OrbStack's x86 emulation (amd64 Hugo loader), unrelated to these content-only changes; CI builds on native amd64.