### PR TITLE
portfolio (prod): gzip/br compression at Traefik edge

### DIFF
--- a/k8s/talos/apps/portfolio/compress-middleware.yaml
+++ b/k8s/talos/apps/portfolio/compress-middleware.yaml
@@ -1,0 +1,29 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: portfolio-compress
+  namespace: portfolio
+spec:
+  # The distroless Node runtime serves text assets uncompressed (Next.js
+  # compress is off, so the edge owns compression). Traefik negotiates br/zstd/
+  # gzip from Accept-Encoding. encodings order wins over the client's q-values,
+  # so brotli leads (smallest for the site HTML/JS); includedContentTypes limits
+  # work to compressible text so images and woff2 fonts aren't re-compressed.
+  compress:
+    encodings:
+      - br
+      - zstd
+      - gzip
+    minResponseBodyBytes: 1024
+    includedContentTypes:
+      - text/html
+      - text/css
+      - text/plain
+      - text/xml
+      - text/javascript
+      - text/x-component
+      - application/javascript
+      - application/json
+      - application/xml
+      - application/manifest+json
+      - image/svg+xml

--- a/k8s/talos/apps/portfolio/httproute.yaml
+++ b/k8s/talos/apps/portfolio/httproute.yaml
@@ -13,13 +13,19 @@ spec:
     - nordbye.it
     - www.nordbye.it
   rules:
-    - backendRefs:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: portfolio-compress
+      backendRefs:
         - group: ""
           kind: Service
           name: nordbye-service
           port: 8080
           weight: 1
-      matches:
-        - path:
-            type: PathPrefix
-            value: /

--- a/k8s/talos/apps/portfolio/kustomization.yaml
+++ b/k8s/talos/apps/portfolio/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - deployment.yaml
 - poddisruptionbudget.yaml
 - httproute.yaml
+- compress-middleware.yaml
 - service.yaml
 - ciliumnetworkpolicy.yaml
 - scaledobject.yaml


### PR DESCRIPTION
## Why

`nordbye.it` runs image 0.0.80, which has Next.js `compress: false` (compression moved to the edge). But prod never got the Traefik compress Middleware — only stage did — so prod has been serving HTML/CSS/JS fully **uncompressed** (262KB homepage HTML raw to every visitor). This restores compression and lands brotli.

## What

Mirror the validated stage setup onto the prod `portfolio` app:
- New Traefik `Middleware` `portfolio-compress` (namespace `portfolio`), `encodings: [br, zstd, gzip]`, `includedContentTypes` scoped to compressible text.
- Attach it to the prod HTTPRoute `nordbye` via an `ExtensionRef` filter.

## Verification

- `kubectl kustomize` renders; `kubectl diff -k` shows only the additive Middleware + HTTPRoute filter; Traefik CRD accepted the `compress` spec on server-side dry-run.
- Stage already proved the encoding: browser-like `Accept-Encoding` returns `content-encoding: br` at ~41KB vs ~262KB uncompressed.
- Post-merge: `curl -sI -H 'Accept-Encoding: gzip, deflate, br, zstd' https://nordbye.it/` should return `content-encoding: br`.