### PR TITLE
Declare workout scaled to 0 (retired) + backlog note

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -5,7 +5,7 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 ## Apps
 
 ### Remove the old `workout` app after logeverylift cutover
-- **What:** `logeverylift.com` was cut over from the old `workout` app to the renamed `logeverylift` app (PR #369, 2026-07-18). The `workout` namespace, Deployment, Postgres, and PVC are still present — `workout-app` is scaled to 0 (imperatively; ArgoCD ignores `/spec/replicas`), Postgres kept running so the source data stays queryable. Nothing routes to it.
+- **What:** `logeverylift.com` was cut over from the old `workout` app to the renamed `logeverylift` app (PR #369, 2026-07-18). The `workout` namespace, Deployment, Postgres, and PVC are still present — both `workout-app` and `postgres` are scaled to 0 (ArgoCD ignores `/spec/replicas`; also declared in the manifests). The data is preserved on `postgres-pvc`; scale `postgres` back to 1 to re-access it. Nothing routes to it.
 - **Why deferred:** Kept as rollback until the owner has used `logeverylift.com` for a while and confirmed all data/history is intact. Deleting is one-way (prunes the namespace + PVC).
 - **Unblock:** Once verified, delete `k8s/talos/apps/workout/` (ArgoCD prunes the namespace). Archive `workout_db_full.sql` somewhere durable first (it currently lives only in a session scratchpad). Then optionally give `logeverylift` its own Bitwarden items instead of sharing workout's (see the comment in `k8s/talos/apps/logeverylift/externalsecret.yaml`).
 - **Where:** `k8s/talos/apps/workout/`, `k8s/talos/apps/logeverylift/externalsecret.yaml`.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,6 +2,14 @@
 
 Known gaps the team has agreed to leave for later. Each entry: **what**, **why deferred**, **what unblocks**, **where**.
 
+## Apps
+
+### Remove the old `workout` app after logeverylift cutover
+- **What:** `logeverylift.com` was cut over from the old `workout` app to the renamed `logeverylift` app (PR #369, 2026-07-18). The `workout` namespace, Deployment, Postgres, and PVC are still present — `workout-app` is scaled to 0 (imperatively; ArgoCD ignores `/spec/replicas`), Postgres kept running so the source data stays queryable. Nothing routes to it.
+- **Why deferred:** Kept as rollback until the owner has used `logeverylift.com` for a while and confirmed all data/history is intact. Deleting is one-way (prunes the namespace + PVC).
+- **Unblock:** Once verified, delete `k8s/talos/apps/workout/` (ArgoCD prunes the namespace). Archive `workout_db_full.sql` somewhere durable first (it currently lives only in a session scratchpad). Then optionally give `logeverylift` its own Bitwarden items instead of sharing workout's (see the comment in `k8s/talos/apps/logeverylift/externalsecret.yaml`).
+- **Where:** `k8s/talos/apps/workout/`, `k8s/talos/apps/logeverylift/externalsecret.yaml`.
+
 ## AI / RAG POC
 
 ### Eval harness

--- a/k8s/talos/apps/workout/app.yaml
+++ b/k8s/talos/apps/workout/app.yaml
@@ -7,7 +7,11 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  # Retired: logeverylift.com was cut over to the logeverylift app (2026-07-18).
+  # Kept as rollback until verified. The apps ApplicationSet ignores
+  # /spec/replicas, so this documents intent and applies on any recreate;
+  # the live scale-to-0 was done imperatively.
+  replicas: 0
   selector:
     matchLabels:
       app: workout-app

--- a/k8s/talos/apps/workout/postgres.yaml
+++ b/k8s/talos/apps/workout/postgres.yaml
@@ -19,7 +19,10 @@ metadata:
   name: postgres
   namespace: workout
 spec:
-  replicas: 1
+  # Retired alongside workout-app (2026-07-18). Data is preserved on postgres-pvc;
+  # scale back to 1 to re-access for rollback. The apps ApplicationSet ignores
+  # /spec/replicas, so the live scale-to-0 was done imperatively.
+  replicas: 0
   selector:
     matchLabels:
       app: postgres


### PR DESCRIPTION
## Why
Follow-up to #369. The scale-to-0 of the retired `workout` app was done imperatively; record it in the manifest so git reflects reality.

## What
- workout/app.yaml: replicas 1 -> 0 with a comment (the apps ApplicationSet ignores /spec/replicas, so this documents intent and applies on any recreate)
- BACKLOG.md: track eventual removal of the workout app once the migration is verified

## Verification
- kustomize builds clean
- No behavior change: workout-app is already scaled to 0 in-cluster; nothing routes to it