### PR TITLE
Grant mealie HTTPRoute ref to keda interceptor

### DIFF
--- a/k8s/talos/infra/keda-http-add-on/referencegrant.yaml
+++ b/k8s/talos/infra/keda-http-add-on/referencegrant.yaml
@@ -29,6 +29,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: gastam
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: mealie
   to:
     - group: ""
       kind: Service


### PR DESCRIPTION
## Why
The mealie HTTPRoute (merged in #366) is Degraded: `missing ReferenceGrant` for its cross-namespace backendRef to the keda interceptor Service.

## What
Add `mealie` to the app-httproutes-to-interceptor ReferenceGrant in the keda namespace.

## Verification
Matches the existing pattern for audiobookshelf/it-tools; ArgoCD sync flips the HTTPRoute from Degraded to Healthy.