### PR TITLE
feat(kargo): instant Argo CD sync on promotion (argocd-update + ApplicationSet goTemplate)

### DIFF
--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -4,6 +4,10 @@ metadata:
   name: apps
   namespace: argocd
 spec:
+  # goTemplate is required for templatePatch below. String fields switch to the
+  # {{.path.*}} syntax; every generated Application renders exactly as before.
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
   generators:
     - git:
         repoURL: https://github.com/mortennordbye/homelab.git
@@ -12,7 +16,7 @@ spec:
           - path: k8s/talos/apps/*
   template:
     metadata:
-      name: "{{ path.basename }}"
+      name: '{{.path.basename}}'
       annotations:
         argocd.argoproj.io/sync-wave: "10"
       finalizers:
@@ -22,10 +26,10 @@ spec:
       source:
         repoURL: https://github.com/mortennordbye/homelab.git
         targetRevision: HEAD
-        path: "{{ path }}"
+        path: '{{.path.path}}'
       destination:
         name: in-cluster
-        namespace: "{{ path.basename }}"
+        namespace: '{{.path.basename}}'
       ignoreDifferences:
         - group: apps
           kind: Deployment
@@ -46,3 +50,18 @@ spec:
           - PruneLast=true
           - ServerSideApply=true
           - RespectIgnoreDifferences=true
+  # Authorize Kargo to sync only the portfolio apps. templatePatch is a
+  # Go-templated merge patch (a string), so structural if/end conditionals are
+  # valid here in a way they are not inside the parsed `template` above. For
+  # every other app this renders empty (no patch).
+  templatePatch: |
+    {{- if eq .path.basename "portfolio-stage" }}
+    metadata:
+      annotations:
+        kargo.akuity.io/authorized-stage: portfolio-cd:stage
+    {{- end }}
+    {{- if eq .path.basename "portfolio" }}
+    metadata:
+      annotations:
+        kargo.akuity.io/authorized-stage: portfolio-cd:prod
+    {{- end }}

--- a/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
@@ -47,3 +47,12 @@ spec:
         - uses: git-push
           config:
             path: ./repo
+        # Trigger the Argo CD sync and block until portfolio (prod) is Synced +
+        # Healthy at the promoted commit before the promotion reports success.
+        - uses: argocd-update
+          config:
+            apps:
+              - name: portfolio
+                sources:
+                  - repoURL: ${{ vars.gitopsRepo }}
+                    desiredRevision: ${{ outputs.commit.commit }}

--- a/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
@@ -51,3 +51,13 @@ spec:
         - uses: git-push
           config:
             path: ./repo
+        # Trigger the Argo CD sync and block until portfolio-stage is Synced +
+        # Healthy at the promoted commit, so the promotion (and its verification)
+        # only succeed once the deploy has actually converged.
+        - uses: argocd-update
+          config:
+            apps:
+              - name: portfolio-stage
+                sources:
+                  - repoURL: ${{ vars.gitopsRepo }}
+                    desiredRevision: ${{ outputs.commit.commit }}


### PR DESCRIPTION
## Why

Today Kargo pushes the promotion commit and waits on Argo CD's ~120s selfHeal
reconcile (Argo CD is internal-only, so there is no GitHub webhook). Kargo also
never learns whether the app came up. `argocd-update` fixes both: it triggers
the sync immediately and blocks until the target Application is Synced + Healthy
at the promoted commit, so the promotion and its verification only pass once the
deploy has actually converged.

## What

- Both portfolio Stages get a final `argocd-update` step, pinned to the commit
  from the git-commit step (`desiredRevision`).
- `argocd-update` requires `kargo.akuity.io/authorized-stage` on each Application
  (no wildcard is supported). The apps are ApplicationSet-generated, so instead
  of splitting them out, the apps ApplicationSet moves to `goTemplate` and uses
  `templatePatch` to add the annotation only to `portfolio` (`portfolio-cd:prod`)
  and `portfolio-stage` (`portfolio-cd:stage`). String fields switch to
  `{{.path.*}}`; nothing else changes.

Note: inline `{{if}}` in the parsed `template` produces invalid YAML (the
manifest must parse before templating). `templatePatch` is a Go-templated string
patch, so structural conditionals are valid there.

## Verification

Rendered with `argocd appset generate` (real engine, a list generator mirroring
the git one) — old vs new:

| App | source.path | destination.namespace | authorized-stage |
| --- | --- | --- | --- |
| portfolio | k8s/talos/apps/portfolio | portfolio | portfolio-cd:prod |
| portfolio-stage | k8s/talos/apps/portfolio-stage | portfolio-stage | portfolio-cd:stage |
| blog | k8s/talos/apps/blog | blog | (none) |
| plex-media-stack | k8s/talos/apps/plex-media-stack | plex-media-stack | (none) |

name / source.path / destination.namespace render identically to the old
fasttemplate for every app; only the two portfolio apps gain the annotation;
non-portfolio apps keep their prior annotations (sync-wave only). The annotation
is metadata-only, so no workload restarts.

## Rollout note

Merging re-renders the ApplicationSet. Generated specs are unchanged (proven
above), so no app should churn; portfolio / portfolio-stage just gain a
metadata annotation. The next promotion then syncs instantly and gates on health.