### PR TITLE
feat(kargo): expose the Kargo UI at kargo.local.bigd.no

### DIFF
--- a/k8s/talos/infra/kargo/httproute.yaml
+++ b/k8s/talos/infra/kargo/httproute.yaml
@@ -1,0 +1,28 @@
+# Exposes the Kargo API + UI at kargo.local.bigd.no via the Traefik private
+# gateway. TLS is terminated at the gateway (*.local.bigd.no); the backend is
+# plain HTTP (api.tls.enabled: false in values.yaml), so kargo-api is port 80.
+# Backend is in this same namespace, so no ReferenceGrant is needed.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kargo-api
+  namespace: kargo
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-private
+      namespace: traefik
+  hostnames:
+    - kargo.local.bigd.no
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: kargo-api
+          port: 80
+          weight: 1

--- a/k8s/talos/infra/kargo/kustomization.yaml
+++ b/k8s/talos/infra/kargo/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - kargo-api-secret.yaml
+  - httproute.yaml
 
 helmCharts:
   - name: kargo

--- a/k8s/talos/infra/kargo/values.yaml
+++ b/k8s/talos/infra/kargo/values.yaml
@@ -5,6 +5,11 @@
 api:
   secret:
     name: kargo-api
+  # The API is fronted by the Traefik private gateway, which terminates TLS for
+  # *.local.bigd.no. Serve plain HTTP in-pod so the gateway can route to it
+  # (kargo-api Service becomes port 80 instead of 443).
+  tls:
+    enabled: false
   # Homelab: admin-account login only for now, bundled Dex OIDC disabled.
   oidc:
     dex:


### PR DESCRIPTION
## Why

Give the Kargo API and dashboard a reachable URL so the promotion pipeline can be
driven and observed from the UI (admin login), fronted by the existing Traefik
private gateway.

## What

- `api.tls.enabled: false` so the API serves plain HTTP in-pod; the gateway
  terminates TLS for `*.local.bigd.no`. This turns the `kargo-api` Service from
  port 443 to port 80.
- New `httproute.yaml`: `kargo.local.bigd.no` to `kargo-api:80` via
  `traefik-gateway-private`. Same-namespace backend, so no ReferenceGrant.

## Verification

`kustomize build --enable-helm` renders the dir (kargo-api Service port 80,
HTTPRoute present). Internal-only, consistent with the Traefik dashboard route.

## Follow-up

Layer Authentik forward-auth in front if we want SSO on the UI later; plain on
the private gateway for now.