### PR TITLE
Deploy Mealie recipe manager

### DIFF
--- a/k8s/talos/apps/mealie/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/mealie/ciliumnetworkpolicy.yaml
@@ -1,0 +1,30 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: mealie-policy
+  namespace: mealie
+spec:
+  endpointSelector:
+    matchLabels:
+      app: mealie
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": traefik
+            "k8s:app.kubernetes.io/instance": traefik-traefik
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": keda
+            "k8s:app.kubernetes.io/component": interceptor
+            "k8s:app.kubernetes.io/part-of": keda-add-ons-http
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - health

--- a/k8s/talos/apps/mealie/data-pvc.yaml
+++ b/k8s/talos/apps/mealie/data-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-pvc
+  namespace: mealie
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: syno-nfs-csi
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/talos/apps/mealie/deployment.yaml
+++ b/k8s/talos/apps/mealie/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mealie
+  namespace: mealie
+  labels:
+    app: mealie
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: mealie
+  template:
+    metadata:
+      labels:
+        app: mealie
+    spec:
+      securityContext:
+        fsGroup: 911
+      containers:
+        - name: mealie
+          image: ghcr.io/mealie-recipes/mealie:v3.20.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9000
+          securityContext:
+            runAsUser: 911
+            runAsGroup: 911
+          env:
+            - name: PUID
+              value: "911"
+            - name: PGID
+              value: "911"
+            - name: TZ
+              value: Europe/Oslo
+            - name: BASE_URL
+              value: https://mealie.bigd.no
+            - name: DB_ENGINE
+              value: sqlite
+            - name: ALLOW_SIGNUP
+              value: "false"
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            periodSeconds: 20
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: data-pvc

--- a/k8s/talos/apps/mealie/httproute.yaml
+++ b/k8s/talos/apps/mealie/httproute.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mealie
+  namespace: mealie
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-public
+      namespace: traefik
+  hostnames:
+    - mealie.bigd.no
+  rules:
+    - backendRefs:
+        # Route through the KEDA HTTP interceptor so mealie wakes from zero.
+        - group: ""
+          kind: Service
+          name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
+          port: 8080
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/k8s/talos/apps/mealie/interceptorroute.yaml
+++ b/k8s/talos/apps/mealie/interceptorroute.yaml
@@ -1,0 +1,15 @@
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: mealie
+  namespace: mealie
+spec:
+  target:
+    service: mealie-service
+    port: 9000
+  rules:
+    - hosts:
+        - mealie.bigd.no
+  scalingMetric:
+    concurrency:
+      targetValue: 100

--- a/k8s/talos/apps/mealie/kustomization.yaml
+++ b/k8s/talos/apps/mealie/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "0"
+
+resources:
+  - namespace.yaml
+  - data-pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - ciliumnetworkpolicy.yaml
+  - interceptorroute.yaml
+  - scaledobject.yaml

--- a/k8s/talos/apps/mealie/namespace.yaml
+++ b/k8s/talos/apps/mealie/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mealie

--- a/k8s/talos/apps/mealie/scaledobject.yaml
+++ b/k8s/talos/apps/mealie/scaledobject.yaml
@@ -1,0 +1,16 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: mealie
+  namespace: mealie
+spec:
+  scaleTargetRef:
+    name: mealie
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  cooldownPeriod: 300
+  triggers:
+    - type: external-push
+      metadata:
+        scalerAddress: keda-add-ons-http-external-scaler.keda:9090
+        interceptorRoute: mealie

--- a/k8s/talos/apps/mealie/service.yaml
+++ b/k8s/talos/apps/mealie/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mealie-service
+  namespace: mealie
+spec:
+  selector:
+    app: mealie
+  ports:
+    - protocol: TCP
+      port: 9000
+      targetPort: 9000


### PR DESCRIPTION
## Why
Add Mealie (self-hosted recipe manager) to the cluster.

## What
New app under `k8s/talos/apps/mealie/`, auto-discovered by the apps ApplicationSet:
- Mealie v3.20.1, SQLite, 10Gi PVC on syno-nfs-csi
- Exposed at mealie.bigd.no via Traefik + KEDA scale-to-zero

## Verification
- `kubectl kustomize` builds clean
- syno-nfs-csi, traefik-gateway-public, and KEDA interceptor confirmed present in-cluster