### PR TITLE
feat(kargo): PR-based prod promotion for blog + workflow name cleanup

### DIFF
--- a/.github/workflows/build-blog.yaml
+++ b/.github/workflows/build-blog.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy Blog
+name: Build Blog image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-portfolio.yaml
+++ b/.github/workflows/build-portfolio.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy Portfolio
+name: Build Portfolio image
 
 on:
   workflow_dispatch:

--- a/k8s/talos/infra/kargo-projects/blog.yaml
+++ b/k8s/talos/infra/kargo-projects/blog.yaml
@@ -22,8 +22,12 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 ---
-# Auto-promotion is a Project-level policy in Kargo (never on a Stage). Here we
-# auto-promote the `stage` Stage and leave `prod` as a deliberate manual step.
+# Auto-promotion is a Project-level policy in Kargo (never on a Stage). Both
+# Stages auto-promote: `stage` pushes the bump straight to main, and `prod` runs
+# promote-via-pr, which auto-opens a homelab PR and then blocks on the merge. So
+# the only human gate in the whole pipeline is approving that prod PR in GitHub;
+# there is no manual "promote" click in the Kargo UI. prod still only receives
+# Freight that passed the stage smoke test (see the Stage's sources.stages).
 apiVersion: kargo.akuity.io/v1alpha1
 kind: ProjectConfig
 metadata:
@@ -34,6 +38,8 @@ metadata:
 spec:
   promotionPolicies:
     - stage: stage
+      autoPromotionEnabled: true
+    - stage: prod
       autoPromotionEnabled: true
 ---
 # Git write credential for Kargo's git-push, using the existing GitHub App
@@ -210,9 +216,11 @@ spec:
             name: promote-to-argocd
             kind: ClusterPromotionTask
 ---
-# prod: receives only Freight already verified in `stage` (sources.stages). No
-# autoPromotionEnabled entry in ProjectConfig, so promotion here is a deliberate
-# manual action.
+# prod: receives only Freight already verified in `stage` (sources.stages).
+# Auto-promoted (see ProjectConfig), but through promote-via-pr: as soon as a
+# Freight passes the stage smoke test, Kargo auto-opens a homelab PR and waits.
+# The prod deploy happens when that PR is approved and merged in GitHub, so the
+# PR review is the prod gate. stage still uses the direct-push promote-to-argocd.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -246,5 +254,5 @@ spec:
           value: blog
       steps:
         - task:
-            name: promote-to-argocd
+            name: promote-via-pr
             kind: ClusterPromotionTask

--- a/portfolio/Dockerfile
+++ b/portfolio/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.25
 
-# Kargo PR-promotion pilot: verifying the stage -> prod PR flow end to end.
-
 # ---- Stage 1: generate LaTeX sources from src/content ----
 # Runs scripts/build-cv.ts (TypeScript). Output goes into latex/.
 FROM node:24-alpine AS texgen


### PR DESCRIPTION
## Why

Extend the portfolio PR-promotion pilot to blog, and tidy up two now-inaccurate names.

## What

- blog prod Stage now uses the `promote-via-pr` ClusterPromotionTask, and blog-cd auto-promotes prod (ProjectConfig). A stage-verified Freight auto-opens a homelab PR; merging it is the prod gate. blog stage still direct-pushes via `promote-to-argocd`. No new task or credential; reuses the shared `promote-via-pr` and the existing GitHub App.
- Rename `Build and Deploy Portfolio` / `Build and Deploy Blog` workflows to `Build Portfolio image` / `Build Blog image`, since Kargo owns the deploy now and these only build and push.
- Remove the leftover pilot trigger comment from `portfolio/Dockerfile`.

## Verification

`kustomize build k8s/talos/infra/kargo-projects` renders clean; blog prod references `promote-via-pr`. Merging retriggers a portfolio build (Dockerfile touched), which should open a portfolio prod PR via the same flow; blog picks up the PR flow on its next `blog/**` build.