### PR TITLE
keda: day-warm cron for the wake-from-zero apps

### DIFF
--- a/k8s/talos/apps/audiobookshelf/scaledobject.yaml
+++ b/k8s/talos/apps/audiobookshelf/scaledobject.yaml
@@ -9,7 +9,16 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   cooldownPeriod: 300
+  # Cron keeps 1 replica warm through the day (07:00-23:00 Oslo) so the app
+  # doesn't cold-start on every visit; at night it scales to zero and the HTTP
+  # trigger wakes it on demand. KEDA scales to the max of the two triggers.
   triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Oslo
+        start: "0 7 * * *"
+        end: "0 23 * * *"
+        desiredReplicas: "1"
     - type: external-push
       metadata:
         scalerAddress: keda-add-ons-http-external-scaler.keda:9090

--- a/k8s/talos/apps/homepage/scaledobject.yaml
+++ b/k8s/talos/apps/homepage/scaledobject.yaml
@@ -9,7 +9,16 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   cooldownPeriod: 300
+  # Cron keeps 1 replica warm through the day (07:00-23:00 Oslo) so the app
+  # doesn't cold-start on every visit; at night it scales to zero and the HTTP
+  # trigger wakes it on demand. KEDA scales to the max of the two triggers.
   triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Oslo
+        start: "0 7 * * *"
+        end: "0 23 * * *"
+        desiredReplicas: "1"
     - type: external-push
       metadata:
         scalerAddress: keda-add-ons-http-external-scaler.keda:9090

--- a/k8s/talos/apps/it-tools/scaledobject.yaml
+++ b/k8s/talos/apps/it-tools/scaledobject.yaml
@@ -9,7 +9,16 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   cooldownPeriod: 300
+  # Cron keeps 1 replica warm through the day (07:00-23:00 Oslo) so the app
+  # doesn't cold-start on every visit; at night it scales to zero and the HTTP
+  # trigger wakes it on demand. KEDA scales to the max of the two triggers.
   triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Oslo
+        start: "0 7 * * *"
+        end: "0 23 * * *"
+        desiredReplicas: "1"
     - type: external-push
       metadata:
         scalerAddress: keda-add-ons-http-external-scaler.keda:9090

--- a/k8s/talos/apps/mealie/scaledobject.yaml
+++ b/k8s/talos/apps/mealie/scaledobject.yaml
@@ -9,7 +9,16 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   cooldownPeriod: 300
+  # Cron keeps 1 replica warm through the day (07:00-23:00 Oslo) so the app
+  # doesn't cold-start on every visit; at night it scales to zero and the HTTP
+  # trigger wakes it on demand. KEDA scales to the max of the two triggers.
   triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Oslo
+        start: "0 7 * * *"
+        end: "0 23 * * *"
+        desiredReplicas: "1"
     - type: external-push
       metadata:
         scalerAddress: keda-add-ons-http-external-scaler.keda:9090

--- a/k8s/talos/apps/omni-tools/scaledobject.yaml
+++ b/k8s/talos/apps/omni-tools/scaledobject.yaml
@@ -9,7 +9,16 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   cooldownPeriod: 300
+  # Cron keeps 1 replica warm through the day (07:00-23:00 Oslo) so the app
+  # doesn't cold-start on every visit; at night it scales to zero and the HTTP
+  # trigger wakes it on demand. KEDA scales to the max of the two triggers.
   triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Oslo
+        start: "0 7 * * *"
+        end: "0 23 * * *"
+        desiredReplicas: "1"
     - type: external-push
       metadata:
         scalerAddress: keda-add-ons-http-external-scaler.keda:9090

--- a/k8s/talos/apps/open-webui/scaledobject.yaml
+++ b/k8s/talos/apps/open-webui/scaledobject.yaml
@@ -9,7 +9,16 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 1
   cooldownPeriod: 300
+  # Cron keeps 1 replica warm through the day (07:00-23:00 Oslo) so the app
+  # doesn't cold-start on every visit; at night it scales to zero and the HTTP
+  # trigger wakes it on demand. KEDA scales to the max of the two triggers.
   triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Oslo
+        start: "0 7 * * *"
+        end: "0 23 * * *"
+        desiredReplicas: "1"
     - type: external-push
       metadata:
         scalerAddress: keda-add-ons-http-external-scaler.keda:9090


### PR DESCRIPTION
## Why

Follow-up to the headroom change (#401). The pure wake-from-zero apps cold-start on every visit, which is annoying for tools used through the day. Give them the same day-warm behavior: warm while in use, scale to zero overnight.

## What

Add a cron trigger (1 replica, 07:00-23:00 Oslo) alongside the existing `external-push` HTTP trigger on six user-facing apps: **mealie, homepage, it-tools, omni-tools, open-webui, audiobookshelf**. KEDA scales to the max of the two — so during the day the cron pins 1 (no cold starts), and at night both go idle and the HTTP trigger wakes on demand.

Only the ScaledObjects change — these apps already route through the KEDA interceptor and have ReferenceGrant entries.

## Deliberately excluded

- **blog-stage, portfolio-stage** — stage apps should scale to zero freely (cold-start on stage is fine).
- **ollama** — heavy LLM server; keeping it warm all day wastes resources and its cold-start is model-load, inherent. Left as pure wake-from-zero. (Say the word if you want it day-warmed too.)

## Verification

- `kubectl diff` against the live cluster shows only the added cron trigger per app (all six retain their HTTP trigger).