### PR TITLE
fix(traefik): migrate logging values to the chart 41.x schema

### DIFF
--- a/k8s/talos/infra/traefik/values.yaml
+++ b/k8s/talos/infra/traefik/values.yaml
@@ -104,11 +104,10 @@ ports:
 service:
   enabled: false
 
-logs:
-  general:
-    level: INFO
-  access:
-    enabled: true
+log:
+  level: INFO
+accessLog:
+  enabled: true
 
 metrics:
   prometheus:


### PR DESCRIPTION
## Why

The traefik app is stuck `Unknown`/OutOfSync in ArgoCD. Manifest generation
fails with `additional properties 'logs' not allowed`: the 41.0.2 major chart
bump set `additionalProperties: false` and renamed the logging keys, but
`values.yaml` still used the pre-41 `logs.general.level` / `logs.access.enabled`
layout. The running Traefik is unaffected (it is on the last good config), but no
traefik change can sync until this validates. We need it green to route the
Kargo UI through the private gateway.

## What

Map the logging config to the 41.x schema:
- `logs.general.level: INFO` becomes `log.level: INFO`
- `logs.access.enabled: true` becomes top-level `accessLog.enabled: true`

## Verification

`kustomize build --enable-helm --helm-api-versions monitoring.coreos.com/v1`
renders 16 objects. The Traefik container args preserve behavior:
`--log.level=INFO` and `--accesslog=true`.