### PR TITLE
feat(kargo): prod verification, Stage descriptions, consistent colours

### DIFF
--- a/k8s/talos/infra/kargo-projects/blog.yaml
+++ b/k8s/talos/infra/kargo-projects/blog.yaml
@@ -139,6 +139,38 @@ spec:
                         -o /dev/null -w '%{http_code}\n'
                         https://blog-stage.local.bigd.no/
 ---
+# prod verification: same one-shot HTTP check against the live public domain.
+# Confirmed the cluster can reach blog.nordbye.it (no NAT-hairpin issue).
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: blog-prod-smoke
+  namespace: blog-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: blog-prod-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsSk --retry 5 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://blog.nordbye.it/
+---
 # stage: receives new Freight directly from the Warehouse (auto-promoted per
 # ProjectConfig), then verifies with the HTTP smoke test. Only Freight that
 # passes verification here becomes available to prod.
@@ -151,6 +183,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     # Cosmetic UI colour, kept identical across apps: stage = blue, prod = red.
     kargo.akuity.io/color: "#0284c7"
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse, then smoke-tested on blog-stage.local.bigd.no."
 spec:
   requestedFreight:
     - origin:
@@ -188,6 +221,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
     kargo.akuity.io/color: "#e11d48"
+    kargo.akuity.io/description: "Manual promotion of stage-verified Freight. Live at blog.nordbye.it; smoke-tested after deploy."
 spec:
   requestedFreight:
     - origin:
@@ -196,6 +230,9 @@ spec:
       sources:
         stages:
           - stage
+  verification:
+    analysisTemplates:
+      - name: blog-prod-smoke
   promotionTemplate:
     spec:
       vars:

--- a/k8s/talos/infra/kargo-projects/blog.yaml
+++ b/k8s/talos/infra/kargo-projects/blog.yaml
@@ -149,6 +149,8 @@ metadata:
   namespace: blog-cd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    # Cosmetic UI colour, kept identical across apps: stage = blue, prod = red.
+    kargo.akuity.io/color: "#0284c7"
 spec:
   requestedFreight:
     - origin:
@@ -185,6 +187,7 @@ metadata:
   namespace: blog-cd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    kargo.akuity.io/color: "#e11d48"
 spec:
   requestedFreight:
     - origin:

--- a/k8s/talos/infra/kargo-projects/portfolio.yaml
+++ b/k8s/talos/infra/kargo-projects/portfolio.yaml
@@ -144,6 +144,40 @@ spec:
                         -o /dev/null -w '%{http_code}\n'
                         https://portfolio-stage.local.bigd.no/
 ---
+# prod verification: same one-shot HTTP check against the live public domain
+# (through the public gateway + TLS), so a bad prod promotion is flagged instead
+# of showing green. Confirmed the cluster can reach nordbye.it (no NAT-hairpin
+# issue). Fewer cold-start retries needed than stage since prod stays warm.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: portfolio-prod-smoke
+  namespace: portfolio-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: portfolio-prod-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsSk --retry 5 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://nordbye.it/
+---
 # stage: receives new Freight directly from the Warehouse (auto-promoted per
 # ProjectConfig), then verifies with the HTTP smoke test. Only Freight that
 # passes verification here becomes available to prod. The promotion steps live
@@ -160,6 +194,7 @@ metadata:
     # across every app: stage = blue, prod = red, so the pipeline reads the same
     # everywhere instead of Kargo picking a random colour per Stage.
     kargo.akuity.io/color: "#0284c7"
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse, then smoke-tested on portfolio-stage.local.bigd.no."
 spec:
   requestedFreight:
     - origin:
@@ -197,6 +232,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
     kargo.akuity.io/color: "#e11d48"
+    kargo.akuity.io/description: "Manual promotion of stage-verified Freight. Live at nordbye.it; smoke-tested after deploy."
 spec:
   requestedFreight:
     - origin:
@@ -205,6 +241,9 @@ spec:
       sources:
         stages:
           - stage
+  verification:
+    analysisTemplates:
+      - name: portfolio-prod-smoke
   promotionTemplate:
     spec:
       vars:

--- a/k8s/talos/infra/kargo-projects/portfolio.yaml
+++ b/k8s/talos/infra/kargo-projects/portfolio.yaml
@@ -156,6 +156,10 @@ metadata:
   namespace: portfolio-cd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    # Cosmetic UI colour (Kargo pipeline view). Set per role and kept identical
+    # across every app: stage = blue, prod = red, so the pipeline reads the same
+    # everywhere instead of Kargo picking a random colour per Stage.
+    kargo.akuity.io/color: "#0284c7"
 spec:
   requestedFreight:
     - origin:
@@ -192,6 +196,7 @@ metadata:
   namespace: portfolio-cd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    kargo.akuity.io/color: "#e11d48"
 spec:
   requestedFreight:
     - origin:


### PR DESCRIPTION
## Why

Three UI/robustness improvements to the Kargo pipeline, on the same four Stages.

## What

**1. Prod smoke verification (the substantive one).** Prod had no verification — `argocd-wait` confirmed pods were Healthy, but nothing checked the real public domain actually served through the gateway + TLS. Added a prod `AnalysisTemplate` per app and wired it into each prod Stage's `verification`:
- portfolio prod → `https://nordbye.it/`
- blog prod → `https://blog.nordbye.it/`

A bad prod promotion is now flagged as unverified instead of showing green. Verified in-cluster reachability of both domains first (no NAT-hairpin issue); fewer retries than stage since prod stays warm.

**2. Stage descriptions.** Added `kargo.akuity.io/description` to every Stage so the UI shows what each does (auto vs manual, which URL).

**3. Consistent colours.** `kargo.akuity.io/color` pinned by role across all apps — `stage` blue `#0284c7`, `prod` red `#e11d48` — instead of Kargo auto-assigning a random colour per Stage (which drew blue/red for blog but red/red for portfolio).

Every future app inherits all three when copied from `portfolio.yaml` / `blog.yaml`.

## Verification
- `kubectl kustomize k8s/talos/infra/kargo-projects` renders 4 Stages (colour + description + verification target) and 4 AnalysisTemplates with the correct smoke URLs.
- Additive/cosmetic; nothing persisted these before, so no drift. Prod verification runs on the next prod promotion.