### PR TITLE
portfolio: disable Next.js compression, let Traefik edge handle it

### DIFF
--- a/portfolio/next.config.ts
+++ b/portfolio/next.config.ts
@@ -5,6 +5,12 @@ const nextConfig: NextConfig = {
   // /api/v1 alongside the site, which a static export cannot do. Emits a
   // self-contained .next/standalone bundle for the Node runtime image.
   output: "standalone",
+  // Compression is handled at the Traefik edge (compress Middleware, br/zstd/
+  // gzip by preference). Next's built-in gzip runs first at the origin and,
+  // because a proxy won't re-encode an already-compressed response, would pin
+  // every client that accepts gzip to gzip and starve brotli. Off here so the
+  // edge picks the smallest encoding.
+  compress: false,
   // Pages keep trailing slashes for stable canonical URLs; the redirect is
   // skipped so API clients hitting /api/v1/profile aren't 308'd to a slash.
   trailingSlash: true,


### PR DESCRIPTION
## Why

Testing the stage edge-compression work (#380/#381) revealed brotli never reached browsers. Root cause: Next.js compresses at the origin. `compress` defaults to `true`, so the Node server gzips any response where the client accepts gzip. Traefik won't re-encode an already-compressed response, so the origin gzip passed straight through and pinned every browser (which all send `gzip, ..., br, zstd`) to gzip. Brotli only appeared when the client did not accept gzip.

Proof from stage: `Accept-Encoding: zstd, gzip` returned **gzip**, not zstd — impossible if Traefik (encodings `[br, zstd, gzip]`) were doing the compression; only a gzip-only origin compressor explains it.

## What

Set `compress: false` in `portfolio/next.config.ts` so the origin serves identity and the Traefik compress Middleware picks the smallest encoding.

## Verification

- Change is a single documented NextConfig boolean; no build-shape change.
- Runtime verification is post-deploy (needs a new image via CI + Kargo promotion to stage). Once live, re-run:
  `curl -sI -H 'Accept-Encoding: gzip, deflate, br, zstd' https://portfolio-stage.local.bigd.no/` should return `content-encoding: br` and ~41KB (down from ~56KB gzip).
- Measured ladder for the homepage HTML: br 41,461 < zstd 48,123 < gzip 55,774 bytes.