### PR TITLE
feat(kargo): onboard logeverylift (single-env, PR-based prod)

### DIFF
--- a/k8s/talos/apps/logeverylift/kustomization.yaml
+++ b/k8s/talos/apps/logeverylift/kustomization.yaml
@@ -11,3 +11,9 @@ resources:
   - app.yaml
   - httproute.yaml
   - ciliumnetworkpolicy.yaml
+
+# newTag via the kustomize-set-image promotion step (Kargo). Overrides the inline
+# tag in app.yaml; the logeverylift-cd Warehouse/promotion rewrites it to 0.0.N.
+images:
+  - name: ghcr.io/mortennordbye/logeverylift
+    newTag: sha-43378df

--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -58,7 +58,7 @@ spec:
   # non-Kargo app matches nothing and renders no patch.
   templatePatch: |
     {{- $base := .path.basename }}
-    {{- range $app := list "portfolio" "blog" }}
+    {{- range $app := list "portfolio" "blog" "logeverylift" }}
     {{- if eq $base $app }}
     metadata:
       annotations:

--- a/k8s/talos/infra/kargo-projects/kustomization.yaml
+++ b/k8s/talos/infra/kargo-projects/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - clusterpromotiontask-pr.yaml
   - portfolio.yaml
   - blog.yaml
+  - logeverylift.yaml

--- a/k8s/talos/infra/kargo-projects/logeverylift.yaml
+++ b/k8s/talos/infra/kargo-projects/logeverylift.yaml
@@ -1,0 +1,186 @@
+# Kargo project for the logeverylift app. Unlike portfolio/blog this app is
+# single-environment (no stage overlay): one Warehouse feeds one `prod` Stage
+# directly, auto-promoted through promote-via-pr. Flow: logeverylift CI pushes a
+# new image -> Warehouse creates Freight -> Kargo auto-opens a homelab PR ->
+# merging it deploys prod -> the smoke test verifies. The image source and CI
+# live in the separate mortennordbye/logeverylift repo; only the deploy manifests
+# and this pipeline live here.
+
+# --- Project namespace ------------------------------------------------------
+# Named `logeverylift-cd` (not `logeverylift`) to avoid colliding with the app
+# namespace. The label lets the Project adopt this pre-created namespace instead
+# of racing to create it, keeping Argo CD sync ordering clean.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logeverylift-cd
+  labels:
+    kargo.akuity.io/project: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: logeverylift-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+---
+# Single Stage, so the whole pipeline is one auto-promotion: a new Freight is
+# auto-promoted to `prod` via promote-via-pr, which opens a homelab PR and blocks
+# on the merge. Merging the PR in GitHub is the only human gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: logeverylift-cd
+  namespace: logeverylift-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  promotionPolicies:
+    - stage: prod
+      autoPromotionEnabled: true
+---
+# Git write credential for Kargo's git-push/PR, using the existing GitHub App
+# `mortennordbye-homelab-deployer`. Same App and Bitwarden keys as portfolio-cd
+# and blog-cd; only the namespace differs (Kargo cred lookup is per-Project). The
+# App needs Contents + Pull requests read/write (promote-via-pr opens a PR).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kargo-git-homelab
+  namespace: logeverylift-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: kargo-git-homelab
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git
+      data:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        githubAppClientID: "{{ .githubAppClientID }}"
+        githubAppInstallationID: "{{ .githubAppInstallationID }}"
+        githubAppPrivateKey: "{{ .githubAppPrivateKey }}"
+  data:
+    - secretKey: githubAppClientID
+      remoteRef:
+        key: "a6b2b4ea-fa97-4d5c-bd74-b489010c5fab"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppInstallationID
+      remoteRef:
+        key: "aabab894-a09a-415c-ba17-b489010c8df5"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppPrivateKey
+      remoteRef:
+        key: "fc775dd0-1b67-4dfa-b2e9-b489010d0359"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: logeverylift
+  namespace: logeverylift-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
+  interval: 5m0s
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/mortennordbye/logeverylift
+        # logeverylift CI tags every build 0.0.<run_number>; SemVer picks the
+        # greatest. strictSemvers keeps the git-SHA/latest tags out of selection.
+        # No eligible Freight exists until the first build after the CI change
+        # lands a 0.0.<run> tag (the current images are only sha-/latest tagged).
+        imageSelectionStrategy: SemVer
+        strictSemvers: true
+        discoveryLimit: 20
+---
+# prod verification: a one-shot Job that curls the app URL and fails on any
+# non-2xx. logeverylift is on the private gateway with an internal cert, so use
+# the internal hostname and -k. No KEDA (stays warm); the retries cover the
+# rolling pod from the deploy the promotion just triggered.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: logeverylift-prod-smoke
+  namespace: logeverylift-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: logeverylift-prod-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsSk --retry 10 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://logeverylift.local.bigd.no/
+---
+# prod: the only Stage. Receives Freight straight from the Warehouse
+# (sources.direct), auto-promoted per ProjectConfig through promote-via-pr, then
+# verified by the smoke test. promote-via-pr opens a homelab PR and waits for the
+# merge, so the PR review is the deploy gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: logeverylift-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    # Cosmetic UI colour, kept identical across apps: prod = red.
+    kargo.akuity.io/color: "#e11d48"
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse via a homelab PR; smoke-tested on logeverylift.local.bigd.no after merge."
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: logeverylift
+      sources:
+        direct: true
+  verification:
+    analysisTemplates:
+      - name: logeverylift-prod-smoke
+  promotionTemplate:
+    spec:
+      vars:
+        - name: appName
+          value: logeverylift
+        - name: appPath
+          value: k8s/talos/apps/logeverylift
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/logeverylift
+        - name: argocdApp
+          value: logeverylift
+      steps:
+        - task:
+            name: promote-via-pr
+            kind: ClusterPromotionTask


### PR DESCRIPTION
## Why

Bring logeverylift onto the same PR-gated Kargo promotion as portfolio/blog. logeverylift is single-environment, so the whole pipeline is one auto-promotion: a new image is detected by Kargo, which opens a homelab PR; merging it deploys prod and runs the smoke test.

## What

- New `kargo-projects/logeverylift.yaml`: project `logeverylift-cd`, one Warehouse (SemVer on `0.0.<run>` tags), one auto-promoted `prod` Stage using `promote-via-pr`, one smoke AnalysisTemplate against `logeverylift.local.bigd.no` (private gateway, `-k`). Reuses the shared task and GitHub App.
- Register it in the kargo-projects kustomization; add `logeverylift` to the apps.yaml authorized-stage list (`logeverylift-cd:prod`).
- Add an `images:` block to the logeverylift app kustomization so `kustomize-set-image` can rewrite the tag.

## Pairing

Needs the logeverylift repo CI change (separate PR): add a `0.0.${{ github.run_number }}` tag and remove the `deploy:` job that self-opens homelab PRs. Until a `0.0.<run>` tag exists the Warehouse has no Freight and this is inert, so merge order is safe.

## Verification

`kustomize build k8s/talos/infra/kargo-projects` and `.../apps/logeverylift` render clean; logeverylift-cd's prod Stage references `promote-via-pr`. End to end after both merge: a logeverylift build lands a `0.0.<run>` tag, Kargo opens a prod PR, merging it deploys and the smoke test passes.