### PR TITLE
fix(verksted): let dind bind its own default 2375 listener

### DIFF
--- a/k8s/talos/apps/verksted/deployment.yaml
+++ b/k8s/talos/apps/verksted/deployment.yaml
@@ -66,8 +66,11 @@ spec:
         # shares the pod netns so the app reaches it at localhost:2375.
         - name: dind
           image: docker:28-dind
-          args:
-            - --host=tcp://127.0.0.1:2375
+          # No explicit --host: with TLS off the dind entrypoint already binds a
+          # single tcp://0.0.0.0:2375 listener. Adding our own -H on 2375 made two
+          # listeners on the same port and dind crash-looped ("port is already
+          # allocated"). 0.0.0.0 is safe here — the CiliumNetworkPolicy blocks
+          # 2375 from other pods, and the app reaches it over loopback.
           env:
             # Plain tcp on 2375, pod-local only — no TLS cert dance.
             - name: DOCKER_TLS_CERTDIR


### PR DESCRIPTION
## Why

verksted's dind sidecar crash-looped (`failed to allocate daemon listening port 2375 ... port is already allocated`). The `docker:dind` entrypoint already binds `tcp://0.0.0.0:2375` when TLS is off; the explicit `--host=tcp://127.0.0.1:2375` arg added a second listener on the same port. The verksted container itself was healthy.

## What

Remove the `--host` arg from the dind sidecar. The entrypoint binds a single `0.0.0.0:2375` listener; the app reaches it over loopback, and the CiliumNetworkPolicy already blocks 2375 from other pods.

## Verification

`kustomize build` renders clean. After sync the pod should reach 2/2 Ready.