### PR TITLE
fix(kargo): set API host so promotion-PR links point at the real UI

### DIFF
--- a/k8s/talos/infra/kargo/values.yaml
+++ b/k8s/talos/infra/kargo/values.yaml
@@ -5,11 +5,19 @@
 api:
   secret:
     name: kargo-api
+  # Where the UI/API is actually reached. Kargo builds the "View in Kargo UI"
+  # link in every promotion PR body from this host; unset it defaults to
+  # `localhost` and the PR links point nowhere.
+  host: kargo.local.bigd.no
   # The API is fronted by the Traefik private gateway, which terminates TLS for
   # *.local.bigd.no. Serve plain HTTP in-pod so the gateway can route to it
-  # (kargo-api Service becomes port 80 instead of 443).
+  # (kargo-api Service becomes port 80 instead of 443). terminatedUpstream forces
+  # the generated URLs to https (the gateway serves https) even though the pod
+  # itself listens on plain HTTP — it is the one tls.* field honoured when
+  # enabled is false.
   tls:
     enabled: false
+    terminatedUpstream: true
   # Homelab: admin-account login only for now, bundled Dex OIDC disabled.
   oidc:
     dex:


### PR DESCRIPTION
## Why

The "View in Kargo UI" link Kargo adds to every promotion PR body pointed at `http://localhost/project/<app>-cd/stage/prod`. Kargo builds that link from `api.host`, which was unset and defaults to `localhost`.

## What

- Set `api.host: kargo.local.bigd.no`.
- Set `api.tls.terminatedUpstream: true` so generated URLs use `https` (the private gateway serves https while the pod keeps serving plain HTTP; `terminatedUpstream` is the one `tls.*` field honoured when `tls.enabled: false`).

Affects every app's promotion PRs (portfolio, blog, logeverylift, headroom, verksted).

## Verification

`helm template` with the new values renders `API_SERVER_BASE_URL: https://kargo.local.bigd.no` (was `https://localhost`). Syncing restarts the kargo-api pod (brief UI blip).