### PR TITLE
blog: emit a single Cache-Control header for cached assets

### DIFF
--- a/blog/nginx.conf
+++ b/blog/nginx.conf
@@ -10,15 +10,14 @@ server {
     gzip off;
 
     # Fingerprinted CSS/JS from Hugo's asset pipeline (the SHA-512 is in the
-    # filename), so the bytes are immutable — cache for a year.
+    # filename), so the bytes are immutable — cache for a year. Cache-Control
+    # only (no `expires`), so nginx doesn't emit the header twice.
     location ~* \.(css|js)$ {
-        expires 1y;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
     # Long cache for static media. Filenames are stable, so let browsers keep them.
     location ~* \.(webp|png|jpe?g|gif|svg|ico|woff2?)$ {
-        expires 30d;
         add_header Cache-Control "public, max-age=2592000";
     }
 


### PR DESCRIPTION
## Why

The blog's CSS/JS and media `location` blocks set both `expires` and `add_header Cache-Control`, so nginx returned **two** `Cache-Control` headers per cached asset (e.g. `max-age=31536000` from `expires` plus `public, max-age=31536000, immutable` from `add_header`). Harmless — the values agree and `immutable` is honored — but untidy.

## What

Drop the `expires` directive in both cache blocks and keep the explicit `add_header Cache-Control`, so each asset returns one clean header. Effective caching is unchanged (same `max-age`, `immutable` still present on CSS/JS).

## Verification

- `nginx -t` passes (config mounted into `nginx:alpine`).
- Post-deploy: a fingerprinted `/css/*.css` returns a single `cache-control: public, max-age=31536000, immutable` (plus `content-encoding: br` from the edge).