### PR TITLE
fix(kargo): drop shared-main revision pin so the portfolio stage stays Healthy

### DIFF
--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -8,14 +8,6 @@ spec:
   # {{.path.*}} syntax; every generated Application renders exactly as before.
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
-  # Kargo pins portfolio and portfolio-stage to a specific commit on promotion
-  # (argocd-update updateTargetRevision, see k8s/talos/infra/kargo-portfolio/).
-  # Without this the ApplicationSet controller would revert targetRevision back
-  # to HEAD and fight Kargo. Scoped to portfolio*; every other app keeps HEAD.
-  ignoreApplicationDifferences:
-    - name: 'portfolio*'
-      jsonPointers:
-        - /spec/source/targetRevision
   generators:
     - git:
         repoURL: https://github.com/mortennordbye/homelab.git

--- a/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-prod.yaml
@@ -49,14 +49,14 @@ spec:
           config:
             path: ./repo
         # Trigger the Argo CD sync and block until portfolio (prod) is Synced +
-        # Healthy before the promotion reports success. Pin the app to this
-        # promotion's commit so Kargo's argocd-update health check stays green as
-        # main advances (see the longer note in stage-stage.yaml).
+        # Healthy before the promotion reports success. Do NOT pin
+        # desiredRevision: the app tracks the shared main HEAD (see the longer
+        # note in stage-stage.yaml).
         - uses: argocd-update
           config:
             apps:
               - name: portfolio
-                sources:
-                  - repoURL: ${{ vars.gitopsRepo }}
-                    desiredRevision: ${{ outputs.commit.commit }}
-                    updateTargetRevision: true
+        - uses: argocd-wait
+          config:
+            apps:
+              - name: portfolio

--- a/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
+++ b/k8s/talos/infra/kargo-portfolio/stage-stage.yaml
@@ -51,20 +51,17 @@ spec:
           config:
             path: ./repo
         # Trigger the Argo CD sync and block until portfolio-stage is Synced +
-        # Healthy, so the promotion (and its verification) only succeed once the
-        # deploy has converged. Pin the app to the commit this promotion just
-        # pushed: argocd-update registers a lasting health check against
-        # desiredRevision, so the app must track a revision Kargo controls.
-        # updateTargetRevision rewrites the Application's targetRevision to that
-        # commit; without it the app tracks the shared main HEAD, which every
-        # later commit advances past, leaving this Stage perpetually Unhealthy.
-        # The apps ApplicationSet ignores /spec/source/targetRevision for
-        # portfolio* so it does not revert this pin (k8s/talos/infra/argocd/apps.yaml).
+        # Healthy. Do NOT pin desiredRevision: both portfolio apps track the
+        # shared main HEAD, so a fixed revision falls behind on the next commit
+        # (another stage's promotion) and reports this Stage perpetually
+        # Unhealthy even though Argo CD is healthy. Kargo v1.1.0+ requires an
+        # explicit desiredRevision precisely so shared-branch setups can omit it.
+        # Real verification comes from the portfolio-smoke test below.
         - uses: argocd-update
           config:
             apps:
               - name: portfolio-stage
-                sources:
-                  - repoURL: ${{ vars.gitopsRepo }}
-                    desiredRevision: ${{ outputs.commit.commit }}
-                    updateTargetRevision: true
+        - uses: argocd-wait
+          config:
+            apps:
+              - name: portfolio-stage


### PR DESCRIPTION
## Why

The `portfolio-cd` Kargo project shows `stage` as **Unhealthy** while `prod` is **Healthy**, both on the same image. A fresh build looks green briefly, then flips red.

Root cause: both ArgoCD apps (`portfolio`, `portfolio-stage`) track the shared `main` branch (`targetRevision=HEAD`), but `argocd-update` pinned a lasting health check to `desiredRevision` = the promotion's own commit (with `updateTargetRevision`). Because both apps share `main`, the next commit to `main` (the paired prod promotion, or the next build) advances the app past that frozen commit, so the stage reports Unhealthy forever even though ArgoCD itself is Synced + Healthy. `prod` stays green only because its promotion produced the most recent commit.

Confirmed on the live cluster: despite `updateTargetRevision: true` and the `ignoreApplicationDifferences` override, `portfolio-stage.spec.source.targetRevision` was still `HEAD` — the pin never took effect, so the check could only ever fall behind.

This is the documented failure mode. Kargo v1.1.0+ stopped auto-inferring the desired revision precisely so multiple Applications tracking the same branch can omit it. `#329` removed the pin correctly; `#330` reintroduced it. This PR finishes what `#329` started.

## What

- `stage-stage.yaml` / `stage-prod.yaml`: drop `sources`/`desiredRevision`/`updateTargetRevision` from `argocd-update`; add an explicit `argocd-wait` so the promotion still blocks until Synced + Healthy.
- `apps.yaml`: remove the now-pointless `ignoreApplicationDifferences` override for `portfolio*`. The `authorized-stage` templatePatch stays.
- Real verification still comes from the `portfolio-smoke` AnalysisTemplate.

Unchanged: the auto-semver Warehouse config and CI `0.0.<run>` tagging from `#330`.

## Verification

- `kubectl kustomize k8s/talos/infra/kargo-portfolio` renders; `apps.yaml` parses.
- After merge, run **one fresh promotion** (new build or manual re-promote) so Kargo re-registers the health check without the pin — the lasting check only re-registers on the next promotion.
- Confirm `kubectl get stages -n portfolio-cd` shows both Healthy, and that `stage` stays Healthy after a subsequent commit lands on `main`.