### PR TITLE
feat(verksted): deploy app + Kargo project (single-env, PR-based prod)

### DIFF
--- a/k8s/talos/apps/verksted/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/verksted/ciliumnetworkpolicy.yaml
@@ -1,0 +1,26 @@
+# Ingress-only policy: lock inbound to the private gateway, leave egress open.
+# verksted legitimately needs broad egress — agent sessions clone repos, hit
+# package registries and LLM APIs, and the dind sidecar pulls images. Cilium only
+# default-denies a direction once a rule for that direction exists, so declaring
+# no egress rule keeps egress unrestricted (matches the other apps here).
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: verksted-app-policy
+  namespace: verksted
+spec:
+  endpointSelector:
+    matchLabels:
+      app: verksted-app
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": traefik
+            "k8s:app.kubernetes.io/instance": traefik-traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - health

--- a/k8s/talos/apps/verksted/data-pvc.yaml
+++ b/k8s/talos/apps/verksted/data-pvc.yaml
@@ -1,0 +1,18 @@
+# Persistent /data: agent repos, session state, per-agent HOME (logins/configs),
+# and settings.json. On Synology NFS so it survives node moves and is easy to
+# back up / inspect. ReadWriteOnce is fine — a single verksted pod owns it (the
+# Deployment uses Recreate, so no two pods contend for the mount).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: verksted-data
+  namespace: verksted
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: syno-nfs-csi
+  resources:
+    requests:
+      storage: 20Gi

--- a/k8s/talos/apps/verksted/deployment.yaml
+++ b/k8s/talos/apps/verksted/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verksted-app
+  namespace: verksted
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  replicas: 1
+  # Single stateful pod on a ReadWriteOnce PVC: never run two at once (the second
+  # could not mount /data), so replace rather than roll.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: verksted-app
+  template:
+    metadata:
+      labels:
+        app: verksted-app
+    spec:
+      containers:
+        - name: verksted
+          image: ghcr.io/mortennordbye/verksted:0.0.7
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            # Agent sessions run docker against the dind sidecar over the shared
+            # pod network (plain tcp, no TLS — pod-local only).
+            - name: DOCKER_HOST
+              value: tcp://localhost:2375
+            # Deep-link base for ntfy pushes back into a waiting session.
+            - name: PUBLIC_URL
+              value: https://verksted.local.bigd.no
+            # Persist settings on the PVC (agent env vars set via the UI).
+            - name: SETTINGS_FILE
+              value: /data/settings.json
+          # The backend serves the built SPA at / — a plain 200 once it is up.
+          # Agent auth (claude/codex/agy tokens) is configured interactively in
+          # the pod terminal afterwards and persists under HOME=/data/home.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+        # Docker daemon for the agent sessions. Privileged is inherent to dind;
+        # shares the pod netns so the app reaches it at localhost:2375.
+        - name: dind
+          image: docker:28-dind
+          args:
+            - --host=tcp://127.0.0.1:2375
+          env:
+            # Plain tcp on 2375, pod-local only — no TLS cert dance.
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          volumeMounts:
+            # Ephemeral image/layer store; rebuilt after a restart. maintenance.ts
+            # prunes it daily. Kept off the NFS PVC (overlayfs needs local disk).
+            - name: dind-storage
+              mountPath: /var/lib/docker
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: verksted-data
+        - name: dind-storage
+          emptyDir: {}

--- a/k8s/talos/apps/verksted/httproute.yaml
+++ b/k8s/talos/apps/verksted/httproute.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: verksted
+  namespace: verksted
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-private
+      namespace: traefik
+  hostnames:
+    - "verksted.local.bigd.no"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: verksted-app
+          port: 8080
+          weight: 1

--- a/k8s/talos/apps/verksted/kustomization.yaml
+++ b/k8s/talos/apps/verksted/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "0"
+
+resources:
+  - namespace.yaml
+  - data-pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - ciliumnetworkpolicy.yaml
+
+# newTag via the kustomize-set-image promotion step (Kargo). Overrides the inline
+# tag in deployment.yaml; the verksted-cd Warehouse/promotion rewrites it to 0.0.N.
+images:
+  - name: ghcr.io/mortennordbye/verksted
+    newTag: 0.0.7

--- a/k8s/talos/apps/verksted/namespace.yaml
+++ b/k8s/talos/apps/verksted/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: verksted
+  # verksted runs a privileged docker:dind sidecar (see deployment.yaml), so the
+  # namespace must allow privileged Pods. This is the accepted tradeoff for giving
+  # agent sessions a real Docker daemon; Falco will flag the privileged container.
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"

--- a/k8s/talos/apps/verksted/service.yaml
+++ b/k8s/talos/apps/verksted/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: verksted-app
+  namespace: verksted
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  selector:
+    app: verksted-app
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -58,7 +58,7 @@ spec:
   # non-Kargo app matches nothing and renders no patch.
   templatePatch: |
     {{- $base := .path.basename }}
-    {{- range $app := list "portfolio" "blog" "logeverylift" "headroom" }}
+    {{- range $app := list "portfolio" "blog" "logeverylift" "headroom" "verksted" }}
     {{- if eq $base $app }}
     metadata:
       annotations:

--- a/k8s/talos/infra/kargo-projects/kustomization.yaml
+++ b/k8s/talos/infra/kargo-projects/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - blog.yaml
   - logeverylift.yaml
   - headroom.yaml
+  - verksted.yaml

--- a/k8s/talos/infra/kargo-projects/verksted.yaml
+++ b/k8s/talos/infra/kargo-projects/verksted.yaml
@@ -1,0 +1,178 @@
+# Kargo project for the verksted app. Single-environment (no stage overlay), so
+# the whole pipeline is one auto-promotion: the verksted CI pushes a new image ->
+# Warehouse creates Freight -> Kargo auto-opens a homelab PR -> merging it deploys
+# prod -> the smoke test verifies. Mirrors logeverylift.yaml/headroom.yaml. The
+# image source and CI live in the separate mortennordbye/verksted repo.
+
+# --- Project namespace ------------------------------------------------------
+# Named `verksted-cd` (not `verksted`) to avoid colliding with the app namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: verksted-cd
+  labels:
+    kargo.akuity.io/project: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: verksted-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+---
+# Single Stage: a new Freight is auto-promoted to `prod` via promote-via-pr, which
+# opens a homelab PR and blocks on the merge. Merging the PR is the only gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: verksted-cd
+  namespace: verksted-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  promotionPolicies:
+    - stage: prod
+      autoPromotionEnabled: true
+---
+# Git write credential for Kargo's git-push/PR, using the existing GitHub App
+# `mortennordbye-homelab-deployer`. Same App and Bitwarden keys as the other
+# projects; only the namespace differs (Kargo cred lookup is per-Project).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kargo-git-homelab
+  namespace: verksted-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: kargo-git-homelab
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git
+      data:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        githubAppClientID: "{{ .githubAppClientID }}"
+        githubAppInstallationID: "{{ .githubAppInstallationID }}"
+        githubAppPrivateKey: "{{ .githubAppPrivateKey }}"
+  data:
+    - secretKey: githubAppClientID
+      remoteRef:
+        key: "a6b2b4ea-fa97-4d5c-bd74-b489010c5fab"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppInstallationID
+      remoteRef:
+        key: "aabab894-a09a-415c-ba17-b489010c8df5"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppPrivateKey
+      remoteRef:
+        key: "fc775dd0-1b67-4dfa-b2e9-b489010d0359"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: verksted
+  namespace: verksted-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
+  interval: 5m0s
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/mortennordbye/verksted
+        # verksted CI tags every build 0.0.<run_number>; SemVer picks the
+        # greatest. strictSemvers keeps the git-SHA/latest tags out of selection.
+        imageSelectionStrategy: SemVer
+        strictSemvers: true
+        discoveryLimit: 20
+---
+# prod verification: a one-shot Job that curls the app URL and fails on any
+# non-2xx. verksted is on the private gateway with an internal cert, so use the
+# internal hostname and -k. argocd-wait has already confirmed the pod Healthy
+# (readiness probe on /), so the retries just cover the brief window after roll.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: verksted-prod-smoke
+  namespace: verksted-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: verksted-prod-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsSk --retry 10 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://verksted.local.bigd.no/
+---
+# prod: the only Stage. Receives Freight straight from the Warehouse
+# (sources.direct), auto-promoted per ProjectConfig through promote-via-pr, then
+# verified by the smoke test. promote-via-pr opens a homelab PR and waits for the
+# merge, so the PR review is the deploy gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: verksted-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    # Cosmetic UI colour, kept identical across apps: prod = red.
+    kargo.akuity.io/color: "#e11d48"
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse via a homelab PR; smoke-tested on verksted.local.bigd.no after merge."
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: verksted
+      sources:
+        direct: true
+  verification:
+    analysisTemplates:
+      - name: verksted-prod-smoke
+  promotionTemplate:
+    spec:
+      vars:
+        - name: appName
+          value: verksted
+        - name: appPath
+          value: k8s/talos/apps/verksted
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/verksted
+        - name: argocdApp
+          value: verksted
+      steps:
+        - task:
+            name: promote-via-pr
+            kind: ClusterPromotionTask


### PR DESCRIPTION
## Why

Onboard verksted (a self-hosted agent workspace) into the cluster on the private gateway at `verksted.local.bigd.no`, on the same PR-gated Kargo promotion as logeverylift/headroom. Brand-new app — no manifests existed here.

## What

App (`k8s/talos/apps/verksted/`):
- Deployment: backend serves the built SPA on `:8080`, `Recreate` strategy, readiness/liveness on `/`.
- **Privileged `docker:dind` sidecar** for agent sessions' Docker (accepted tradeoff, per verksted's BACKLOG). Namespace is labelled `pod-security: privileged`.
- 20Gi Synology-NFS `/data` PVC (repos, sessions, agent homes, `settings.json`).
- Service, HTTPRoute (private gateway), ingress-only CiliumNetworkPolicy (egress open — agents need the internet).

Kargo (`kargo-projects/verksted.yaml`): single-env `verksted-cd`, one Warehouse (SemVer `0.0.<run>`), one auto-promoted `prod` Stage via `promote-via-pr`, smoke test on `verksted.local.bigd.no`. Registered + authorized (`verksted-cd:prod`). Image pinned to `0.0.7`; Kargo rewrites on the next build.

Paired verksted-repo changes already merged: `0.0.<run>` image tag, and ripgrep installed in the CI test job (its file-search tests shell out to `rg`; that had left verksted CI red on main since Jul 13).

## Review notes

- **Privileged container:** the dind sidecar runs privileged. Falco will flag it; may need a tuned rule.
- **No secrets in this PR:** agent auth (claude/codex/agy tokens, `gh`) is configured interactively in the pod terminal after deploy and persists on the `/data` PVC (per verksted's `.env.example`). An ExternalSecret can be added later if you want ESO-managed tokens.
- **Resources** (cpu/mem requests/limits) and the 20Gi PVC size are starting points — tune to the cluster.
- **Smoke test** will be red until the temporary `*.local.bigd.no` in-cluster DNS is fixed (same as logeverylift/headroom); the deploy itself is unaffected.

## Verification

`kustomize build` of `k8s/talos/apps/verksted` and `k8s/talos/infra/kargo-projects` render clean; `verksted-cd` prod Stage references `promote-via-pr`. verksted CI is green and pushed `0.0.7`. Left unmerged for your review since it deploys a privileged workload.