### PR TITLE
portfolio-stage: prefer brotli in compress encodings order

### DIFF
--- a/k8s/talos/apps/portfolio-stage/compress-middleware.yaml
+++ b/k8s/talos/apps/portfolio-stage/compress-middleware.yaml
@@ -9,6 +9,13 @@ spec:
   # includedContentTypes limits work to compressible text so already-compressed
   # images and woff2 fonts aren't re-compressed for no gain.
   compress:
+    # Traefik selects by this order, not the client's q-values. Browsers send
+    # "gzip, deflate, br, zstd"; without this it defaults to gzip. Brotli is the
+    # smallest for our HTML/JS and universally supported, so it leads.
+    encodings:
+      - br
+      - zstd
+      - gzip
     minResponseBodyBytes: 1024
     includedContentTypes:
       - text/html


### PR DESCRIPTION
## Why

Follow-up to #380. Testing on stage showed compression works (HTML 262KB → 56KB) but Traefik served **gzip** to clients that also accept brotli. Traefik picks the encoding by its own `encodings` list order, not the client's q-values, and defaults to gzip. Browsers send `gzip, deflate, br, zstd`, so real visitors got gzip.

Measured transfer for the site HTML: br 41,461 < zstd 48,123 < gzip 55,774 bytes. Brotli is ~26% smaller than gzip and universally supported, so it should lead.

## What

Set `compress.encodings: [br, zstd, gzip]` on the stage compress Middleware so brotli wins for any client that accepts it, falling back to zstd then gzip.

## Verification

- `kubectl diff -k` shows only the added `encodings` list.
- Post-merge, re-run against stage: a browser-like `Accept-Encoding: gzip, deflate, br, zstd` should return `content-encoding: br` and ~41KB instead of ~56KB.