### PR TITLE
feat(alerts): critical PodCrashLooping alert

### DIFF
--- a/k8s/talos/infra/kube-prometheus-stack/homelab-alerts.yaml
+++ b/k8s/talos/infra/kube-prometheus-stack/homelab-alerts.yaml
@@ -43,6 +43,25 @@ spec:
               Deployment `{{ $labels.namespace }}/{{ $labels.deployment }}` wants >0 replicas but has 0 available for over 5 minutes.
               Check: kubectl -n {{ $labels.namespace }} describe deploy {{ $labels.deployment }}
 
+        # A container stuck in CrashLoopBackOff for 10 min. Unlike DeploymentUnavailable
+        # (which needs 0 available replicas), this fires even when a rolling update
+        # keeps the old pod serving while the NEW revision crash-loops — e.g. a bad
+        # image promoted to prod (the Kargo case: the app looks "up" but main is
+        # pinned to a broken tag). Critical so it routes to Discord. max_over_time
+        # smooths the brief gaps while the kubelet is mid-restart-attempt (the
+        # waiting reason clears during the run); a single crash that recovers keeps
+        # the expr true for only ~5 min and never reaches `for: 10m`, so no false page.
+        - alert: PodCrashLooping
+          expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"}[5m]) == 1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container }} crash-looping'
+            description: |
+              Container `{{ $labels.container }}` in pod `{{ $labels.namespace }}/{{ $labels.pod }}` has been in CrashLoopBackOff for over 10 minutes. A rolling update may be masking this (an old pod still serving) — the new revision is broken.
+              Check: kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }} -c {{ $labels.container }} --previous
+
         # Any container whose last termination was OOMKilled within the last 10 min.
         # last_terminated_reason is a persistent gauge (stays 1 forever after an OOM),
         # so we AND it with a recency check on last_terminated_timestamp to ensure the

--- a/k8s/talos/infra/kube-prometheus-stack/tests/pod-crashlooping.yaml
+++ b/k8s/talos/infra/kube-prometheus-stack/tests/pod-crashlooping.yaml
@@ -1,0 +1,38 @@
+# Triggers: PodCrashLooping
+#
+# Container exits immediately on start, so the kubelet backs off and the pod
+# enters CrashLoopBackOff within a minute. The alert requires the CrashLoopBackOff
+# waiting reason to persist for `for: 10m` (max_over_time[5m] smooths the restart
+# attempts), so a single transient crash would NOT fire — only a stuck one.
+#
+# Expected timeline:
+#   t≈0       pod starts, container exits 1
+#   t≈1min    repeated fast failures → CrashLoopBackOff
+#   t≈10min   `for: 10m` elapsed → firing → Discord (critical route, group_wait: 30s)
+#
+# Note: this crashes outright (no old ReplicaSet), so DeploymentUnavailable also
+# fires. The point of PodCrashLooping is the case where a rolling update keeps an
+# old pod serving — which DeploymentUnavailable misses — so verify this one on its
+# own by watching the alert in Alertmanager, not just that Discord pinged.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alert-test-crashloop
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: homelab-alert-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alert-test-crashloop
+  template:
+    metadata:
+      labels:
+        app: alert-test-crashloop
+        app.kubernetes.io/managed-by: homelab-alert-test
+    spec:
+      containers:
+        - name: crash
+          image: busybox:1.37.0
+          command: ["sh", "-c", "echo starting; exit 1"]


### PR DESCRIPTION
## Why

A broken image promoted to prod (headroom `0.0.225`, missing module) crash-looped but sent nothing to Discord: the crashloop-adjacent rules (`ContainerRestartingFrequently`, `ArgoCDAppDegraded`) are `warning`, and Alertmanager routes only `critical` to Discord. `DeploymentUnavailable` is `critical` but needs 0 available replicas — the rolling update kept the old `0.0.223` pod serving, so it never fired.

## What

Add a `critical` `PodCrashLooping` alert: a container in `CrashLoopBackOff` sustained for 10 minutes. Uses `max_over_time(...[5m])` to smooth restart attempts and `for: 10m` so a single transient crash doesn't page. Critical → routes through the existing Discord path, no new webhook. Plus a live-fire `tests/pod-crashlooping.yaml`.

This catches the "new revision broken, old pod masks it" case the other rules miss.

## Verification

Rule YAML parses. `tests/` is not in the kustomization (manual-apply only). To live-fire: `kubectl apply -f tests/pod-crashlooping.yaml`, watch it fire in Alertmanager after ~10m, then delete.