### PR TITLE
fix(kargo): stop ArgoCD drift on the portfolio Warehouse

### DIFF
--- a/k8s/talos/infra/kargo-portfolio/warehouse.yaml
+++ b/k8s/talos/infra/kargo-portfolio/warehouse.yaml
@@ -6,7 +6,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  interval: 5m
+  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
+  interval: 5m0s
   freightCreationPolicy: Automatic
   subscriptions:
     - image:
@@ -17,3 +18,5 @@ spec:
         imageSelectionStrategy: NewestBuild
         allowTags: ^[0-9a-f]{7,40}$
         discoveryLimit: 20
+        # Kargo defaults this to true; spell it out so ArgoCD sees no drift.
+        strictSemvers: true


### PR DESCRIPTION
## Why

After #324, `kargo-portfolio` sits OutOfSync (Healthy) because Kargo defaults
`strictSemvers: true` on the image subscription and normalizes `interval` to
`5m0s`; the manifest had neither, so ArgoCD sees drift on the Warehouse.

## What

Add `strictSemvers: true` and set `interval: 5m0s` to match the live spec.

## Verification

Pipeline dir renders. Post-merge the kargo-portfolio app should return to Synced.