### PR TITLE
blog: nginx gzip off + immutable cache for fingerprinted CSS/JS

### DIFF
--- a/blog/nginx.conf
+++ b/blog/nginx.conf
@@ -4,9 +4,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Gzip for speed (svg compresses well; webp/png/jpg are already compressed, so not listed)
-    gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+    # Compression is handled at the Traefik edge (br/zstd/gzip). nginx must not
+    # compress at the origin: Traefik won't re-encode an already-gzipped response,
+    # so origin gzip would pin every client to gzip and starve brotli.
+    gzip off;
+
+    # Fingerprinted CSS/JS from Hugo's asset pipeline (the SHA-512 is in the
+    # filename), so the bytes are immutable — cache for a year.
+    location ~* \.(css|js)$ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
 
     # Long cache for static media. Filenames are stable, so let browsers keep them.
     location ~* \.(webp|png|jpe?g|gif|svg|ico|woff2?)$ {


### PR DESCRIPTION
## Why

Follow-up to #387 (which added the Traefik compress Middleware to the blog Stages). With the Middleware now live, the last step to get brotli — and to fix a missing caching win — is at the origin.

nginx currently does two suboptimal things:
- `gzip on;` compresses at the origin. Traefik won't re-encode an already-compressed response, so this pins every client to gzip and starves brotli.
- The Hugo asset pipeline emits **fingerprinted** CSS/JS (SHA-512 in the filename, e.g. `main.bundle.min.<hash>.css`), but `nginx.conf` only caches images/fonts — so those immutable bundles get **no cache headers at all** and are refetched on every visit.

## What

- `gzip off;` — hand compression to the Traefik edge (br/zstd/gzip).
- Add `location ~* \.(css|js)$` with `Cache-Control: public, max-age=31536000, immutable` for the fingerprinted bundles.

Because the filenames are content-addressed, immutable caching is safe: any content change produces a new filename.

## Ordering / safety

The Middleware (#387) is already live, so when this image deploys, Traefik takes over compression cleanly — no uncompressed window. The change flows through the normal blog CI build → Kargo promotes to blog-stage, then prod via its PR gate.

## Verification

- `nginx -t` passes (config mounted into `nginx:alpine`).
- Post-deploy on blog-stage: `curl -sI -H 'Accept-Encoding: gzip, deflate, br, zstd' https://blog-stage.local.bigd.no/` returns `content-encoding: br`; a fingerprinted `/css/*.css` returns `cache-control: ...immutable` + `content-encoding: br`. Then promote to prod and re-check `blog.nordbye.it`.