### PR TITLE
fix(kargo): stop argocd-update pinning a commit on shared main

### DIFF
--- a/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
@@ -48,11 +48,9 @@ spec:
           config:
             path: ./repo
         # Trigger the Argo CD sync and block until portfolio (prod) is Synced +
-        # Healthy at the promoted commit before the promotion reports success.
+        # Healthy before the promotion reports success. desiredRevision is
+        # intentionally not pinned (app tracks main HEAD; see stage-stage.yaml).
         - uses: argocd-update
           config:
             apps:
               - name: portfolio
-                sources:
-                  - repoURL: ${{ vars.gitopsRepo }}
-                    desiredRevision: ${{ outputs.commit.commit }}

--- a/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
@@ -52,12 +52,12 @@ spec:
           config:
             path: ./repo
         # Trigger the Argo CD sync and block until portfolio-stage is Synced +
-        # Healthy at the promoted commit, so the promotion (and its verification)
-        # only succeed once the deploy has actually converged.
+        # Healthy, so the promotion (and its verification) only succeed once the
+        # deploy has converged. We do NOT pin desiredRevision: the app tracks
+        # main HEAD, and any later commit from another app's promotion would then
+        # make Kargo report this stage perpetually unhealthy on a revision
+        # mismatch even though Argo CD itself is healthy.
         - uses: argocd-update
           config:
             apps:
               - name: portfolio-stage
-                sources:
-                  - repoURL: ${{ vars.gitopsRepo }}
-                    desiredRevision: ${{ outputs.commit.commit }}


### PR DESCRIPTION
## Why

`stage` showed Failed/Unhealthy while running the same freight prod runs Healthy.
Root cause: the `argocd-update` steps pinned `desiredRevision` to each promotion's
commit. All apps promote to `main` and the Applications track HEAD, so once a
later commit lands (the prod promotion did), the stage app's synced revision no
longer equals the pinned SHA and Kargo flags the stage Unhealthy on a revision
mismatch. Argo CD itself reports Synced + Healthy the whole time. Prod would hit
the same on the next unrelated commit to main.

## What

Remove the `sources`/`desiredRevision` block from `argocd-update` on both Stages.
The step still triggers the sync and blocks until the app is Synced + Healthy,
just not against a frozen commit.

## Verification

`kustomize build k8s/talos/infra/kargo-portfolio` renders; no `desiredRevision`
remains. After merge + a re-promote, the stage health should clear.