### PR TITLE
headroom: warm by day, scale-to-zero + HTTP wake at night

### DIFF
--- a/k8s/talos/apps/headroom/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/headroom/ciliumnetworkpolicy.yaml
@@ -16,6 +16,17 @@ spec:
         - ports:
             - port: "3001"
               protocol: TCP
+    # Requests now flow Traefik -> KEDA HTTP interceptor -> headroom, so the
+    # interceptor needs to reach the pod (also the path that wakes it from zero).
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": keda
+            "k8s:app.kubernetes.io/component": interceptor
+            "k8s:app.kubernetes.io/part-of": keda-add-ons-http
+      toPorts:
+        - ports:
+            - port: "3001"
+              protocol: TCP
     - fromEntities:
         - host
         - health

--- a/k8s/talos/apps/headroom/httproute.yaml
+++ b/k8s/talos/apps/headroom/httproute.yaml
@@ -13,9 +13,13 @@ spec:
     - headroom.local.bigd.no
   rules:
     - backendRefs:
+        # Route through the KEDA HTTP interceptor so a request can wake headroom
+        # from zero at night. The InterceptorRoute matches on the host and
+        # forwards to headroom-service.
         - group: ""
           kind: Service
-          name: headroom-service
+          name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
           port: 8080
           weight: 1
       matches:

--- a/k8s/talos/apps/headroom/interceptorroute.yaml
+++ b/k8s/talos/apps/headroom/interceptorroute.yaml
@@ -1,0 +1,15 @@
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: headroom
+  namespace: headroom
+spec:
+  target:
+    service: headroom-service
+    port: 8080
+  rules:
+    - hosts:
+        - headroom.local.bigd.no
+  scalingMetric:
+    concurrency:
+      targetValue: 100

--- a/k8s/talos/apps/headroom/kustomization.yaml
+++ b/k8s/talos/apps/headroom/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - data-pvc.yaml
 - deployment.yaml
 - httproute.yaml
+- interceptorroute.yaml
 - service.yaml
 - ciliumnetworkpolicy.yaml
 - scaledobject.yaml

--- a/k8s/talos/apps/headroom/scaledobject.yaml
+++ b/k8s/talos/apps/headroom/scaledobject.yaml
@@ -9,6 +9,11 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   cooldownPeriod: 300
+  # KEDA scales to the max of the triggers. The cron pins 1 replica through the
+  # day (07:00-23:00 Oslo) so headroom stays warm and never cold-starts while in
+  # use. Outside that window the cron is inactive, so scaling falls to the HTTP
+  # trigger: 0 with no traffic (scales down at night) but a request through the
+  # KEDA interceptor wakes it from zero.
   triggers:
     - type: cron
       metadata:
@@ -16,3 +21,7 @@ spec:
         start: "0 7 * * *"
         end: "0 23 * * *"
         desiredReplicas: "1"
+    - type: external-push
+      metadata:
+        scalerAddress: keda-add-ons-http-external-scaler.keda:9090
+        interceptorRoute: headroom

--- a/k8s/talos/infra/keda-http-add-on/referencegrant.yaml
+++ b/k8s/talos/infra/keda-http-add-on/referencegrant.yaml
@@ -32,6 +32,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: mealie
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: headroom
   to:
     - group: ""
       kind: Service


### PR DESCRIPTION
## Why

Headroom currently scales to zero outside 07:00-23:00 (cron trigger only), but with no HTTP trigger a request at night can't wake it — it stays down until 07:00. And pure wake-from-zero apps cold-start on every visit, which is annoying during the day. Goal: stay warm while in use, but still save resources overnight without going fully dark.

## What

Combine the existing cron trigger with a KEDA HTTP (`external-push`) trigger on the same ScaledObject. KEDA scales to the **max** of its triggers:

- **Day (07:00-23:00 Oslo):** cron pins 1 replica → always warm, no cold starts.
- **Night:** cron inactive; scaling follows the HTTP trigger → 0 with no traffic (scales down), but a request through the KEDA interceptor wakes it from zero.

Supporting changes (mirrors the blog-stage/homepage wake-from-zero pattern):
- `interceptorroute.yaml` (new) — registers headroom with the KEDA HTTP interceptor.
- `httproute.yaml` — routes through `keda-add-ons-http-interceptor-proxy` so a zero-scaled pod can wake.
- `ciliumnetworkpolicy.yaml` — allow the interceptor → headroom pod (:3001).
- `keda-http-add-on/referencegrant.yaml` — add `headroom` to the cross-namespace grant.

`minReplicaCount: 0`, `maxReplicaCount: 1`, `cooldownPeriod: 300` unchanged. (Cooldown is the 'how long after the last night request before scaling back down' knob — bump it if you want a longer tail.)

## Verification

- `kubectl kustomize` renders headroom; `kubectl diff -k` against the live cluster shows only the intended additive changes (InterceptorRoute created, external-push trigger added, HTTPRoute backend swapped, CNP interceptor rule, ReferenceGrant +headroom). CRDs accepted on server-side dry-run.