### PR TITLE
fix(kargo): skip PR steps on no-op portfolio prod promotion

### DIFF
--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
@@ -47,8 +47,15 @@ spec:
       config:
         path: ./repo
         generateTargetBranch: true
+    # The `if` guards make a no-op promotion (image tag unchanged, e.g. Kargo
+    # re-promoting a fresh Freight for the already-live version) skip cleanly
+    # instead of erroring: git-commit is skipped when there is nothing to commit,
+    # so git-push produces no branch, so there is nothing to open a PR for. On a
+    # real bump push.branch is set and both steps run. argocd-update/wait below
+    # stay unguarded so a no-op still ends green by confirming prod is Healthy.
     - uses: git-open-pr
       as: open-pr
+      if: ${{ (outputs?.push?.branch ?? '') != '' }}
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         provider: github
@@ -58,6 +65,7 @@ spec:
     # Blocks the promotion until the PR is merged in GitHub.
     - uses: git-wait-for-pr
       as: wait-pr
+      if: ${{ (outputs?.push?.branch ?? '') != '' }}
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         provider: github


### PR DESCRIPTION
## Why

The first live prod promotion errored at `git-open-pr` with `cannot fetch branch from <nil> | outputs.push.branch`. Kargo auto-promoted a fresh Freight for image `0.0.75`, which is already the tag deployed in prod. `kustomize-set-image` produced no diff, `git-commit` was skipped, `git-push` produced no branch, and `git-open-pr` failed on the empty `sourceBranch`. The direct-push task tolerates no-op promotions; the PR path did not.

## What

Guard `git-open-pr` and `git-wait-for-pr` in `promote-via-pr` with `if: ${{ (outputs?.push?.branch ?? '') != '' }}`. On a real tag bump `push.branch` is set and both run; on a no-op they skip and `argocd-update`/`argocd-wait` still confirm prod is Healthy, so the promotion ends green instead of errored.

## Verification

- `kustomize build k8s/talos/infra/kargo-projects` renders clean.
- After merge: Retry the errored prod promotion in Kargo; it should skip the PR steps and finish Succeeded. A genuine new portfolio build (new tag) should instead open the prod PR.