### PR TITLE
feat(kargo): PR-based prod promotion for portfolio (pilot)

### DIFF
--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
@@ -1,0 +1,72 @@
+# PR-based variant of promote-to-argocd. Same image-bump logic, but instead of
+# pushing the commit straight to main it pushes to a generated branch, opens a
+# homelab PR, and blocks until that PR is merged in GitHub before syncing Argo
+# CD. This keeps promotion "review-and-merge in GitHub" while Kargo still drives
+# image discovery, the pipeline view, and post-deploy verification.
+#
+# Currently used only by portfolio's prod Stage as a pilot. The direct-push
+# promote-to-argocd task (clusterpromotiontask.yaml) is unchanged and still used
+# by every stage Stage and by blog.
+#
+# PREREQUISITE: the git credential's GitHub App (mortennordbye-homelab-deployer)
+# needs Pull requests: read/write in addition to Contents: read/write. git-open-pr
+# fails without it. desiredRevision is deliberately NOT pinned on argocd-update
+# for the same reason as promote-to-argocd: prod tracks shared main HEAD, so a
+# fixed revision would report the Stage perpetually Unhealthy on the next commit.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ClusterPromotionTask
+metadata:
+  name: promote-via-pr
+spec:
+  vars:
+    - name: appName      # commit-message scope, e.g. portfolio
+    - name: appPath      # kustomization dir, e.g. k8s/talos/apps/portfolio
+    - name: imageRepo    # GHCR repo the Warehouse subscribes to
+    - name: argocdApp    # Argo CD Application to sync, e.g. portfolio
+  steps:
+    - uses: git-clone
+      config:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        checkout:
+          - branch: main
+            path: ./repo
+    - uses: kustomize-set-image
+      config:
+        path: ./repo/${{ vars.appPath }}
+        images:
+          - image: ${{ vars.imageRepo }}
+            tag: ${{ imageFrom(vars.imageRepo).Tag }}
+    - uses: git-commit
+      config:
+        path: ./repo
+        message: "chore(${{ vars.appName }}): promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
+    # generateTargetBranch pushes to kargo/promotion/<promotionName> instead of
+    # main; its `branch` output feeds git-open-pr's sourceBranch.
+    - uses: git-push
+      as: push
+      config:
+        path: ./repo
+        generateTargetBranch: true
+    - uses: git-open-pr
+      as: open-pr
+      config:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        provider: github
+        sourceBranch: ${{ outputs.push.branch }}
+        targetBranch: main
+        title: "chore(${{ vars.appName }}): promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
+    # Blocks the promotion until the PR is merged in GitHub.
+    - uses: git-wait-for-pr
+      as: wait-pr
+      config:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        provider: github
+        prNumber: ${{ outputs['open-pr'].pr.id }}
+    - uses: argocd-update
+      config:
+        apps:
+          - name: ${{ vars.argocdApp }}
+    - uses: argocd-wait
+      config:
+        apps:
+          - name: ${{ vars.argocdApp }}

--- a/k8s/talos/infra/kargo-projects/kustomization.yaml
+++ b/k8s/talos/infra/kargo-projects/kustomization.yaml
@@ -7,5 +7,6 @@ kind: Kustomization
 # ../argocd/apps.yaml.
 resources:
   - clusterpromotiontask.yaml
+  - clusterpromotiontask-pr.yaml
   - portfolio.yaml
   - blog.yaml

--- a/k8s/talos/infra/kargo-projects/portfolio.yaml
+++ b/k8s/talos/infra/kargo-projects/portfolio.yaml
@@ -223,7 +223,10 @@ spec:
 ---
 # prod: receives only Freight already verified in `stage` (sources.stages). No
 # autoPromotionEnabled entry in ProjectConfig, so promotion here is a deliberate
-# manual action.
+# manual action. Pilot: prod promotion goes through promote-via-pr (opens a
+# homelab PR and waits for the merge) instead of the direct-push
+# promote-to-argocd, so the manual prod gate is a GitHub PR review. stage still
+# uses promote-to-argocd above.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -257,5 +260,5 @@ spec:
           value: portfolio
       steps:
         - task:
-            name: promote-to-argocd
+            name: promote-via-pr
             kind: ClusterPromotionTask

--- a/k8s/talos/infra/kargo-projects/portfolio.yaml
+++ b/k8s/talos/infra/kargo-projects/portfolio.yaml
@@ -23,8 +23,12 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 ---
-# Auto-promotion is a Project-level policy in Kargo (never on a Stage). Here we
-# auto-promote the `stage` Stage and leave `prod` as a deliberate manual step.
+# Auto-promotion is a Project-level policy in Kargo (never on a Stage). Both
+# Stages auto-promote: `stage` pushes the bump straight to main, and `prod` runs
+# promote-via-pr, which auto-opens a homelab PR and then blocks on the merge. So
+# the only human gate in the whole pipeline is approving that prod PR in GitHub;
+# there is no manual "promote" click in the Kargo UI. prod still only receives
+# Freight that passed the stage smoke test (see the Stage's sources.stages).
 apiVersion: kargo.akuity.io/v1alpha1
 kind: ProjectConfig
 metadata:
@@ -35,6 +39,8 @@ metadata:
 spec:
   promotionPolicies:
     - stage: stage
+      autoPromotionEnabled: true
+    - stage: prod
       autoPromotionEnabled: true
 ---
 # Git write credential for Kargo's git-push, using the existing GitHub App
@@ -221,12 +227,11 @@ spec:
             name: promote-to-argocd
             kind: ClusterPromotionTask
 ---
-# prod: receives only Freight already verified in `stage` (sources.stages). No
-# autoPromotionEnabled entry in ProjectConfig, so promotion here is a deliberate
-# manual action. Pilot: prod promotion goes through promote-via-pr (opens a
-# homelab PR and waits for the merge) instead of the direct-push
-# promote-to-argocd, so the manual prod gate is a GitHub PR review. stage still
-# uses promote-to-argocd above.
+# prod: receives only Freight already verified in `stage` (sources.stages).
+# Auto-promoted (see ProjectConfig), but through promote-via-pr: as soon as a
+# Freight passes the stage smoke test, Kargo auto-opens a homelab PR and waits.
+# The prod deploy happens when that PR is approved and merged in GitHub, so the
+# PR review is the prod gate. stage still uses the direct-push promote-to-argocd.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:


### PR DESCRIPTION
## Why

Piloting a Kargo promotion flow where the only human gate is approving a GitHub PR. Commit to build to stage runs automatically; once stage passes its smoke test, Kargo auto-opens a prod PR; merging that PR is what ships prod. If it works well for portfolio, the same task can be reused for headroom and logeverylift.

## What

- New `promote-via-pr` ClusterPromotionTask: same image-bump as `promote-to-argocd`, but pushes to a generated `kargo/promotion/<name>` branch, opens a homelab PR (`git-open-pr`), and blocks on the merge (`git-wait-for-pr`) before `argocd-update`/`argocd-wait`.
- Portfolio prod Stage references `promote-via-pr` and is now auto-promoted (ProjectConfig `autoPromotionEnabled` for prod), so a stage-verified Freight opens the prod PR with no manual Kargo click. prod still only accepts Freight that passed the stage smoke test.
- Portfolio stage, both blog Stages, and `promote-to-argocd` are unchanged (still direct-push).
- Registered the new task in the kargo-projects kustomization.

## Prerequisite

The `mortennordbye-homelab-deployer` GitHub App needs Pull requests: read/write added (it currently has only Contents: read/write). `git-open-pr` fails without it. No new secret or repo change required.

## Verification

- `kustomize build k8s/talos/infra/kargo-projects` renders clean; confirmed only portfolio-prod uses `promote-via-pr` and portfolio-cd auto-promotes both stage and prod.
- End-to-end (post-merge, after the App permission is granted): push a portfolio change, confirm it auto-promotes to stage and passes the stage smoke test, confirm Kargo auto-opens a prod PR and the prod Stage sits in Promoting, merge the PR, confirm Argo syncs prod and the prod smoke test passes.