### PR TITLE
feat(kargo): activate portfolio promotion pipeline + CI cutover (phase 2)

### DIFF
--- a/.github/workflows/build-portfolio.yaml
+++ b/.github/workflows/build-portfolio.yaml
@@ -67,7 +67,7 @@ jobs:
     if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') && github.repository_owner == 'mortennordbye' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     steps:
@@ -88,12 +88,6 @@ jobs:
           fi
 
           echo "ENV=${ENV}" >> $GITHUB_OUTPUT
-
-          if [[ "${ENV}" == "prod" ]]; then
-            echo "MANIFEST=k8s/talos/apps/portfolio/deployment.yaml" >> $GITHUB_OUTPUT
-          else
-            echo "MANIFEST=k8s/talos/apps/portfolio-stage/deployment.yaml" >> $GITHUB_OUTPUT
-          fi
 
           echo "Deploying to environment: ${ENV}"
 
@@ -131,39 +125,3 @@ jobs:
       - name: Logout from Docker Hub
         if: always()
         run: docker logout
-
-      - name: Update Kubernetes Manifest
-        run: |
-          MANIFEST="${{ steps.context.outputs.MANIFEST }}"
-          TAG="${{ steps.context.outputs.TAG }}"
-          ENV="${{ steps.context.outputs.ENV }}"
-          NEW_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
-
-          echo "Updating manifest: ${MANIFEST}"
-          echo "New image: ${NEW_IMAGE}"
-
-          if [[ ! -f "${MANIFEST}" ]]; then
-            echo "ERROR: Manifest file not found: ${MANIFEST}"
-            exit 1
-          fi
-
-          sed -i "s|image: ${{ env.REGISTRY }}/${{ github.repository }}/portfolio:.*|image: ${NEW_IMAGE}|g" $MANIFEST
-
-          echo "Changes made:"
-          git diff $MANIFEST
-
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-
-          if [[ -n $(git status -s) ]]; then
-            git add $MANIFEST
-            git commit -m "chore(portfolio): deploy ${TAG} to ${ENV}"
-            # main may have advanced while the image built (e.g. the blog
-            # deploy pushing its manifest commit); rebase so the push is
-            # fast-forward instead of getting rejected.
-            git fetch origin main
-            git rebase origin/main
-            git push origin HEAD:main
-          else
-            echo "Manifest already up to date."
-          fi

--- a/k8s/talos/apps/portfolio-stage/kustomization.yaml
+++ b/k8s/talos/apps/portfolio-stage/kustomization.yaml
@@ -12,3 +12,10 @@ resources:
   - ciliumnetworkpolicy.yaml
   - interceptorroute.yaml
   - scaledobject.yaml
+
+# Image tag is owned by Kargo (kargo-portfolio Warehouse/Stage), which rewrites
+# newTag via the kustomize-set-image promotion step. Overrides the inline tag in
+# deployment.yaml.
+images:
+  - name: ghcr.io/mortennordbye/homelab/portfolio
+    newTag: def4da2

--- a/k8s/talos/apps/portfolio/kustomization.yaml
+++ b/k8s/talos/apps/portfolio/kustomization.yaml
@@ -13,3 +13,10 @@ resources:
   - ciliumnetworkpolicy.yaml
   - scaledobject.yaml
   - status-publisher.yaml
+
+# Image tag is owned by Kargo (kargo-portfolio Warehouse/Stage), which rewrites
+# newTag via the kustomize-set-image promotion step. Overrides the inline tag in
+# deployment.yaml.
+images:
+  - name: ghcr.io/mortennordbye/homelab/portfolio
+    newTag: caa53f4

--- a/k8s/talos/infra/kargo-portfolio/analysistemplate.yaml
+++ b/k8s/talos/infra/kargo-portfolio/analysistemplate.yaml
@@ -1,0 +1,34 @@
+# Stage verification: a one-shot Job that curls the stage URL and fails on any
+# non-2xx. Retries cover the KEDA scale-from-zero cold start (the request also
+# wakes the stage deployment). -k skips TLS verify for the internal local cert.
+# Note: Argo Rollouts uses {{ }} (no $) for its own expressions; there are none
+# here. Kargo consumes this via the Stage's spec.verification.analysisTemplates.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: portfolio-smoke
+  namespace: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: portfolio-stage-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.11.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsSk --retry 10 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://portfolio-stage.local.bigd.no/

--- a/k8s/talos/infra/kargo-portfolio/git-credentials.yaml
+++ b/k8s/talos/infra/kargo-portfolio/git-credentials.yaml
@@ -1,0 +1,51 @@
+# Git write credential for Kargo's git-push, using the existing GitHub App
+# `mortennordbye-homelab-deployer` (scoped to mortennordbye/homelab, Contents
+# read/write). ESO pulls the three App values from Bitwarden and templates them
+# plus the static repoURL and the required cred-type label into the Secret.
+# Create three Bitwarden Secrets Manager items and set their UUIDs below:
+#   - App Client ID       (App settings -> Client ID, e.g. Iv23li...)
+#   - App Installation ID  (the installation's numeric ID)
+#   - App private key      (the full PEM, generated under the App's settings)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kargo-git-homelab
+  namespace: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: kargo-git-homelab
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git
+      data:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        githubAppClientID: "{{ .githubAppClientID }}"
+        githubAppInstallationID: "{{ .githubAppInstallationID }}"
+        githubAppPrivateKey: "{{ .githubAppPrivateKey }}"
+  data:
+    - secretKey: githubAppClientID
+      remoteRef:
+        key: "a6b2b4ea-fa97-4d5c-bd74-b489010c5fab"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppInstallationID
+      remoteRef:
+        key: "aabab894-a09a-415c-ba17-b489010c8df5"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppPrivateKey
+      remoteRef:
+        key: "fc775dd0-1b67-4dfa-b2e9-b489010d0359"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/k8s/talos/infra/kargo-portfolio/kustomization.yaml
+++ b/k8s/talos/infra/kargo-portfolio/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - project.yaml
+  - projectconfig.yaml
+  - git-credentials.yaml
+  - warehouse.yaml
+  - analysistemplate.yaml
+  - stage-stage.yaml
+  - stage-prod.yaml

--- a/k8s/talos/infra/kargo-portfolio/namespace.yaml
+++ b/k8s/talos/infra/kargo-portfolio/namespace.yaml
@@ -1,0 +1,12 @@
+# Kargo project namespace. Named `portfolio-cd` (not `portfolio`) to avoid
+# colliding with the existing portfolio app namespace. The label lets the
+# Kargo Project below adopt this pre-created namespace instead of racing to
+# create it, which keeps Argo CD sync ordering clean.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portfolio-cd
+  labels:
+    kargo.akuity.io/project: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/k8s/talos/infra/kargo-portfolio/project.yaml
+++ b/k8s/talos/infra/kargo-portfolio/project.yaml
@@ -1,0 +1,6 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/k8s/talos/infra/kargo-portfolio/projectconfig.yaml
+++ b/k8s/talos/infra/kargo-portfolio/projectconfig.yaml
@@ -1,0 +1,13 @@
+# Auto-promotion is a Project-level policy in Kargo (never on a Stage). Here we
+# auto-promote the `stage` Stage and leave `prod` as a deliberate manual step.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: portfolio-cd
+  namespace: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  promotionPolicies:
+    - stage: stage
+      autoPromotionEnabled: true

--- a/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
@@ -1,0 +1,49 @@
+# prod: receives only Freight already verified in `stage` (sources.stages).
+# No autoPromotionEnabled entry in ProjectConfig, so promotion here is a
+# deliberate manual action. This is the structural replacement for today's
+# manual `environment: prod` workflow dispatch that skipped the CI gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: portfolio
+      sources:
+        stages:
+          - stage
+  promotionTemplate:
+    spec:
+      vars:
+        - name: gitopsRepo
+          value: https://github.com/mortennordbye/homelab.git
+        - name: appPath
+          value: k8s/talos/apps/portfolio
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/homelab/portfolio
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./repo
+        - uses: kustomize-set-image
+          config:
+            path: ./repo/${{ vars.appPath }}
+            images:
+              - image: ${{ vars.imageRepo }}
+                tag: ${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: git-commit
+          as: commit
+          config:
+            path: ./repo
+            message: "chore(portfolio): promote ${{ imageFrom(vars.imageRepo).Tag }} to prod"
+        - uses: git-push
+          config:
+            path: ./repo

--- a/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
@@ -1,0 +1,53 @@
+# stage: receives new Freight directly from the Warehouse (auto-promoted per
+# ProjectConfig), rewrites the image tag in the portfolio-stage kustomization,
+# pushes to main, then verifies with an HTTP smoke test. Only Freight that
+# passes verification here becomes available to prod.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: stage
+  namespace: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: portfolio
+      sources:
+        direct: true
+  verification:
+    analysisTemplates:
+      - name: portfolio-smoke
+  promotionTemplate:
+    spec:
+      vars:
+        - name: gitopsRepo
+          value: https://github.com/mortennordbye/homelab.git
+        - name: appPath
+          value: k8s/talos/apps/portfolio-stage
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/homelab/portfolio
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: ${{ vars.gitopsRepo }}
+            checkout:
+              - branch: main
+                path: ./repo
+        - uses: kustomize-set-image
+          config:
+            path: ./repo/${{ vars.appPath }}
+            images:
+              # Confirm the imageFrom(...).Tag expression against the promotion
+              # steps expression reference for the pinned Kargo version.
+              - image: ${{ vars.imageRepo }}
+                tag: ${{ imageFrom(vars.imageRepo).Tag }}
+        - uses: git-commit
+          as: commit
+          config:
+            path: ./repo
+            message: "chore(portfolio): promote ${{ imageFrom(vars.imageRepo).Tag }} to stage"
+        - uses: git-push
+          config:
+            path: ./repo

--- a/k8s/talos/infra/kargo-portfolio/warehouse.yaml
+++ b/k8s/talos/infra/kargo-portfolio/warehouse.yaml
@@ -1,0 +1,19 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: portfolio
+  namespace: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  interval: 5m
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/mortennordbye/homelab/portfolio
+        # Tags are immutable git short-SHAs, so neither SemVer nor Lexical
+        # ordering applies. NewestBuild orders by image build time. allowTags
+        # keeps the moving `stage`/`prod` tags out of Freight selection.
+        imageSelectionStrategy: NewestBuild
+        allowTags: ^[0-9a-f]{7,40}$
+        discoveryLimit: 20


### PR DESCRIPTION
## Why

Phase 2 of the Kargo pilot: replace the CI sed+commit tag bump with a real
Warehouse to Freight to Stage promotion pipeline for portfolio, with a verified
stage and a manual, gated prod.

## What

Pipeline (`k8s/talos/infra/kargo-portfolio/`, project `portfolio-cd`):
- Warehouse watches `ghcr.io/mortennordbye/homelab/portfolio` (NewestBuild,
  `allowTags: ^[0-9a-f]{7,40}$` so the moving stage/prod tags are ignored).
- `stage` Stage: auto-promotes new Freight (ProjectConfig), rewrites the tag,
  pushes to main, verifies with an HTTP smoke test on the stage URL.
- `prod` Stage: accepts only Freight verified in stage; promotion is manual.
- Git writes use the `mortennordbye-homelab-deployer` GitHub App via ESO.

Coupled cutover (must ship together so CI and Kargo don't both write the tag):
- `images:` block added to the portfolio and portfolio-stage kustomizations.
  newTag matches the current deployed tag, so rendering is unchanged until Kargo
  promotes.
- `build-portfolio.yaml`: manifest sed+commit step removed, job downgraded to
  `contents: read`. CI now only builds and pushes.

## Verification

- `kustomize build` on both apps renders the current image tags unchanged (no
  ArgoCD diff on merge).
- Pipeline dir renders 8 objects; workflow parses (`yq`), no manifest write left.
- Depends on the Kargo CRDs from #320 (live). Pairs with #323 (UI route).

## Rollout note

On first sync the `stage` Stage auto-promotes the newest built image and runs
verification, which may move the stage tag from its current value. prod stays
manual until you promote stage-verified Freight.