### PR TITLE
docs(kargo): surface Kargo in README, diagrams, and Homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ homelab
 
 | Category      | Components                                                                                                                                                                             |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GitOps        | [ArgoCD](https://argoproj.github.io/cd/)                                                                                                                                               |
+| GitOps        | [ArgoCD](https://argoproj.github.io/cd/), [Kargo](https://kargo.io/) (stage → prod promotion, portfolio pilot)                                                                          |
 | Networking    | [Cilium](https://cilium.io/) (CNI + eBPF), [Traefik](https://traefik.io/) ([Gateway API](https://gateway-api.sigs.k8s.io/)), [external-dns](https://github.com/kubernetes-sigs/external-dns) (Cloudflare DNS automation)                                                            |
 | Security      | [Falco](https://falco.org/) (runtime security), [Authentik](https://goauthentik.io/) (SSO), [Cert-manager](https://cert-manager.io/), [External Secrets Operator](https://external-secrets.io/)                                                                                    |
 | Observability | [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/), [Loki](https://grafana.com/oss/loki/) (logs), [Tempo](https://grafana.com/oss/tempo/) (traces), [OpenTelemetry](https://opentelemetry.io/), [Metrics-server](https://github.com/kubernetes-sigs/metrics-server) |
@@ -124,7 +124,7 @@ Automated vulnerability scanning runs weekly and on every Dockerfile change usin
 | Workflow                                                                                | Trigger                                   | Purpose                                                |
 | --------------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------ |
 | [**Build and Deploy Blog**](.github/workflows/build-blog.yaml)                          | Push to `main` (blog changes)                  | Builds Hugo blog, pushes to GHCR, updates k8s manifest |
-| [**Build and Deploy Portfolio**](.github/workflows/build-portfolio.yaml)                | Push to `main` (stage); manual dispatch (prod) | Builds portfolio image, pushes to GHCR, deploys stage/prod |
+| [**Build and Deploy Portfolio**](.github/workflows/build-portfolio.yaml)                | Push to `main`                                 | Builds portfolio image and pushes to GHCR ([Kargo](https://kargo.io/) promotes stage → prod) |
 | [**Bump Image Tag**](.github/workflows/bump-image.yml)                                  | Called by external app repos (`workflow_call`) | Opens a PR pinning an app to a new immutable `sha-` image tag ([pattern](docs/gitops-external-app-deploys.md)) |
 | [**Container Vulnerability Scan**](.github/workflows/container-vulnerability-scan.yaml) | Weekly, Dockerfile changes, manual             | Scans blog & portfolio containers with Trivy           |
 | [**Render Diagrams**](.github/workflows/render-diagram.yaml)                            | Push to `main` (`docs/diagrams/*.d2`), manual  | Renders D2 sources to SVG + PNG, commits the result    |

--- a/docs/diagrams/homelab-overview.d2
+++ b/docs/diagrams/homelab-overview.d2
@@ -150,6 +150,7 @@ k8s: Genesis · Talos Kubernetes {
       shape: image
       icon: ${di}/argo-cd.svg
     }
+    kargo: "Kargo\n(promotion)"
     traefik: Traefik {
       shape: image
       icon: ${di}/traefik.svg

--- a/docs/diagrams/network-flow.d2
+++ b/docs/diagrams/network-flow.d2
@@ -62,6 +62,7 @@ ops: GitOps & Config {
   style.font-size: 34
   style: {fill: "#eef2ff"; stroke: "#4f46e5"; font-color: "#312e81"}
   argocd: ArgoCD {shape: image; icon: ${di}/argo-cd.svg}
+  kargo: "Kargo\n(promotion)"
   eso: External Secrets
   reloader: Reloader
   keda: KEDA {shape: image; icon: ${di}/keda.svg}
@@ -198,6 +199,8 @@ cloudflare -> letsencrypt: ACME {style: {stroke: "#0891b2"; stroke-dash: 4}}
 # ── GitOps (indigo dashed) ──
 github -> ops.argocd: git push {style: {stroke: "#4f46e5"; stroke-width: 2; stroke-dash: 4}}
 github -> ghcr: build & push image {style: {stroke: "#4f46e5"; stroke-width: 2; stroke-dash: 4}}
+ghcr -> ops.kargo: watch images {style: {stroke: "#4f46e5"; stroke-dash: 4}}
+ops.kargo -> github: promote (git push) {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 ghcr -> sites: image pull {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 ops.argocd -> sites: deploys {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 ops.argocd -> media: deploys {style: {stroke: "#4f46e5"; stroke-dash: 4}}

--- a/k8s/talos/apps/homepage/values.yaml
+++ b/k8s/talos/apps/homepage/values.yaml
@@ -230,6 +230,10 @@ config:
             icon: argocd.png
             href: https://10.3.10.100
             description: Direct LB IP fallback (bypasses Traefik)
+        - Kargo:
+            icon: https://raw.githubusercontent.com/akuity/kargo/main/ui/public/kargo-logo.png
+            href: https://kargo.local.bigd.no
+            description: GitOps promotion (portfolio stage to prod)
 
     - Torrent Sites:
         - IPTorrents:


### PR DESCRIPTION
## Why

Portfolio now promotes through Kargo, so the docs and dashboards should show it.

## What

- README: Kargo added to the GitOps stack row; the Build and Deploy Portfolio
  workflow row now notes Kargo owns stage -> prod promotion.
- `homelab-overview.d2`: Kargo node in the Platform & Infrastructure section.
- `network-flow.d2`: Kargo node in GitOps & Config, plus edges (GHCR -> Kargo
  watch images, Kargo -> GitHub promote).
- Homepage: Kargo tile in the Infrastructure group, linking kargo.local.bigd.no.

## Verification

`make diagram` compiles both D2 sources successfully. SVG/PNG are left for the
Render Diagrams workflow to regenerate on merge (its normal job).