### PR TITLE
ci: scheduled Lighthouse audit of the live public sites

### DIFF
--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -1,0 +1,15 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "assertions": {
+        "categories:seo": ["error", { "minScore": 1.0 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["error", { "minScore": 0.9 }],
+        "categories:performance": ["warn", { "minScore": 0.8 }]
+      }
+    }
+  }
+}

--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -1,0 +1,42 @@
+name: Lighthouse
+
+# Audits the live public sites with Lighthouse on real GitHub runners (not the
+# qemu-emulated local runs, which throttle CPU and inflate perf metrics).
+# Median of 3 runs per URL. Assertions gate the trustworthy categories (SEO,
+# accessibility, best-practices) and treat performance as a warning, since it
+# varies run-to-run and the 3D globe keeps it borderline. Reports upload to
+# Lighthouse CI's temporary public storage — the run log links each one.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lighthouse
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        url:
+          - https://nordbye.it/
+          - https://blog.nordbye.it/
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: ${{ matrix.url }}
+          configPath: ./.github/lighthouse/lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true


### PR DESCRIPTION
## Why

Lighthouse scores are only trustworthy on real hardware — local runs here go through qemu emulation, which throttles CPU and tanks the performance metrics. Running it in GitHub Actions gives honest numbers, and scheduling it turns the one-off manual check into automated regression detection.

## What

- `.github/workflows/lighthouse.yaml` — audits `nordbye.it` and `blog.nordbye.it` (matrix) via `treosh/lighthouse-ci-action`, on a weekly cron + `workflow_dispatch`. Median of 3 runs per URL; reports upload to Lighthouse CI temporary public storage (linked in the run log).
- `.github/lighthouse/lighthouserc.json` — assertions:
  - SEO = 100 (error)
  - Accessibility >= 90 (error)
  - Best Practices >= 90 (error)
  - Performance >= 80 (warn only — varies run-to-run; the 3D globe keeps it borderline, and a flaky red build over a few points isn't useful)

Thresholds pass today's live state and gate against regressions. Once the small a11y `<dl>` fix lands, accessibility can be tightened to >= 0.95.

## Verification

- `lighthouserc.json` is valid JSON; `actionlint` passes on the workflow.
- After merge: trigger via `workflow_dispatch` (or wait for the Monday run) and open the temporary-storage report link from the run log.