### PR TITLE
Cover all apps and infra in dashboard and diagrams

### DIFF
--- a/docs/diagrams/homelab-overview.d2
+++ b/docs/diagrams/homelab-overview.d2
@@ -197,6 +197,11 @@ k8s: Genesis · Talos Kubernetes {
       shape: image
       icon: ${di}/kubernetes.svg
     }
+    rollouts: "Argo Rollouts\n(progressive delivery)" {
+      shape: image
+      icon: ${di}/argo-cd.svg
+    }
+    otel: "OpenTelemetry\nCollector"
     keda: KEDA {
       shape: image
       icon: ${di}/keda.svg
@@ -288,6 +293,16 @@ k8s: Genesis · Talos Kubernetes {
     openwebui: Open WebUI {
       shape: image
       icon: ${di}/open-webui.svg
+    }
+    mealie: Mealie {
+      shape: image
+      icon: ${di}/mealie.svg
+    }
+    logeverylift: "LogEveryLift\n(local build)"
+    verksted: "Verksted\n(workshop app)"
+    bigd: "bigd.no\n(landing page)" {
+      shape: image
+      icon: ${di}/nginx.svg
     }
   }
 }

--- a/docs/diagrams/network-flow.d2
+++ b/docs/diagrams/network-flow.d2
@@ -66,6 +66,7 @@ ops: GitOps & Config {
   eso: External Secrets
   reloader: Reloader
   keda: KEDA {shape: image; icon: ${di}/keda.svg}
+  rollouts: "Argo Rollouts" {shape: image; icon: ${di}/argo-cd.svg}
 }
 
 # ───────────── Public sites ─────────────
@@ -84,6 +85,10 @@ sites: Public Sites {
   ittools: IT-Tools {shape: image; icon: ${di}/it-tools.svg}
   omnitools: Omni-Tools
   headroom: "Headroom\n(personal finance app)"
+  mealie: Mealie {shape: image; icon: ${di}/mealie.svg}
+  logeverylift: "LogEveryLift (local)" {shape: image; icon: ${di}/nextjs.svg; style.opacity: 0.7}
+  verksted: "Verksted\n(workshop)"
+  bigd: "bigd.no" {shape: image; icon: ${di}/nginx.svg}
 }
 
 # ───────────── Media stack ─────────────
@@ -123,6 +128,7 @@ obs: Observability {
   tempo: Tempo {shape: image; icon: ${di}/tempo.svg}
   grafana: Grafana {shape: image; icon: ${di}/grafana.svg}
   metrics: metrics-server {shape: image; icon: ${di}/kubernetes.svg}
+  otel: "OTel Collector"
 }
 
 # ───────────── Security ─────────────
@@ -206,6 +212,7 @@ ops.argocd -> sites: deploys {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 ops.argocd -> media: deploys {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 ops.argocd -> net: deploys {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 ops.argocd -> obs: deploys {style: {stroke: "#4f46e5"; stroke-dash: 4}}
+ops.rollouts -> sites: canary / blue-green {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 
 # ── Autoscaling (indigo) ──
 # Cron scaling: portfolio & blog 1↔3 off-hours, headroom 0↔1 overnight.
@@ -257,7 +264,8 @@ ops.argocd -> ai: deploys {style: {stroke: "#4f46e5"; stroke-dash: 4}}
 ai -> store.nfscsi: models + data {style: {stroke: "#d97706"}}
 
 # ── Observability (teal) ──
-net.traefik -> obs.tempo: OTLP traces {style: {stroke: "#0d9488"}}
+net.traefik -> obs.otel: OTLP traces {style: {stroke: "#0d9488"}}
+obs.otel -> obs.tempo: export {style: {stroke: "#0d9488"; stroke-dash: 2}}
 obs.prometheus -> net.traefik: scrape {style: {stroke: "#0d9488"; stroke-dash: 2}}
 obs.prometheus -> sec.falco: scrape {style: {stroke: "#0d9488"; stroke-dash: 2}}
 obs.prometheus -> obs.loki: scrape {style: {stroke: "#0d9488"; stroke-dash: 2}}

--- a/k8s/talos/apps/homepage/values.yaml
+++ b/k8s/talos/apps/homepage/values.yaml
@@ -139,6 +139,22 @@ config:
             icon: mdi-head-cog
             href: https://headroom.local.bigd.no
             description: Self-hosted Headroom instance
+        - Mealie:
+            icon: mealie.png
+            href: https://mealie.bigd.no
+            description: Recipe manager and meal planner
+        - LogEveryLift (Local):
+            icon: mdi-dumbbell
+            href: https://logeverylift.local.bigd.no
+            description: Workout logger (local build)
+        - Verksted:
+            icon: mdi-wrench
+            href: https://verksted.local.bigd.no
+            description: Workshop app
+        - BigD:
+            icon: mdi-web
+            href: https://bigd.no
+            description: bigd.no landing page
 
     - Media Management:
         - Radarr:
@@ -196,6 +212,22 @@ config:
             icon: flaresolverr.png
             href: https://flaresolverr.local.bigd.no
             description: Cloudflare bypass
+        - Readarr:
+            icon: readarr.png
+            href: https://readarr.local.bigd.no
+            description: Book and audiobook management
+        - Tdarr:
+            icon: mdi-transcode
+            href: https://tdarr.local.bigd.no
+            description: Transcode automation
+        - Cleanuparr:
+            icon: mdi-broom
+            href: https://cleanuparr.local.bigd.no
+            description: Download queue cleanup
+        - Huntarr:
+            icon: mdi-magnify
+            href: https://huntarr.local.bigd.no
+            description: Missing and upgrade hunter
 
     - Infrastructure:
         - Proxmox Hyper1:
@@ -234,6 +266,10 @@ config:
             icon: https://raw.githubusercontent.com/akuity/kargo/main/ui/public/kargo-logo.png
             href: https://kargo.local.bigd.no
             description: GitOps promotion (portfolio stage to prod)
+        - Authentik:
+            icon: authentik.png
+            href: https://auth.local.bigd.no
+            description: SSO and identity provider
 
     - Torrent Sites:
         - IPTorrents:


### PR DESCRIPTION
## Why
Keep the Homepage dashboard and the two D2 diagrams in sync with what actually runs in the cluster (mealie was just added, plus several apps/infra were never represented).

## What
Diagrams (both auto-render to SVG/PNG on merge):
- overview: add apps mealie, logeverylift, verksted, bigd; add infra argo-rollouts, otel-collector
- network-flow: same additions, wired into existing flows

Dashboard (Homepage): add tiles for apps with a web UI - mealie, logeverylift (local), verksted, bigd, authentik, and arr extras (readarr, tdarr, cleanuparr, huntarr). Headless infra (ESO, reloader, CRDs, csi drivers, etc.) is intentionally left off the dashboard - it has no UI and is represented in the diagrams instead.

## Verification
- Both diagrams render clean via terrastruct/d2:v0.7.1 (same image CI uses)
- values.yaml parses (yq)