### PR TITLE
feat(kargo): onboard blog to the promotion pipeline

### DIFF
--- a/.github/workflows/build-blog.yaml
+++ b/.github/workflows/build-blog.yaml
@@ -17,10 +17,9 @@ on:
     paths:
       - "blog/**"
 
-# Serialise deploys to the same environment: the manifest commit is rebased onto
-# main and pushed, so two runs racing would fight over the same branch. Never
-# cancel in progress, which could tear a half-finished deploy. Scoped per
-# environment so a stage push can't cancel a queued prod dispatch.
+# Serialise image builds per environment. Never cancel in progress, which could
+# tear a half-finished build. Kargo (not this workflow) owns the manifest write
+# and promotion now; CI only builds and pushes the image.
 concurrency:
   group: build-blog-${{ inputs.environment || 'stage' }}
   cancel-in-progress: false
@@ -54,7 +53,7 @@ jobs:
     if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') && github.repository_owner == 'mortennordbye' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Needed to update manifests
+      contents: read
       packages: write # Needed to push images
 
     steps:
@@ -78,13 +77,7 @@ jobs:
 
           echo "ENV=${ENV}" >> $GITHUB_OUTPUT
 
-          if [[ "${ENV}" == "prod" ]]; then
-            echo "MANIFEST=k8s/talos/apps/blog/deployment.yaml" >> $GITHUB_OUTPUT
-          else
-            echo "MANIFEST=k8s/talos/apps/blog-stage/deployment.yaml" >> $GITHUB_OUTPUT
-          fi
-
-          echo "Deploying to environment: ${ENV}"
+          echo "Building for environment: ${ENV}"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -103,47 +96,16 @@ jobs:
         with:
           context: ./blog
           push: true
-          # Immutable SHA tag + mutable env tag (stage / prod)
+          # 0.0.<run_number> is a strict-semver build counter GitHub increments
+          # on its own: monotonic, so the Kargo Warehouse (SemVer strategy) always
+          # selects the newest build without any manual tagging. The git-SHA tag
+          # stays for human traceability; strictSemvers makes the Warehouse ignore
+          # it and the moving env tag automatically.
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.TAG }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:0.0.${{ github.run_number }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.ENV }}
 
       - name: Logout from Docker Hub
         if: always()
         run: docker logout
-
-      - name: Update Kubernetes Manifest
-        run: |
-          MANIFEST="${{ steps.context.outputs.MANIFEST }}"
-          TAG="${{ steps.context.outputs.TAG }}"
-          ENV="${{ steps.context.outputs.ENV }}"
-          NEW_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
-
-          echo "Updating manifest: ${MANIFEST}"
-          echo "New image: ${NEW_IMAGE}"
-
-          if [[ ! -f "${MANIFEST}" ]]; then
-            echo "ERROR: Manifest file not found: ${MANIFEST}"
-            exit 1
-          fi
-
-          sed -i "s|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:.*|image: ${NEW_IMAGE}|g" $MANIFEST
-
-          echo "Changes made:"
-          git diff $MANIFEST
-
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-
-          if [[ -n $(git status -s) ]]; then
-            git add $MANIFEST
-            git commit -m "chore(blog): deploy ${TAG} to ${ENV}"
-            # main may have advanced while the image built (e.g. the portfolio
-            # deploy pushing its manifest commit); rebase so the push is
-            # fast-forward instead of getting rejected.
-            git fetch origin main
-            git rebase origin/main
-            git push origin HEAD:main
-          else
-            echo "Manifest already up to date."
-          fi

--- a/k8s/talos/apps/blog-stage/kustomization.yaml
+++ b/k8s/talos/apps/blog-stage/kustomization.yaml
@@ -12,3 +12,10 @@ resources:
   - ciliumnetworkpolicy.yaml
   - interceptorroute.yaml
   - scaledobject.yaml
+
+# Image tag is owned by Kargo (kargo-projects Warehouse/Stage), which rewrites
+# newTag via the kustomize-set-image promotion step. Overrides the inline tag in
+# deployment.yaml.
+images:
+  - name: ghcr.io/mortennordbye/homelab/blog
+    newTag: a5feaed

--- a/k8s/talos/apps/blog/kustomization.yaml
+++ b/k8s/talos/apps/blog/kustomization.yaml
@@ -12,3 +12,10 @@ resources:
   - namespace.yaml
   - ciliumnetworkpolicy.yaml
   - scaledobject.yaml
+
+# Image tag is owned by Kargo (kargo-projects Warehouse/Stage), which rewrites
+# newTag via the kustomize-set-image promotion step. Overrides the inline tag in
+# deployment.yaml.
+images:
+  - name: ghcr.io/mortennordbye/homelab/blog
+    newTag: 10930ac

--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -58,7 +58,7 @@ spec:
   # non-Kargo app matches nothing and renders no patch.
   templatePatch: |
     {{- $base := .path.basename }}
-    {{- range $app := list "portfolio" }}
+    {{- range $app := list "portfolio" "blog" }}
     {{- if eq $base $app }}
     metadata:
       annotations:

--- a/k8s/talos/infra/kargo-projects/blog.yaml
+++ b/k8s/talos/infra/kargo-projects/blog.yaml
@@ -1,0 +1,210 @@
+# Kargo project for the blog app: stage -> prod promotion driven by the blog
+# Warehouse. Mirrors portfolio.yaml; the promotion steps live in the shared
+# promote-to-argocd ClusterPromotionTask.
+
+# --- Project namespace ------------------------------------------------------
+# Named `blog-cd` (not `blog`) to avoid colliding with the blog app namespace.
+# The label lets the Project below adopt this pre-created namespace instead of
+# racing to create it, keeping Argo CD sync ordering clean.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: blog-cd
+  labels:
+    kargo.akuity.io/project: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+---
+# Auto-promotion is a Project-level policy in Kargo (never on a Stage). Here we
+# auto-promote the `stage` Stage and leave `prod` as a deliberate manual step.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: blog-cd
+  namespace: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  promotionPolicies:
+    - stage: stage
+      autoPromotionEnabled: true
+---
+# Git write credential for Kargo's git-push, using the existing GitHub App
+# `mortennordbye-homelab-deployer` (scoped to mortennordbye/homelab, Contents
+# read/write). Same App as portfolio-cd; only the namespace differs. The Secret
+# must live in this Project namespace (Kargo cred lookup is per-Project).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kargo-git-homelab
+  namespace: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: kargo-git-homelab
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git
+      data:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        githubAppClientID: "{{ .githubAppClientID }}"
+        githubAppInstallationID: "{{ .githubAppInstallationID }}"
+        githubAppPrivateKey: "{{ .githubAppPrivateKey }}"
+  data:
+    - secretKey: githubAppClientID
+      remoteRef:
+        key: "a6b2b4ea-fa97-4d5c-bd74-b489010c5fab"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppInstallationID
+      remoteRef:
+        key: "aabab894-a09a-415c-ba17-b489010c8df5"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppPrivateKey
+      remoteRef:
+        key: "fc775dd0-1b67-4dfa-b2e9-b489010d0359"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: blog
+  namespace: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
+  interval: 5m0s
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/mortennordbye/homelab/blog
+        # CI tags every build 0.0.<run_number>; SemVer picks the greatest.
+        # strictSemvers keeps the git-SHA and moving env tags out of selection.
+        # No eligible Freight exists until the first build after the CI change
+        # lands a 0.0.<run> tag (the current blog images are git-SHA tagged).
+        imageSelectionStrategy: SemVer
+        strictSemvers: true
+        discoveryLimit: 20
+---
+# Stage verification: a one-shot Job that curls the stage URL and fails on any
+# non-2xx. Retries cover the KEDA scale-from-zero cold start (the request also
+# wakes the stage deployment). -k skips TLS verify for the internal local cert.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: blog-smoke
+  namespace: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: blog-stage-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsSk --retry 10 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://blog-stage.local.bigd.no/
+---
+# stage: receives new Freight directly from the Warehouse (auto-promoted per
+# ProjectConfig), then verifies with the HTTP smoke test. Only Freight that
+# passes verification here becomes available to prod.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: stage
+  namespace: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: blog
+      sources:
+        direct: true
+  verification:
+    analysisTemplates:
+      - name: blog-smoke
+  promotionTemplate:
+    spec:
+      vars:
+        - name: appName
+          value: blog
+        - name: appPath
+          value: k8s/talos/apps/blog-stage
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/homelab/blog
+        - name: argocdApp
+          value: blog-stage
+      steps:
+        - task:
+            name: promote-to-argocd
+            kind: ClusterPromotionTask
+---
+# prod: receives only Freight already verified in `stage` (sources.stages). No
+# autoPromotionEnabled entry in ProjectConfig, so promotion here is a deliberate
+# manual action.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: blog
+      sources:
+        stages:
+          - stage
+  promotionTemplate:
+    spec:
+      vars:
+        - name: appName
+          value: blog
+        - name: appPath
+          value: k8s/talos/apps/blog
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/homelab/blog
+        - name: argocdApp
+          value: blog
+      steps:
+        - task:
+            name: promote-to-argocd
+            kind: ClusterPromotionTask

--- a/k8s/talos/infra/kargo-projects/kustomization.yaml
+++ b/k8s/talos/infra/kargo-projects/kustomization.yaml
@@ -8,3 +8,4 @@ kind: Kustomization
 resources:
   - clusterpromotiontask.yaml
   - portfolio.yaml
+  - blog.yaml


### PR DESCRIPTION
## Why

Blog was the app the scale refactor (#334) was built for. It already has stage + prod overlays but was still self-deploying via CI (a `sed` + `git push origin HEAD:main` step) — a double-write landmine once a blog Warehouse exists. This brings blog onto the same Kargo `stage → prod` pipeline as portfolio.

## What

Reuses the shared `promote-to-argocd` ClusterPromotionTask — onboarding is one file plus one word:

- **`kargo-projects/blog.yaml`** — project `blog-cd` (Namespace, Project, ProjectConfig, ExternalSecret, Warehouse, AnalysisTemplate, `stage`/`prod` Stages). Warehouse watches `ghcr.io/mortennordbye/homelab/blog` (SemVer, strictSemvers); smoke test on `blog-stage.local.bigd.no`; reuses the same GitHub App git credential (only the namespace differs). Both Stages are just a `- task:` reference + vars.
- **`apps.yaml`** — added `"blog"` to the `templatePatch` list; `blog` → `blog-cd:prod`, `blog-stage` → `blog-cd:stage` (rendered-verified).
- **blog / blog-stage kustomizations** — added the Kargo-owned `images:` block seeded to the currently deployed tags (`10930ac` / `a5feaed`), so `kustomize build` renders identically to today.
- **`build-blog.yaml`** — removed the `Update Kubernetes Manifest` step, dropped `contents: write` → `read`, added a `0.0.${{ github.run_number }}` tag. CI now only builds and pushes.

## Sequencing (important)

The Warehouse uses SemVer, but blog's current images are git-SHA tagged. So **no Freight is eligible until the first blog build after this merges emits a `0.0.<run>` tag** — nothing promotes on merge, and the seeded `images:` tags keep the running site unchanged. To activate: push under `blog/**` (or run `build-blog.yaml`). Stage then auto-promotes + verifies; prod stays manual.

This is additive (new `blog-cd` project, new kargo-projects entries) — no app rename, so no special cutover like #334.

## Verification
- `kubectl kustomize` renders blog (`:10930ac`) and blog-stage (`:a5feaed`) unchanged, and kargo-projects with both projects (2× each resource + 1 shared task).
- `apps.yaml` + `blog.yaml` parse; templatePatch rendered offline for `blog`/`blog-stage`/`portfolio*`/`plex` → correct.
- `build-blog.yaml` valid YAML, no leftover manifest-write / `contents: write`.