### PR TITLE
fix(kargo): status()-based no-op promotion guards + faster warehouse scan

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -125,6 +125,14 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Scope the read (constant path, or `outputFileTracingRoot`/`outputFileTracingExcludes` in `next.config.ts`) until the warning clears without pulling in extra files.
 - **Where:** `portfolio/src/app/api/v1/infra/route.ts`, `portfolio/next.config.ts`.
 
+## Kargo
+
+### git-push not skipped on no-op prod promotion (orphan branches)
+- **What:** In the `promote-via-pr` ClusterPromotionTask, `git-push` carries the same `if: (task.outputs?.['commit']?.commit ?? '') != ''` guard as `git-commit` and `git-open-pr`, but on a no-op promotion (target image already live) `git-commit`/`git-open-pr` are correctly Skipped while `git-push` runs anyway (status Succeeded) and creates a `kargo/promotion/prod.*` branch via `generateTargetBranch: true`. Each no-op retry leaves another orphan branch (~10 accumulated as of 2026-07-18). Harmless but messy; the fatal no-op error was fixed separately by null-safing `wait-pr`'s `prNumber` (PR #385).
+- **Why deferred:** Cosmetic — promotions succeed once #385 lands. Root cause is unclear: `git-push` isn't honoring `if` the way sibling steps do (possible Kargo v1.10.9 quirk), so it needs reproduction/upstream check rather than a blind config tweak.
+- **Unblock:** Repro on a no-op promotion and confirm whether `git-push` ignores `if` or the guard evaluates differently for it; check Kargo issues for the pinned version. Interim option: drop `generateTargetBranch` in favour of a deterministic branch name so retries reuse one branch instead of spawning new ones. Then delete the accumulated `origin/kargo/promotion/prod.*` branches.
+- **Where:** `k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml` (`git-push` step).
+
 ## Cluster / infra
 
 ### Extend Loki PVC after kube-events validated

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -125,14 +125,6 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Scope the read (constant path, or `outputFileTracingRoot`/`outputFileTracingExcludes` in `next.config.ts`) until the warning clears without pulling in extra files.
 - **Where:** `portfolio/src/app/api/v1/infra/route.ts`, `portfolio/next.config.ts`.
 
-## Kargo
-
-### git-push not skipped on no-op prod promotion (orphan branches)
-- **What:** In the `promote-via-pr` ClusterPromotionTask, `git-push` carries the same `if: (task.outputs?.['commit']?.commit ?? '') != ''` guard as `git-commit` and `git-open-pr`, but on a no-op promotion (target image already live) `git-commit`/`git-open-pr` are correctly Skipped while `git-push` runs anyway (status Succeeded) and creates a `kargo/promotion/prod.*` branch via `generateTargetBranch: true`. Each no-op retry leaves another orphan branch (~10 accumulated as of 2026-07-18). Harmless but messy; the fatal no-op error was fixed separately by null-safing `wait-pr`'s `prNumber` (PR #385).
-- **Why deferred:** Cosmetic — promotions succeed once #385 lands. Root cause is unclear: `git-push` isn't honoring `if` the way sibling steps do (possible Kargo v1.10.9 quirk), so it needs reproduction/upstream check rather than a blind config tweak.
-- **Unblock:** Repro on a no-op promotion and confirm whether `git-push` ignores `if` or the guard evaluates differently for it; check Kargo issues for the pinned version. Interim option: drop `generateTargetBranch` in favour of a deterministic branch name so retries reuse one branch instead of spawning new ones. Then delete the accumulated `origin/kargo/promotion/prod.*` branches.
-- **Where:** `k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml` (`git-push` step).
-
 ## Cluster / infra
 
 ### Extend Loki PVC after kube-events validated

--- a/k8s/talos/infra/kargo-projects/blog.yaml
+++ b/k8s/talos/infra/kargo-projects/blog.yaml
@@ -98,8 +98,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
-  interval: 5m0s
+  # interval as Kargo normalizes it (1m -> 1m0s), to avoid ArgoCD drift.
+  interval: 1m0s
   freightCreationPolicy: Automatic
   subscriptions:
     - image:

--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
@@ -41,41 +41,40 @@ spec:
       config:
         path: ./repo
         message: "chore(${{ vars.appName }}): promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
-    # Steps inside a task reference each other via task.outputs['<alias>'] (plain
-    # outputs.* does not resolve; the task's runtime step alias is not known at
-    # definition time).
+    # No-op promotions (image tag unchanged, e.g. Kargo re-promoting a fresh
+    # Freight for the already-live version) are gated with the `status('<alias>')`
+    # function, the Kargo-canonical way to branch on a skipped step. git-commit
+    # auto-skips when there is nothing to commit, so status('commit') == 'Skipped'
+    # is the no-op signal. Guarding git-push on it makes push actually skip on a
+    # no-op (so no orphan kargo/promotion branch is created), and open-pr/wait-pr
+    # skip in turn. argocd-update/wait stay unguarded so the promotion still ends
+    # green by confirming prod Healthy.
     #
-    # The `if` guards handle a no-op promotion (image tag unchanged, e.g. Kargo
-    # re-promoting a fresh Freight for the already-live version). git-push creates
-    # a branch even with nothing new to push, so branch-presence is not a reliable
-    # signal; git-commit is skipped when there is nothing to commit and emits no
-    # `commit` output, so that is the no-op signal. On a no-op these three git
-    # steps all skip (no orphan branch, no empty PR) and argocd-update/wait below
-    # stay unguarded so the promotion still ends green by confirming prod Healthy.
+    # This replaced home-grown `task.outputs['commit'].commit` guards, which
+    # evaluated unreliably here: with identical guards git-push ran and wait-pr
+    # errored while open-pr skipped, leaking a branch per no-op retry. status() is
+    # purpose-built for skip detection and resolves with the plain step alias
+    # (outputs still need task.outputs[...] scoping inside a task; status() does not).
+    # Output references are also kept null-safe as belt-and-suspenders.
     - uses: git-push
       as: push
-      if: ${{ (task.outputs?.['commit']?.commit ?? '') != '' }}
+      if: ${{ status('commit') != 'Skipped' }}
       config:
         path: ./repo
         generateTargetBranch: true
     - uses: git-open-pr
       as: open-pr
-      if: ${{ (task.outputs?.['commit']?.commit ?? '') != '' }}
+      if: ${{ status('commit') != 'Skipped' }}
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         provider: github
-        sourceBranch: ${{ task.outputs['push'].branch }}
+        sourceBranch: ${{ task.outputs?.['push']?.branch ?? '' }}
         targetBranch: main
         title: "chore(${{ vars.appName }}): promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
     # Blocks the promotion until the PR is merged in GitHub.
-    # prNumber must be null-safe: Kargo builds a step's config before evaluating
-    # its `if`, so on a no-op (open-pr skipped, no output) a bare
-    # task.outputs['open-pr'].pr.id throws "cannot fetch id from <nil>" and the
-    # guard never gets to skip the step. The `?? 0` fallback is never used at
-    # runtime because the `if` skips the step whenever open-pr was skipped.
     - uses: git-wait-for-pr
       as: wait-pr
-      if: ${{ (task.outputs?.['commit']?.commit ?? '') != '' }}
+      if: ${{ status('open-pr') != 'Skipped' }}
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         provider: github

--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
@@ -68,13 +68,18 @@ spec:
         targetBranch: main
         title: "chore(${{ vars.appName }}): promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
     # Blocks the promotion until the PR is merged in GitHub.
+    # prNumber must be null-safe: Kargo builds a step's config before evaluating
+    # its `if`, so on a no-op (open-pr skipped, no output) a bare
+    # task.outputs['open-pr'].pr.id throws "cannot fetch id from <nil>" and the
+    # guard never gets to skip the step. The `?? 0` fallback is never used at
+    # runtime because the `if` skips the step whenever open-pr was skipped.
     - uses: git-wait-for-pr
       as: wait-pr
       if: ${{ (task.outputs?.['commit']?.commit ?? '') != '' }}
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         provider: github
-        prNumber: ${{ task.outputs['open-pr'].pr.id }}
+        prNumber: ${{ task.outputs?.['open-pr']?.pr?.id ?? 0 }}
     - uses: argocd-update
       config:
         apps:

--- a/k8s/talos/infra/kargo-projects/headroom.yaml
+++ b/k8s/talos/infra/kargo-projects/headroom.yaml
@@ -91,8 +91,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
-  interval: 5m0s
+  # interval as Kargo normalizes it (1m -> 1m0s), to avoid ArgoCD drift.
+  interval: 1m0s
   freightCreationPolicy: Automatic
   subscriptions:
     - image:

--- a/k8s/talos/infra/kargo-projects/logeverylift.yaml
+++ b/k8s/talos/infra/kargo-projects/logeverylift.yaml
@@ -97,8 +97,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
-  interval: 5m0s
+  # interval as Kargo normalizes it (1m -> 1m0s), to avoid ArgoCD drift.
+  interval: 1m0s
   freightCreationPolicy: Automatic
   subscriptions:
     - image:

--- a/k8s/talos/infra/kargo-projects/portfolio.yaml
+++ b/k8s/talos/infra/kargo-projects/portfolio.yaml
@@ -100,8 +100,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
-  interval: 5m0s
+  # interval as Kargo normalizes it (1m -> 1m0s), to avoid ArgoCD drift.
+  interval: 1m0s
   freightCreationPolicy: Automatic
   subscriptions:
     - image:

--- a/k8s/talos/infra/kargo-projects/verksted.yaml
+++ b/k8s/talos/infra/kargo-projects/verksted.yaml
@@ -91,8 +91,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  # interval as Kargo normalizes it (5m -> 5m0s), to avoid ArgoCD drift.
-  interval: 5m0s
+  # interval as Kargo normalizes it (1m -> 1m0s), to avoid ArgoCD drift.
+  interval: 1m0s
   freightCreationPolicy: Automatic
   subscriptions:
     - image:


### PR DESCRIPTION
## Why

Portfolio prod promotions were stuck in an erroring retry loop. Image 0.0.80 was already promoted to prod (#383), but Kargo's prod Stage still tracked the previous freight, so it kept re-promoting 0.0.80 as a no-op — and every attempt errored at `git-wait-for-pr`:

```
commit   => Skipped
push     => Succeeded   <- ran despite an identical guard to open-pr
open-pr  => Skipped
wait-pr  => Errored: cannot fetch id from <nil> | task.outputs['open-pr'].pr.id
```

Root cause: the task used home-grown `task.outputs['commit'].commit` guards, which evaluate unreliably — with the *same* guard, `git-push` ran, `git-open-pr` skipped, and `git-wait-for-pr` ran and dereferenced the nil `open-pr` output. The unreliable guard also meant `git-push` ran on every no-op retry, leaking a `kargo/promotion/prod.*` branch each time (~10 accumulated).

## What

- Switch the `promote-via-pr` no-op guards to Kargo's canonical `status('<alias>')` function (the documented way to branch on a skipped step). `git-commit` auto-skips when there's nothing to commit, so `status('commit') != 'Skipped'` is the reliable no-op signal:
  - `git-push`, `git-open-pr`: `if: status('commit') != 'Skipped'` — push now genuinely skips on a no-op, so no orphan branch is created.
  - `git-wait-for-pr`: `if: status('open-pr') != 'Skipped'`.
  - Output references kept null-safe as a safety net.
- Drop every Warehouse `interval` 5m0s -> 1m0s (portfolio, blog, headroom, verksted, logeverylift) so new image builds are discovered within a minute instead of up to five.

## Verification

- `kubectl diff -k k8s/talos/infra/kargo-projects/` shows only the guard rewrites, the null-safe output refs, and the five interval changes.
- After merge + ArgoCD sync: re-run the stuck prod promotion — commit/push/open-pr/wait-pr all Skipped, argocd-update/argocd-wait run, promotion ends green and the prod Stage advances to the live freight, with no new `kargo/promotion` branch. Existing orphan branches cleaned up separately.