### PR TITLE
chore(portfolio): trigger build for Kargo PR-promotion pilot

### DIFF
--- a/portfolio/Dockerfile
+++ b/portfolio/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.25
 
+# Kargo PR-promotion pilot: trigger a build to exercise the stage -> prod PR flow.
+
 # ---- Stage 1: generate LaTeX sources from src/content ----
 # Runs scripts/build-cv.ts (TypeScript). Output goes into latex/.
 FROM node:24-alpine AS texgen


### PR DESCRIPTION
## Why

Trigger a real portfolio image build so the Kargo stage -> prod PR promotion flow runs end to end (the earlier run was a no-op re-promote of an already-live tag).

## What

One invisible comment line in `portfolio/Dockerfile`. No functional or visible change; it only produces a new image tag for the Warehouse to pick up.

## Verification

After merge: CI builds and pushes a new `0.0.<run>` tag; the portfolio Warehouse creates Freight; stage auto-promotes and passes its smoke test; Kargo auto-opens a prod PR; merging that PR deploys prod and runs the prod smoke test.