### PR TITLE
traefik: advertise HTTP/3 on port 443, not internal 8443

### DIFF
--- a/k8s/talos/infra/traefik/values.yaml
+++ b/k8s/talos/infra/traefik/values.yaml
@@ -75,6 +75,11 @@ ports:
     # TCP stays the fallback, so clients that can't reach H3 use HTTP/2.
     http3:
       enabled: true
+      # Advertise h3 on the exposed port (443), not Traefik's internal 8443.
+      # The Service maps 443 -> 8443, so browsers must be told to reach h3 on
+      # 443; without this Traefik advertises alt-svc h3=":8443", which isn't
+      # exposed externally and h3 silently fails.
+      advertisedPort: 443
     expose:
       default: true
   web-private:


### PR DESCRIPTION
## Why

Follow-up to #389. With HTTP/3 enabled, verification showed Traefik advertising `alt-svc: h3=":8443"` — its internal entrypoint port. Externally the sites are on 443 (the `traefik-public` Service maps 443 → 8443), so browsers would attempt h3 on UDP/8443, which isn't exposed, and silently fall back to HTTP/2. So H3 was advertised but unreachable.

## What

Set `ports.websecure.http3.advertisedPort: 443` so the `alt-svc` header points at the externally-reachable port.

## Verification

Post-merge: `curl -sI https://nordbye.it/` should show `alt-svc: h3=":443"`; then an h3-capable client (Chrome DevTools Protocol column, or `curl --http3`) completes the handshake over UDP/443.