### PR TITLE
fix(kargo): stop ArgoCD drift on the kargo-api ExternalSecret

### DIFF
--- a/k8s/talos/infra/kargo/kargo-api-secret.yaml
+++ b/k8s/talos/infra/kargo/kargo-api-secret.yaml
@@ -23,6 +23,12 @@ spec:
     - secretKey: ADMIN_ACCOUNT_PASSWORD_HASH
       remoteRef:
         key: "c0e7dd57-f041-4679-a408-b489010bed58"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
     - secretKey: ADMIN_ACCOUNT_TOKEN_SIGNING_KEY
       remoteRef:
         key: "72c98fb4-90e1-4af6-b80c-b489010c112e"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
## Why

After #320 merged, the `kargo` app sits `OutOfSync` (Healthy). ESO writes the
`conversionStrategy`/`decodingStrategy`/`metadataPolicy` defaults back into the
ExternalSecret spec; the git manifest omitted them, so ArgoCD reports drift.

## What

Spell out those three fields on both remoteRefs, matching the existing pattern
in `kube-prometheus-stack/grafana-admin-credentials-secret.yaml`.

## Verification

- `kubectl -n kargo get externalsecret kargo-api` already reports SecretSynced.
- Post-merge the `kargo` app should return to Synced.