### PR TITLE
blog: gzip/br compression at Traefik edge (stage + prod)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -28,11 +28,6 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Portfolio modern — items deferred during initial build
 
-### Brotli precompression for nginx static assets — SUPERSEDED
-- **What:** Was: ship `.br` siblings and enable `brotli_static on;` in `nginx.conf`. The portfolio no longer uses nginx — it runs the distroless Node runtime, and compression is now handled at the Traefik edge (see "Response compression on the Node runtime — prod cutover"). Traefik negotiates brotli from `Accept-Encoding` at request time, so precompressed `.br` siblings are unnecessary.
-- **Action:** Delete this entry once the edge-compression prod cutover lands.
-- **Where:** obsolete — retired `portfolio/nginx/`.
-
 ### Docker build verification
 - **What:** Build and run `portfolio/Dockerfile` end-to-end (`docker build` then `docker run -p 8080:8080`) and confirm `/healthz`, security headers, and routing work as expected.
 - **Why deferred:** Local build was verified via `npm run build` + `npx serve out`; Docker layer not run during the rebuild session.
@@ -112,12 +107,6 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Why deferred:** The static key is simpler and sufficient to ship the framework; Authentik wiring only pays off once a real user-facing write exists.
 - **Unblock:** Add an Authentik provider + Traefik forward-auth middleware on the `/api/v1` POST paths, and relax `requireApiKey` to accept the forwarded identity.
 - **Where:** `portfolio/src/lib/api.ts`, `k8s/talos/apps/portfolio/httproute.yaml`, Authentik config.
-
-### Response compression on the Node runtime — prod cutover
-- **What:** Stage now compresses at the Traefik edge: a `compress` Middleware (`portfolio-stage-compress`) attached to the stage HTTPRoute via an `ExtensionRef` filter (PR #380). Prod (`nordbye.it`) still serves text assets uncompressed from the distroless Node runtime.
-- **Why deferred:** Stage-first per [[feedback_stage_before_prod]] — validate the encoding/size win on stage before touching warm prod.
-- **Unblock:** After confirming stage returns `content-encoding: br`/`gzip` and a real size drop on the largest JS bundle, mirror the change into the prod app: add an equivalent `compress` Middleware in the `portfolio` namespace and the `ExtensionRef` filter on the prod HTTPRoute.
-- **Where:** stage (done) `k8s/talos/apps/portfolio-stage/{compress-middleware,httproute}.yaml`; prod (pending) `k8s/talos/apps/portfolio/httproute.yaml`.
 
 ### Silence the Turbopack NFT over-trace on /api/v1/infra
 - **What:** `next build` warns that the `fs.readFile` in the infra route causes Node File Tracing to sweep the whole project into `.next/standalone` (locally this pulled in `latex/`, `out/`, CV markdown). The shipped Docker image is unaffected because the build stage only `COPY`s `src`/`public`/config, but the warning is noise and the local standalone is bloated.

--- a/k8s/talos/apps/blog-stage/compress-middleware.yaml
+++ b/k8s/talos/apps/blog-stage/compress-middleware.yaml
@@ -1,0 +1,30 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: blog-stage-compress
+  namespace: stage-blog
+spec:
+  # Edge compression for the Hugo/nginx blog. Traefik negotiates br/zstd/gzip
+  # from Accept-Encoding; encodings order wins over the client's q-values so
+  # brotli leads. includedContentTypes limits work to compressible text.
+  # NOTE: nginx.conf still has `gzip on;`, which compresses at the origin and
+  # would pin clients to gzip (Traefik won't re-encode). Brotli only takes over
+  # once nginx gzip is disabled in a follow-up image build.
+  compress:
+    encodings:
+      - br
+      - zstd
+      - gzip
+    minResponseBodyBytes: 1024
+    includedContentTypes:
+      - text/html
+      - text/css
+      - text/plain
+      - text/xml
+      - text/javascript
+      - application/javascript
+      - application/json
+      - application/xml
+      - application/rss+xml
+      - application/manifest+json
+      - image/svg+xml

--- a/k8s/talos/apps/blog-stage/httproute.yaml
+++ b/k8s/talos/apps/blog-stage/httproute.yaml
@@ -12,14 +12,20 @@ spec:
   hostnames:
     - blog-stage.local.bigd.no
   rules:
-    - backendRefs:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: blog-stage-compress
+      backendRefs:
         - group: ""
           kind: Service
           name: keda-add-ons-http-interceptor-proxy
           namespace: keda
           port: 8080
           weight: 1
-      matches:
-        - path:
-            type: PathPrefix
-            value: /

--- a/k8s/talos/apps/blog-stage/kustomization.yaml
+++ b/k8s/talos/apps/blog-stage/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - deployment.yaml
 - service.yaml
 - httproute.yaml
+- compress-middleware.yaml
 - ciliumnetworkpolicy.yaml
 - interceptorroute.yaml
 - scaledobject.yaml

--- a/k8s/talos/apps/blog/compress-middleware.yaml
+++ b/k8s/talos/apps/blog/compress-middleware.yaml
@@ -1,0 +1,30 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: blog-compress
+  namespace: blog
+spec:
+  # Edge compression for the Hugo/nginx blog. Traefik negotiates br/zstd/gzip
+  # from Accept-Encoding; encodings order wins over the client's q-values so
+  # brotli leads. includedContentTypes limits work to compressible text.
+  # NOTE: nginx.conf still has `gzip on;`, which compresses at the origin and
+  # would pin clients to gzip (Traefik won't re-encode). Brotli only takes over
+  # once nginx gzip is disabled in a follow-up image build.
+  compress:
+    encodings:
+      - br
+      - zstd
+      - gzip
+    minResponseBodyBytes: 1024
+    includedContentTypes:
+      - text/html
+      - text/css
+      - text/plain
+      - text/xml
+      - text/javascript
+      - application/javascript
+      - application/json
+      - application/xml
+      - application/rss+xml
+      - application/manifest+json
+      - image/svg+xml

--- a/k8s/talos/apps/blog/httproute.yaml
+++ b/k8s/talos/apps/blog/httproute.yaml
@@ -12,13 +12,19 @@ spec:
   hostnames:
     - blog.nordbye.it
   rules:
-    - backendRefs:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: blog-compress
+      backendRefs:
         - group: ""
           kind: Service
           name: blog
           port: 80
           weight: 1
-      matches:
-        - path:
-            type: PathPrefix
-            value: /

--- a/k8s/talos/apps/blog/kustomization.yaml
+++ b/k8s/talos/apps/blog/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - poddisruptionbudget.yaml
 - service.yaml
 - httproute.yaml
+- compress-middleware.yaml
 - namespace.yaml
 - ciliumnetworkpolicy.yaml
 - scaledobject.yaml


### PR DESCRIPTION
## Why

Part 1 of bringing the blog in line with the portfolio's edge compression. `blog.nordbye.it` currently serves gzip via nginx's own `gzip on;`. To get brotli, compression has to move to the Traefik edge — but that's a two-step change to avoid an uncompressed window. This PR is the safe first step: add the Traefik Middleware while nginx keeps gzipping.

## What

- New Traefik `Middleware` on both blog Stages: `blog-compress` (ns `blog`) and `blog-stage-compress` (ns `stage-blog`), `encodings: [br, zstd, gzip]`, `includedContentTypes` scoped to compressible text (incl. `application/rss+xml` for the Hugo feed).
- Attached to the `blog` and `blog-stage` HTTPRoutes via `ExtensionRef` filters, matching the portfolio and homepage pattern.

While `nginx.conf` still has `gzip on;`, nginx compresses at the origin and Traefik passes that through — so clients keep getting gzip and there is **no regression**. Brotli only takes over in the follow-up PR that disables nginx gzip (image rebuild), which lands after this is verified on `blog-stage`.

Also removes the two now-complete portfolio compression entries from `BACKLOG.md` (edge compression shipped to portfolio stage and prod).

## Verification

- `kubectl kustomize` renders both apps; `kubectl diff -k` shows only the additive Middleware + HTTPRoute filter per app; Traefik CRD accepted the `compress` spec on server-side dry-run.
- Post-merge: `blog-stage` and `blog.nordbye.it` keep returning `content-encoding: gzip` (unchanged) with the Middleware attached — confirming no regression before the nginx-gzip-off follow-up.