### PR TITLE
chore(ci): drop the moving stage/prod image tags from build workflows

### DIFF
--- a/.github/workflows/build-blog.yaml
+++ b/.github/workflows/build-blog.yaml
@@ -2,26 +2,18 @@ name: Build and Deploy Blog
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: "Target environment"
-        required: true
-        type: choice
-        options:
-          - stage
-          - prod
-        default: stage
   push:
     branches:
-      - main # Pushing here updates STAGE only
+      - main
     paths:
       - "blog/**"
 
-# Serialise image builds per environment. Never cancel in progress, which could
-# tear a half-finished build. Kargo (not this workflow) owns the manifest write
-# and promotion now; CI only builds and pushes the image.
+# Serialise image builds. Never cancel in progress, which could tear a
+# half-finished build. Kargo (not this workflow) owns the manifest write and
+# promotion; the same image is promoted stage -> prod, so there is no
+# per-environment build.
 concurrency:
-  group: build-blog-${{ inputs.environment || 'stage' }}
+  group: build-blog
   cancel-in-progress: false
 
 env:
@@ -30,9 +22,9 @@ env:
 
 jobs:
   ci:
-    # Gates stage deploys on push to main. Manual prod dispatch skips this.
-    # The Hugo render itself is validated by the Docker build below, and
-    # the image is only pushed if that succeeds.
+    # Gates builds on push to main. Manual dispatch skips this. The Hugo render
+    # itself is validated by the Docker build below, and the image is only
+    # pushed if that succeeds.
     if: github.event_name == 'push' && github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     permissions:
@@ -49,7 +41,7 @@ jobs:
 
   build-and-deploy:
     needs: ci
-    # success = push with green ci; skipped = manual prod dispatch
+    # success = push with green ci; skipped = manual dispatch
     if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') && github.repository_owner == 'mortennordbye' }}
     runs-on: ubuntu-latest
     permissions:
@@ -62,22 +54,10 @@ jobs:
           submodules: recursive # Critical for the Hugo theme submodule
           fetch-depth: 0
 
-      - name: Determine Environment
+      - name: Determine tag
         id: context
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "TAG=${SHORT_SHA}" >> $GITHUB_OUTPUT
-
-          # workflow_dispatch input takes precedence, otherwise default to stage
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            ENV="${{ inputs.environment }}"
-          else
-            ENV="stage"
-          fi
-
-          echo "ENV=${ENV}" >> $GITHUB_OUTPUT
-
-          echo "Building for environment: ${ENV}"
+          echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -96,15 +76,14 @@ jobs:
         with:
           context: ./blog
           push: true
-          # 0.0.<run_number> is a strict-semver build counter GitHub increments
-          # on its own: monotonic, so the Kargo Warehouse (SemVer strategy) always
-          # selects the newest build without any manual tagging. The git-SHA tag
-          # stays for human traceability; strictSemvers makes the Warehouse ignore
-          # it and the moving env tag automatically.
+          # Two tags: the git short-SHA for human traceability, and a
+          # 0.0.<run_number> strict-semver build counter that the Kargo Warehouse
+          # (SemVer strategy) selects. No moving stage/prod tag -- the same image
+          # is promoted across environments by Kargo, so an env tag would be
+          # redundant (stage) or misleading (prod is promoted in git, not tagged).
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.TAG }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:0.0.${{ github.run_number }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.ENV }}
 
       - name: Logout from Docker Hub
         if: always()

--- a/.github/workflows/build-portfolio.yaml
+++ b/.github/workflows/build-portfolio.yaml
@@ -2,28 +2,19 @@ name: Build and Deploy Portfolio
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        description: "Target environment"
-        required: true
-        type: choice
-        options:
-          - stage
-          - prod
-        default: stage
   push:
     branches:
-      - main # Pushing here updates STAGE only
+      - main
     paths:
       - "portfolio/**"
       - ".github/workflows/build-portfolio.yaml"
 
-# Serialise deploys to the same environment: the manifest commit is rebased onto
-# main and pushed, so two runs racing would fight over the same branch. Never
-# cancel in progress, which could tear a half-finished deploy. Scoped per
-# environment so a stage push can't cancel a queued prod dispatch.
+# Serialise image builds. Never cancel in progress, which could tear a
+# half-finished build. Kargo (not this workflow) owns the manifest write and
+# promotion; the same image is promoted stage -> prod, so there is no
+# per-environment build.
 concurrency:
-  group: build-portfolio-${{ inputs.environment || 'stage' }}
+  group: build-portfolio
   cancel-in-progress: false
 
 env:
@@ -32,9 +23,9 @@ env:
 
 jobs:
   ci:
-    # Gates stage deploys on push to main. Manual prod dispatch skips this.
-    # next build is not repeated here: it runs inside the Docker build, and
-    # the image is only pushed if that succeeds.
+    # Gates builds on push to main. Manual dispatch skips this. The next build
+    # is not repeated here: it runs inside the Docker build, and the image is
+    # only pushed if that succeeds.
     if: github.event_name == 'push' && github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     permissions:
@@ -63,7 +54,7 @@ jobs:
 
   build-and-deploy:
     needs: ci
-    # success = push with green ci; skipped = manual prod dispatch
+    # success = push with green ci; skipped = manual dispatch
     if: ${{ !cancelled() && (needs.ci.result == 'success' || needs.ci.result == 'skipped') && github.repository_owner == 'mortennordbye' }}
     runs-on: ubuntu-latest
     permissions:
@@ -75,21 +66,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine Environment
+      - name: Determine tag
         id: context
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "TAG=${SHORT_SHA}" >> $GITHUB_OUTPUT
-
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            ENV="${{ inputs.environment }}"
-          else
-            ENV="stage"
-          fi
-
-          echo "ENV=${ENV}" >> $GITHUB_OUTPUT
-
-          echo "Deploying to environment: ${ENV}"
+          echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -118,15 +98,14 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_SHA=${{ steps.context.outputs.TAG }}
-          # 0.0.<run_number> is a strict-semver build counter GitHub increments
-          # on its own: monotonic, so the Kargo Warehouse (SemVer strategy) always
-          # selects the newest build without any manual tagging. The git-SHA tag
-          # stays for human traceability; strictSemvers makes the Warehouse ignore
-          # it and the moving env tag automatically.
+          # Two tags: the git short-SHA for human traceability, and a
+          # 0.0.<run_number> strict-semver build counter that the Kargo Warehouse
+          # (SemVer strategy) selects. No moving stage/prod tag -- the same image
+          # is promoted across environments by Kargo, so an env tag would be
+          # redundant (stage) or misleading (prod is promoted in git, not tagged).
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.TAG }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:0.0.${{ github.run_number }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.context.outputs.ENV }}
 
       - name: Logout from Docker Hub
         if: always()


### PR DESCRIPTION
## Why

The `:stage` / `:prod` moving image tags are a leftover from the pre-Kargo model, where CI deployed a specific environment and the tag denoted "what's live there." With Kargo, **one image (selected by the `0.0.<run>` SemVer tag) is promoted stage → prod**, so a per-environment tag no longer makes sense:

- Both Warehouses use `SemVer` + `strictSemvers`, so the moving tags are **ignored** for selection.
- No manifest pulls `:stage`/`:prod` (verified with `git grep`).
- `:stage` just duplicates the semver tag on every main build.
- `:prod` is **stale and misleading** — it would only move on a manual prod *dispatch*, which no longer happens (prod is promoted in the Kargo UI, i.e. in git). It implies "this is prod's image" when git is the source of truth.

## What

Remove the env tag and the now-vestigial `environment` concept from both `build-portfolio.yaml` and `build-blog.yaml`:

- Drop the `workflow_dispatch` `environment` input, the `ENV` computation, and the env-scoped `concurrency` group (now a single `build-<app>` group).
- Builds tag only: the **git short-SHA** (human traceability) and **`0.0.<run_number>`** (Kargo selection).
- A bare `workflow_dispatch` still forces a rebuild; push-to-main still gates on CI. CI only builds and pushes — Kargo owns promotion.

No behavior change for the pipeline: Kargo already selected by semver and ignored these tags.

## Verification
- Both workflows parse as valid YAML; no leftover `ENV` / `inputs.environment` / `:stage` / `:prod` references.
- `git grep` confirms no manifest or other workflow consumes the moving tags.

Note: the inline `image:` tags in the `deployment.yaml` files (e.g. `:caa53f4`) are a separate thing — they're the kustomize base tag that the Kargo-owned `images:` block overrides, so they're harmless placeholders and left as-is.