### PR TITLE
feat(kargo): onboard headroom (single-env, PR-based prod)

### DIFF
--- a/k8s/talos/apps/headroom/kustomization.yaml
+++ b/k8s/talos/apps/headroom/kustomization.yaml
@@ -12,3 +12,9 @@ resources:
   - service.yaml
   - ciliumnetworkpolicy.yaml
   - scaledobject.yaml
+
+# newTag via the kustomize-set-image promotion step (Kargo). Overrides the inline
+# tag in deployment.yaml; the headroom-cd Warehouse/promotion rewrites it to 0.0.N.
+images:
+  - name: ghcr.io/mortennordbye/headroom
+    newTag: sha-32a1389

--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -58,7 +58,7 @@ spec:
   # non-Kargo app matches nothing and renders no patch.
   templatePatch: |
     {{- $base := .path.basename }}
-    {{- range $app := list "portfolio" "blog" "logeverylift" }}
+    {{- range $app := list "portfolio" "blog" "logeverylift" "headroom" }}
     {{- if eq $base $app }}
     metadata:
       annotations:

--- a/k8s/talos/infra/kargo-projects/headroom.yaml
+++ b/k8s/talos/infra/kargo-projects/headroom.yaml
@@ -1,0 +1,180 @@
+# Kargo project for the headroom app. Single-environment (no stage overlay), so
+# the whole pipeline is one auto-promotion: the headroom CI pushes a new image ->
+# Warehouse creates Freight -> Kargo auto-opens a homelab PR -> merging it deploys
+# prod -> the smoke test verifies. Mirrors logeverylift.yaml. The image source and
+# CI live in the separate mortennordbye/headroom repo.
+
+# --- Project namespace ------------------------------------------------------
+# Named `headroom-cd` (not `headroom`) to avoid colliding with the app namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headroom-cd
+  labels:
+    kargo.akuity.io/project: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+---
+# Single Stage: a new Freight is auto-promoted to `prod` via promote-via-pr, which
+# opens a homelab PR and blocks on the merge. Merging the PR is the only gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: headroom-cd
+  namespace: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  promotionPolicies:
+    - stage: prod
+      autoPromotionEnabled: true
+---
+# Git write credential for Kargo's git-push/PR, using the existing GitHub App
+# `mortennordbye-homelab-deployer`. Same App and Bitwarden keys as the other
+# projects; only the namespace differs (Kargo cred lookup is per-Project).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kargo-git-homelab
+  namespace: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: kargo-git-homelab
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git
+      data:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        githubAppClientID: "{{ .githubAppClientID }}"
+        githubAppInstallationID: "{{ .githubAppInstallationID }}"
+        githubAppPrivateKey: "{{ .githubAppPrivateKey }}"
+  data:
+    - secretKey: githubAppClientID
+      remoteRef:
+        key: "a6b2b4ea-fa97-4d5c-bd74-b489010c5fab"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppInstallationID
+      remoteRef:
+        key: "aabab894-a09a-415c-ba17-b489010c8df5"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppPrivateKey
+      remoteRef:
+        key: "fc775dd0-1b67-4dfa-b2e9-b489010d0359"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: headroom
+  namespace: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
+  interval: 5m0s
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/mortennordbye/headroom
+        # headroom CI tags every build 0.0.<run_number>; SemVer picks the
+        # greatest. strictSemvers keeps the git-SHA/latest tags out of selection.
+        # No eligible Freight exists until the first build after the CI change
+        # lands a 0.0.<run> tag (the current images are only sha-/latest tagged).
+        imageSelectionStrategy: SemVer
+        strictSemvers: true
+        discoveryLimit: 20
+---
+# prod verification: a one-shot Job that curls the app URL and fails on any
+# non-2xx. headroom is on the private gateway with an internal cert, so use the
+# internal hostname and -k. headroom scales to zero (KEDA), so the request also
+# wakes it; the higher retry count covers the cold start.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: headroom-prod-smoke
+  namespace: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: headroom-prod-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsSk --retry 15 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://headroom.local.bigd.no/
+---
+# prod: the only Stage. Receives Freight straight from the Warehouse
+# (sources.direct), auto-promoted per ProjectConfig through promote-via-pr, then
+# verified by the smoke test. promote-via-pr opens a homelab PR and waits for the
+# merge, so the PR review is the deploy gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    # Cosmetic UI colour, kept identical across apps: prod = red.
+    kargo.akuity.io/color: "#e11d48"
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse via a homelab PR; smoke-tested on headroom.local.bigd.no after merge."
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: headroom
+      sources:
+        direct: true
+  verification:
+    analysisTemplates:
+      - name: headroom-prod-smoke
+  promotionTemplate:
+    spec:
+      vars:
+        - name: appName
+          value: headroom
+        - name: appPath
+          value: k8s/talos/apps/headroom
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/headroom
+        - name: argocdApp
+          value: headroom
+      steps:
+        - task:
+            name: promote-via-pr
+            kind: ClusterPromotionTask

--- a/k8s/talos/infra/kargo-projects/kustomization.yaml
+++ b/k8s/talos/infra/kargo-projects/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - portfolio.yaml
   - blog.yaml
   - logeverylift.yaml
+  - headroom.yaml


### PR DESCRIPTION
## Why

Bring headroom onto the same PR-gated Kargo promotion as logeverylift (single-environment): a new image is detected by Kargo, which opens a homelab PR; merging it deploys prod and runs the smoke test.

## What

- New `kargo-projects/headroom.yaml`: project `headroom-cd`, one Warehouse (SemVer on `0.0.<run>` tags), one auto-promoted `prod` Stage using `promote-via-pr`, one smoke AnalysisTemplate against `headroom.local.bigd.no` (private gateway, `-k`, extra retries for KEDA cold start). Reuses the shared task and GitHub App.
- Register it in the kargo-projects kustomization; add `headroom` to the apps.yaml authorized-stage list (`headroom-cd:prod`).
- Add an `images:` block to the headroom app kustomization so `kustomize-set-image` can rewrite the tag.

## Pairing

Needs the headroom repo CI change (separate PR): add a `0.0.${{ github.run_number }}` tag and remove the `deploy:` job. Inert until a `0.0.<run>` tag exists, so merge order is safe.

## Verification

`kustomize build` of kargo-projects and the headroom app render clean; headroom-cd's prod Stage references `promote-via-pr`. End to end after both merge: a headroom build lands a `0.0.<run>` tag, Kargo opens a prod PR, merging it deploys.