### PR TITLE
traefik: enable HTTP/3 (QUIC) on the public websecure entrypoint

### DIFF
--- a/k8s/talos/infra/traefik/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/infra/traefik/ciliumnetworkpolicy.yaml
@@ -17,6 +17,9 @@ spec:
               protocol: TCP
             - port: "8443"
               protocol: TCP
+            # HTTP/3 (QUIC) on the public websecure entrypoint.
+            - port: "8443"
+              protocol: UDP
             - port: "8444"
               protocol: TCP
     # Dashboard / metrics endpoint scraped by Prometheus.

--- a/k8s/talos/infra/traefik/service-public.yaml
+++ b/k8s/talos/infra/traefik/service-public.yaml
@@ -18,6 +18,11 @@ spec:
       port: 443
       targetPort: 8443
       protocol: TCP
+    # QUIC / HTTP/3 for the websecure entrypoint (same VIP + port, UDP).
+    - name: websecure-h3
+      port: 443
+      targetPort: 8443
+      protocol: UDP
     - name: plex
       port: 32400
       targetPort: 32400

--- a/k8s/talos/infra/traefik/values.yaml
+++ b/k8s/talos/infra/traefik/values.yaml
@@ -68,6 +68,13 @@ ports:
     port: 8443
     exposedPort: 443
     protocol: TCP
+    # HTTP/3 (QUIC) on the public HTTPS entrypoint. Traefik also listens UDP on
+    # this port and advertises Alt-Svc: h3=":443" so browsers upgrade. Serving
+    # over UDP/443 additionally needs the port on the public Service and the
+    # CiliumNetworkPolicy (both below), plus a UDP/443 forward on the router.
+    # TCP stays the fallback, so clients that can't reach H3 use HTTP/2.
+    http3:
+      enabled: true
     expose:
       default: true
   web-private:


### PR DESCRIPTION
## Why

Modern-protocol upgrade with a real performance benefit for public sites (nordbye.it, blog.nordbye.it): HTTP/3 / QUIC gives faster connection setup (fewer round-trips than TCP+TLS) and better behavior on mobile/lossy networks. Confirmed the public sites are served **directly from origin** (no Cloudflare proxy — no `cf-ray`, DNS points at the home IP), so enabling H3 on Traefik actually reaches browsers.

TCP stays the fallback: any client that can't use H3 keeps using HTTP/2, so this is additive and non-breaking.

## What

Public `websecure` entrypoint only (private/LAN keeps HTTP/2 — no latency benefit there):
- `values.yaml`: `ports.websecure.http3.enabled=true` — Traefik listens UDP on 8443 and advertises `Alt-Svc: h3=":443"`.
- `service-public.yaml`: add `websecure-h3` UDP/443 → 8443 on the `traefik-public` LB Service (mixed-protocol, same Cilium VIP 10.3.10.101).
- `ciliumnetworkpolicy.yaml`: allow `world → UDP/8443` ingress.

## Manual step required for external H3

The router must forward **UDP/443** to the VIP (TCP/443 is already forwarded, which is why the sites work). Until that's done, browsers simply stay on HTTP/2 — no breakage, just no H3 from the internet.

## Verification (post-merge, after ArgoCD sync)

- Existing traffic unaffected: `curl -sI https://nordbye.it/` still returns HTTP/2 200, and `curl -sI -H 'Accept-Encoding: br' https://nordbye.it/` still returns `content-encoding: br`.
- H3 advertised: response now carries `alt-svc: h3=":443"`.
- Cilium VIP intact — check `traefik-public` keeps 10.3.10.101 and TCP/443 still serves (per the known Cilium L2/BPF sensitivity, confirm BPF LB state has a backend for the frontend after sync).
- After the router UDP/443 forward: `curl --http3-only -sI https://nordbye.it/` returns 200 over h3.