### PR TITLE
fix(kargo): auto-semver image tags + shared-main health check

### DIFF
--- a/.github/workflows/build-portfolio.yaml
+++ b/.github/workflows/build-portfolio.yaml
@@ -118,8 +118,14 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_SHA=${{ steps.context.outputs.TAG }}
+          # 0.0.<run_number> is a strict-semver build counter GitHub increments
+          # on its own: monotonic, so the Kargo Warehouse (SemVer strategy) always
+          # selects the newest build without any manual tagging. The git-SHA tag
+          # stays for human traceability; strictSemvers makes the Warehouse ignore
+          # it and the moving env tag automatically.
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.TAG }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:0.0.${{ github.run_number }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.ENV }}
 
       - name: Logout from Docker Hub

--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -8,6 +8,14 @@ spec:
   # {{.path.*}} syntax; every generated Application renders exactly as before.
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
+  # Kargo pins portfolio and portfolio-stage to a specific commit on promotion
+  # (argocd-update updateTargetRevision, see k8s/talos/infra/kargo-portfolio/).
+  # Without this the ApplicationSet controller would revert targetRevision back
+  # to HEAD and fight Kargo. Scoped to portfolio*; every other app keeps HEAD.
+  ignoreApplicationDifferences:
+    - name: 'portfolio*'
+      jsonPointers:
+        - /spec/source/targetRevision
   generators:
     - git:
         repoURL: https://github.com/mortennordbye/homelab.git

--- a/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
@@ -37,6 +37,7 @@ spec:
           config:
             path: ./repo/${{ vars.appPath }}
             images:
+              # Freight tag is the 0.0.<run_number> semver the Warehouse selected.
               - image: ${{ vars.imageRepo }}
                 tag: ${{ imageFrom(vars.imageRepo).Tag }}
         - uses: git-commit
@@ -48,9 +49,14 @@ spec:
           config:
             path: ./repo
         # Trigger the Argo CD sync and block until portfolio (prod) is Synced +
-        # Healthy before the promotion reports success. desiredRevision is
-        # intentionally not pinned (app tracks main HEAD; see stage-stage.yaml).
+        # Healthy before the promotion reports success. Pin the app to this
+        # promotion's commit so Kargo's argocd-update health check stays green as
+        # main advances (see the longer note in stage-stage.yaml).
         - uses: argocd-update
           config:
             apps:
               - name: portfolio
+                sources:
+                  - repoURL: ${{ vars.gitopsRepo }}
+                    desiredRevision: ${{ outputs.commit.commit }}
+                    updateTargetRevision: true

--- a/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
@@ -39,8 +39,7 @@ spec:
           config:
             path: ./repo/${{ vars.appPath }}
             images:
-              # Confirm the imageFrom(...).Tag expression against the promotion
-              # steps expression reference for the pinned Kargo version.
+              # Freight tag is the 0.0.<run_number> semver the Warehouse selected.
               - image: ${{ vars.imageRepo }}
                 tag: ${{ imageFrom(vars.imageRepo).Tag }}
         - uses: git-commit
@@ -53,11 +52,19 @@ spec:
             path: ./repo
         # Trigger the Argo CD sync and block until portfolio-stage is Synced +
         # Healthy, so the promotion (and its verification) only succeed once the
-        # deploy has converged. We do NOT pin desiredRevision: the app tracks
-        # main HEAD, and any later commit from another app's promotion would then
-        # make Kargo report this stage perpetually unhealthy on a revision
-        # mismatch even though Argo CD itself is healthy.
+        # deploy has converged. Pin the app to the commit this promotion just
+        # pushed: argocd-update registers a lasting health check against
+        # desiredRevision, so the app must track a revision Kargo controls.
+        # updateTargetRevision rewrites the Application's targetRevision to that
+        # commit; without it the app tracks the shared main HEAD, which every
+        # later commit advances past, leaving this Stage perpetually Unhealthy.
+        # The apps ApplicationSet ignores /spec/source/targetRevision for
+        # portfolio* so it does not revert this pin (k8s/talos/infra/argocd/apps.yaml).
         - uses: argocd-update
           config:
             apps:
               - name: portfolio-stage
+                sources:
+                  - repoURL: ${{ vars.gitopsRepo }}
+                    desiredRevision: ${{ outputs.commit.commit }}
+                    updateTargetRevision: true

--- a/k8s/talos/infra/kargo-portfolio/warehouse.yaml
+++ b/k8s/talos/infra/kargo-portfolio/warehouse.yaml
@@ -12,11 +12,13 @@ spec:
   subscriptions:
     - image:
         repoURL: ghcr.io/mortennordbye/homelab/portfolio
-        # Tags are immutable git short-SHAs, so neither SemVer nor Lexical
-        # ordering applies. NewestBuild orders by image build time. allowTags
-        # keeps the moving `stage`/`prod` tags out of Freight selection.
-        imageSelectionStrategy: NewestBuild
-        allowTags: ^[0-9a-f]{7,40}$
-        discoveryLimit: 20
-        # Kargo defaults this to true; spell it out so ArgoCD sees no drift.
+        # CI tags every build 0.0.<run_number> (GitHub's monotonic run counter).
+        # SemVer picks the greatest such tag, so new builds are always selected
+        # with no manual tagging and no dependence on image timestamps (the
+        # reason NewestBuild stalled: all builds share the base layer's `created`).
+        # strictSemvers (default true) makes the git-SHA and env tags non-eligible.
+        # discoveryLimit + strictSemvers spelled out to match Kargo's defaults and
+        # avoid ArgoCD drift.
+        imageSelectionStrategy: SemVer
         strictSemvers: true
+        discoveryLimit: 20


### PR DESCRIPTION
Two coupled fixes for the portfolio Kargo pipeline: the Warehouse never cut Freight for new builds, and both Stages reported Unhealthy forever even when promotions and verification passed.

## Why

**Freight never created.** `NewestBuild` orders images by their config `created` timestamp, but every portfolio image inherits `created` from the shared base layer (all recent builds show `2026-07-16T02:21:31Z`). Builds tie, Kargo keeps its current pick, and new builds are never selected.

**Stages perpetually Unhealthy.** `argocd-update` registers a lasting health check comparing each app's synced revision to a fixed `desiredRevision`. Both portfolio apps track `main` HEAD, so every unrelated commit advances HEAD past the promoted commit and the check goes red, while promotions and verification stay green. #329's "stop pinning desiredRevision" made it worse: a HEAD-tracking app can never satisfy a fixed-revision check on a shared branch.

## What

- CI tags every build `0.0.<run_number>` (GitHub's monotonic run counter) alongside the existing git-SHA tag.
- Warehouse -> `imageSelectionStrategy: SemVer`, which always selects the greatest version. Monotonic, no manual tagging, no dependence on image timestamps. `strictSemvers` (default) keeps the SHA and moving env tags out of selection.
- Promotions set the image by `tag` (the selected semver) and pin each app to the promoted commit: `desiredRevision: ${{ outputs.commit.commit }}` + `updateTargetRevision: true`.
- The `apps` ApplicationSet gets `ignoreApplicationDifferences` on `/spec/source/targetRevision` (scoped `portfolio*`) so it stops reverting Kargo's pin. Kargo becomes the sole deployer for these two apps.

## Verification

`kustomize build` renders both apps and the pipeline dir. `kubectl diff` on the Warehouse and both Stages is clean; the Warehouse spells out `strictSemvers`/`discoveryLimit` to match Kargo's defaults so ArgoCD sees no drift. `apps.yaml` passes a server-side dry-run. The two app kustomizations end identical to `main`, so no deploy flicker on merge.

## Rollout

Merging this changes `build-portfolio.yaml`, which triggers a build that publishes the first `0.0.N` tag; the Warehouse then cuts Freight and auto-promotes stage. The health pin engages on that promotion. Promote to prod manually to clear its red.