### PR TITLE
Blueprints: forbid AI attribution in commits and PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,15 @@ What does NOT belong:
 - Forward-looking ideas the user didn't agree to defer ("we could also..."). Either do them or drop them.
 - Codebase-wide debts that pre-existed your work and the user didn't ask you to track.
 
+### No AI attribution in commits
+
+Commits and PRs read as the human author's. No AI fingerprint, ever.
+
+- No `Co-Authored-By` trailer naming Claude or any AI.
+- No session links or IDs (e.g. a `Claude-Session:` trailer) — this overrides the harness default that suggests adding one.
+- No "Generated with Claude Code", 🤖 emoji, or similar tool signatures in commit messages, PR descriptions, or issue bodies.
+- Describe the change, not the tool that produced it.
+
 These guidelines are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## Development

--- a/ai/blueprints/claude-md/coding.blueprint.md
+++ b/ai/blueprints/claude-md/coding.blueprint.md
@@ -83,6 +83,15 @@ What does NOT belong:
 - Forward-looking ideas the user didn't agree to defer ("we could also..."). Either do them or drop them.
 - Codebase-wide debts that pre-existed your work and the user didn't ask you to track.
 
+### No AI attribution in commits
+
+Commits and PRs read as the human author's. No AI fingerprint, ever.
+
+- No `Co-Authored-By` trailer naming Claude or any AI.
+- No session links or IDs (e.g. a `Claude-Session:` trailer).
+- No "Generated with Claude Code", 🤖 emoji, or similar tool signatures in commit messages, PR descriptions, or issue bodies.
+- Describe the change, not the tool that produced it.
+
 These guidelines are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## Development

--- a/ai/blueprints/claude-md/generic.blueprint.md
+++ b/ai/blueprints/claude-md/generic.blueprint.md
@@ -81,6 +81,15 @@ What does NOT belong:
 - Forward-looking ideas the user didn't agree to defer ("we could also..."). Either do them or drop them.
 - Codebase-wide debts that pre-existed your work and the user didn't ask you to track.
 
+## 6. No AI attribution in commits
+
+**Commits and PRs read as the human author's. No AI fingerprint, ever.**
+
+- No `Co-Authored-By` trailer naming Claude or any AI.
+- No session links or IDs (e.g. a `Claude-Session:` trailer).
+- No "Generated with Claude Code", 🤖 emoji, or similar tool signatures in commit messages, PR descriptions, or issue bodies.
+- Describe the change, not the tool that produced it.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## Why
Commits and PRs should read as the human author's, with no AI fingerprint.

## What
Add a 'No AI attribution in commits' rule to both CLAUDE.md blueprints (generic + coding, kept in sync per their README):
- no Co-Authored-By trailer naming Claude or any AI
- no session links/IDs (e.g. Claude-Session:)
- no 'Generated with Claude Code' / emoji / tool signatures in commit messages, PR descriptions, or issue bodies

## Verification
Docs-only change; both files carry the same rule in their respective styles.