### PR TITLE
portfolio: public API docs page and generated OpenAPI document

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,25 +26,7 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Pick the prober, publish daily results as JSON the page can fetch (second file next to `status.json`, or merged into it), then swap the strip's data source and drop the "observed in-cluster" qualifier.
 - **Where:** `portfolio/src/components/infrastructure/LiveStatus.tsx` (`buildUptime`), `k8s/talos/apps/portfolio/status-publisher.yaml` (history merge step).
 
-## Portfolio modern — items deferred during initial build
-
-### Lighthouse / axe verification on the live stage URL
-- **What:** Run Lighthouse mobile + `@axe-core/cli` against the deployed `portfolio-stage` URL and act on findings (target ≥95 perf / 100 a11y / 100 SEO).
-- **Why deferred:** Site has not yet been deployed to stage — first push to `portfolio/**` will trigger CI and deploy.
-- **Unblock:** Push the branch, wait for ArgoCD sync, run Lighthouse against `portfolio-stage.local.bigd.no`.
-- **Where:** Run from `portfolio/` after deploy.
-
-### CI auto-rebuild of CV/résumé PDFs on content change
-- **What:** GitHub Action that runs `cd portfolio && make cv` (with TeX Live in CI) when `src/content/{site,resume,skills}.ts` changes, then commits the refreshed `public/{resume,cv}.pdf` back to the branch.
-- **Why deferred:** Manual `make cv` works fine for now; user can re-run locally and commit the PDFs. Adding CI = an extra ~3 GB Docker layer or a `xu-cheng/latex-action` step in the workflow.
-- **Unblock:** Decide whether the CI runs the full TeX Live image (slow but cached) or a slim variant. Add a `.github/workflows/build-cv.yaml`.
-- **Where:** `.github/workflows/`, `portfolio/Makefile` already has the targets.
-
-### Tighten résumé bullet copy for PDF density
-- **What:** The website resume bullets read more like LinkedIn paragraphs than CV bullets — fine for the web (long-form) but pushes the PDF to 2 pages with dense text. Tightening to 1 sentence per `\item` would let the résumé fit on a single page.
-- **Why deferred:** Single-source-of-truth design means tightening for the PDF would shorten the website too — that's a content-voice decision, not a tooling fix.
-- **Unblock:** Edit each `description` array in `src/content/resume.ts` to 1 punchy sentence per element.
-- **Where:** `portfolio/src/content/resume.ts`.
+## Portfolio
 
 ### Image optimization pass
 - **What:** Re-encode the migrated case-study images via `sharp` to a normalised max-width and AVIF + WebP. Drop any unused PNGs that weren't migrated.
@@ -64,10 +46,10 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Decide the route/assertion list, add `portfolio/tests/` with a Playwright config running via `mcr.microsoft.com/playwright` Docker image, add the CI job.
 - **Where:** `.github/workflows/ci-portfolio.yaml`, new `portfolio/tests/`.
 
-### ESLint 9 → 10 and TypeScript 5 → 6 bump
-- **What:** Bump `eslint` to `^10` and `typescript` to `^6` in `portfolio/package.json`. Held back during the 2026-06-16 dependency-upgrade pass (which shipped Node 22, Next 16.2.9, React 19.2.7, and the patch/minor batch).
-- **Why deferred:** `eslint-config-next@16.2.9` transitively bundles `typescript-eslint@8`, whose ESLint peer range tops out at 9 and which warns on TS 6.x. Forcing either major now risks a peer/plugin mismatch with zero runtime benefit (lint + typecheck only). The two unblock together.
-- **Unblock:** Wait for an `eslint-config-next` release built on `typescript-eslint@9` (supports ESLint 10 + TS 6). Then bump both, run a containerised `tsc --noEmit` and `next build`, and clear any new `strict`-mode diagnostics TS 6 surfaces.
+### ESLint 9 → 10 bump
+- **What:** Bump `eslint` to `^10` in `portfolio/package.json`. Originally paired with a TypeScript 5 → 6 bump; the TS half has since shipped (`typescript` is now `^6.0.0`), leaving only ESLint.
+- **Why deferred:** `eslint-config-next@16.2.10` transitively bundles `typescript-eslint@8`, whose ESLint peer range tops out at 9. Forcing the major risks a peer/plugin mismatch with zero runtime benefit (lint only).
+- **Unblock:** Wait for an `eslint-config-next` release built on `typescript-eslint@9` (supports ESLint 10). Then bump, and run a containerised `make lint` to confirm the config still loads.
 - **Where:** `portfolio/package.json`, `portfolio/eslint.config.mjs`; see `portfolio/DEPENDENCY-UPGRADE-PLAN.md` (Phase 3).
 
 ## Portfolio API

--- a/portfolio/src/app/api/page.tsx
+++ b/portfolio/src/app/api/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import { Section } from "@/components/primitives/Section";
+import { Reveal } from "@/components/primitives/Reveal";
+import { Tag } from "@/components/primitives/Tag";
+import {
+  apiIntro,
+  endpoints,
+  errorEnvelope,
+  formatSample,
+  type Endpoint,
+} from "@/content/api";
+
+export const metadata: Metadata = {
+  title: "API — Morten Nordbye",
+  description:
+    "The public JSON API this site serves: endpoints, authentication, caching and example responses.",
+};
+
+function Code({ children }: { children: string }) {
+  return (
+    <pre className="overflow-x-auto rounded-lg border border-line bg-bg-2/60 p-4 font-mono text-xs leading-relaxed text-fg-2">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function EndpointBlock({ endpoint }: { endpoint: Endpoint }) {
+  return (
+    <div className="flex flex-col gap-4 bg-bg p-8">
+      <div className="flex flex-wrap items-center gap-3">
+        <Tag variant={endpoint.method === "POST" ? "warm" : "accent"}>
+          {endpoint.method}
+        </Tag>
+        <code className="font-mono text-sm text-fg">{endpoint.path}</code>
+        <Tag variant="muted">{endpoint.auth}</Tag>
+      </div>
+
+      <div>
+        <h3 className="text-h3 text-fg">{endpoint.summary}</h3>
+        <p className="mt-3 max-w-2xl text-sm text-fg-2 leading-relaxed">
+          {endpoint.detail}
+        </p>
+      </div>
+
+      <dl className="font-mono text-xs text-fg-3">
+        <dt className="sr-only">Cache policy</dt>
+        <dd>cache-control: {endpoint.caching}</dd>
+      </dl>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div>
+          <p className="eyebrow mb-2">request</p>
+          <Code>{endpoint.curl}</Code>
+        </div>
+        <div>
+          <p className="eyebrow mb-2">response</p>
+          <Code>{formatSample(endpoint.sample)}</Code>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ApiPage() {
+  return (
+    <main className="pt-32">
+      <Section
+        eyebrow="api"
+        heading="This site has a public API."
+        description={apiIntro.blurb}
+      >
+        <div className="grid gap-8 md:grid-cols-2 md:gap-12">
+          <div>
+            <p className="eyebrow mb-2">base url</p>
+            <Code>{apiIntro.base}</Code>
+          </div>
+          <div>
+            <p className="eyebrow mb-2">error envelope</p>
+            <Code>{formatSample(errorEnvelope)}</Code>
+          </div>
+        </div>
+
+        <p className="mt-8 text-sm text-fg-2 leading-relaxed">
+          The whole surface is also published as an{" "}
+          <a
+            href="/api/v1/openapi.json"
+            className="focus-ring text-fg underline decoration-accent decoration-2 underline-offset-4 hover:text-accent"
+          >
+            OpenAPI 3.1 document
+          </a>
+          , generated from the same definitions as this page, so it can be
+          imported straight into Postman, Bruno or a client generator.
+        </p>
+      </Section>
+
+      <Section
+        eyebrow="reference"
+        heading="Endpoints."
+        description={`${endpoints.length} routes. Start at the discovery index if you would rather read it as JSON.`}
+        className="border-t border-line"
+      >
+        <div className="grid gap-px overflow-hidden rounded-lg border border-line bg-line">
+          {endpoints.map((endpoint, i) => (
+            <Reveal key={endpoint.path} delay={i * 0.05}>
+              <EndpointBlock endpoint={endpoint} />
+            </Reveal>
+          ))}
+        </div>
+      </Section>
+    </main>
+  );
+}

--- a/portfolio/src/app/api/v1/openapi.json/route.ts
+++ b/portfolio/src/app/api/v1/openapi.json/route.ts
@@ -1,0 +1,10 @@
+import { json } from "@/lib/api";
+import { buildOpenApi } from "@/content/api";
+
+// OpenAPI 3.1 document, generated from the endpoint definitions in
+// @/content/api. Static: the spec only changes when the code does.
+export const dynamic = "force-static";
+
+export function GET() {
+  return json(buildOpenApi());
+}

--- a/portfolio/src/app/api/v1/route.ts
+++ b/portfolio/src/app/api/v1/route.ts
@@ -1,23 +1,11 @@
-import { json, API_VERSION } from "@/lib/api";
-import { site } from "@/content/site";
+import { json } from "@/lib/api";
+import { buildIndex } from "@/content/api";
 
-// Discovery index — the API's "front door". Static: the endpoint map only
-// changes when the code does.
+// Discovery index — the API's "front door". Generated from the endpoint
+// definitions in @/content/api so it cannot drift from the docs page or the
+// OpenAPI document. Static: the endpoint map only changes when the code does.
 export const dynamic = "force-static";
 
 export function GET() {
-  return json({
-    name: `${site.name} — portfolio API`,
-    version: API_VERSION,
-    docs: `${site.url}/api/${API_VERSION}`,
-    endpoints: [
-      { method: "GET", path: "/api/health", desc: "Liveness probe." },
-      { method: "GET", path: "/api/v1", desc: "This index." },
-      { method: "GET", path: "/api/v1/profile", desc: "Identity, certifications, skills, socials." },
-      { method: "GET", path: "/api/v1/infra", desc: "Live Talos cluster status and 30-day uptime." },
-      { method: "GET", path: "/api/v1/blog", desc: "Latest posts from blog.nordbye.it." },
-      { method: "POST", path: "/api/v1/echo", desc: "Authenticated write example (Bearer key)." },
-    ],
-    notes: "Reads are public. Writes require an API key.",
-  });
+  return json(buildIndex());
 }

--- a/portfolio/src/components/layout/Footer.tsx
+++ b/portfolio/src/components/layout/Footer.tsx
@@ -23,6 +23,13 @@ export function Footer() {
             >
               See how this page reaches you
             </Link>
+            , or read it as{" "}
+            <Link
+              href="/api"
+              className="focus-ring text-fg underline decoration-accent decoration-2 underline-offset-4 hover:text-accent"
+            >
+              JSON over the public API
+            </Link>
             .
           </p>
         </div>

--- a/portfolio/src/content/api.ts
+++ b/portfolio/src/content/api.ts
@@ -1,0 +1,468 @@
+/**
+ * Single source of truth for the public API surface under /api.
+ *
+ * Three consumers derive from this module and must never be edited to
+ * describe an endpoint directly:
+ *   - the human docs page at /api            (src/app/api/page.tsx)
+ *   - the machine index at /api/v1           (src/app/api/v1/route.ts)
+ *   - the OpenAPI document at /api/v1/openapi.json
+ *
+ * Adding a route means adding an entry here and nothing else. Sample bodies
+ * are real objects (not display strings) so the same value renders on the
+ * page and serves as the OpenAPI example — keep them short but valid, and
+ * re-check them against the live endpoint when a route changes.
+ */
+import { site } from "@/content/site";
+
+export const API_VERSION = "v1";
+
+/** JSON Schema fragment. Loose by design — this module writes them by hand. */
+type Schema = Record<string, unknown>;
+
+export type Endpoint = {
+  method: "GET" | "POST";
+  operationId: string;
+  path: string;
+  auth: "public" | "api key";
+  summary: string;
+  detail: string;
+  caching: string;
+  curl: string;
+  sample: unknown;
+  /** Response body schema, typed down to the field level. */
+  schema: Schema;
+  /**
+   * Failure responses the handler can actually return, beyond the 401 that
+   * every authenticated route gets automatically. Message strings must match
+   * what the route passes to apiError().
+   */
+  errors?: readonly { status: number; description: string; message: string }[];
+};
+
+// Shorthands so the schemas below stay readable at a glance.
+const str: Schema = { type: "string" };
+const int: Schema = { type: "integer" };
+const bool: Schema = { type: "boolean" };
+const dateTime: Schema = { type: "string", format: "date-time" };
+const uri: Schema = { type: "string", format: "uri" };
+
+function obj(properties: Record<string, Schema>, required?: string[]): Schema {
+  return {
+    type: "object",
+    properties,
+    required: required ?? Object.keys(properties),
+  };
+}
+
+function arr(items: Schema): Schema {
+  return { type: "array", items };
+}
+
+export const apiIntro = {
+  base: site.url,
+  blurb:
+    "The site serves its own content over a small JSON API. Reads are public and need no key, responses carry permissive CORS headers so they work from a browser, and every route returns the same error envelope. It runs in the same Node process as the pages you are reading, on the cluster described on the infrastructure page.",
+};
+
+export const endpoints: readonly Endpoint[] = [
+  {
+    method: "GET",
+    operationId: "getHealth",
+    path: "/api/health",
+    auth: "public",
+    summary: "Liveness probe.",
+    detail:
+      "Unversioned and always dynamic, so it reflects the running process rather than a build-time cache. This is the target Kubernetes uses for its probes.",
+    caching: "no-store",
+    curl: "curl -s https://nordbye.it/api/health",
+    sample: { status: "ok" },
+    schema: obj({ status: { type: "string", enum: ["ok"] } }),
+  },
+  {
+    method: "GET",
+    operationId: "getIndex",
+    path: "/api/v1",
+    auth: "public",
+    summary: "Discovery index.",
+    detail:
+      "The front door: a machine-readable map of every endpoint, generated from the same source as this page. Static, because the map only changes when the code does.",
+    caching: "public, max-age=60",
+    curl: "curl -s https://nordbye.it/api/v1",
+    // Shape excerpt. The live response lists every endpoint below.
+    sample: {
+      name: "Morten Nordbye — portfolio API",
+      version: "v1",
+      docs: "https://nordbye.it/api",
+      openapi: "https://nordbye.it/api/v1/openapi.json",
+      endpoints: [
+        { method: "GET", path: "/api/health", desc: "Liveness probe." },
+      ],
+      notes: "Reads are public. Writes require an API key.",
+    },
+    schema: obj({
+      name: str,
+      version: str,
+      docs: uri,
+      openapi: uri,
+      endpoints: arr(
+        obj({
+          method: { type: "string", enum: ["GET", "POST"] },
+          path: str,
+          desc: str,
+        }),
+      ),
+      notes: str,
+    }),
+  },
+  {
+    method: "GET",
+    operationId: "getOpenapi",
+    path: "/api/v1/openapi.json",
+    auth: "public",
+    summary: "OpenAPI 3.1 document.",
+    detail:
+      "The whole surface as a spec you can import into Postman, Bruno, Swagger UI or a client generator. Generated from the same endpoint definitions that render this page, so it cannot drift from the routes it describes.",
+    caching: "public, max-age=60",
+    curl: "curl -s https://nordbye.it/api/v1/openapi.json",
+    sample: {
+      openapi: "3.1.0",
+      info: { title: "Morten Nordbye — portfolio API", version: "v1" },
+      servers: [{ url: "https://nordbye.it" }],
+      paths: { "/api/health": { get: { operationId: "getHealth" } } },
+    },
+    // The response is itself an OpenAPI document; describing its full grammar
+    // here would restate the OpenAPI meta-schema, so pin the top level only.
+    schema: {
+      type: "object",
+      properties: {
+        openapi: { type: "string", const: "3.1.0" },
+        info: { type: "object" },
+        servers: { type: "array" },
+        components: { type: "object" },
+        paths: { type: "object" },
+      },
+      required: ["openapi", "info", "paths"],
+      additionalProperties: true,
+    },
+  },
+  {
+    method: "GET",
+    operationId: "getProfile",
+    path: "/api/v1/profile",
+    auth: "public",
+    summary: "Identity, certifications, skills and socials.",
+    detail:
+      "Served straight from the content modules that render the site itself, so the API and the pages can never disagree. Refreshed on each deploy.",
+    caching: "public, max-age=60",
+    curl: "curl -s https://nordbye.it/api/v1/profile",
+    sample: {
+      name: "Morten Nordbye",
+      role: "Cloud Engineer & Architect",
+      location: "Oslo, Norway",
+      url: "https://nordbye.it",
+      summary: "Cloud engineer working on automated, secure infrastructure…",
+      socials: [{ label: "GitHub", href: "https://github.com/mortennordbye" }],
+      certifications: [
+        {
+          title: "CKA: Certified Kubernetes Administrator",
+          issuer: "The Linux Foundation",
+          date: "Jan 2024",
+        },
+      ],
+      skills: [{ label: "Kubernetes", level: 80, group: "platform" }],
+    },
+    schema: obj({
+      name: str,
+      role: str,
+      location: str,
+      url: uri,
+      summary: str,
+      socials: arr(obj({ label: str, href: uri })),
+      certifications: arr(
+        obj(
+          {
+            title: str,
+            issuer: str,
+            date: str,
+            // Omitted entirely for certifications without a public ID.
+            credentialId: str,
+          },
+          ["title", "issuer", "date"],
+        ),
+      ),
+      skills: arr(
+        obj({
+          label: str,
+          // Proficiency as a percentage, the scale the skill bars render.
+          level: { type: "integer", minimum: 0, maximum: 100 },
+          group: str,
+        }),
+      ),
+    }),
+  },
+  {
+    method: "GET",
+    operationId: "getInfra",
+    path: "/api/v1/infra",
+    auth: "public",
+    summary: "Live Talos cluster status and 30-day history.",
+    detail:
+      "A CronJob in the cluster writes a status ConfigMap every five minutes; it is mounted into the pod and read fresh per request. When the file is not mounted the route falls back to a baked snapshot and marks it with a source field. This is what drives the infrastructure page.",
+    caching: "public, max-age=30",
+    curl: "curl -s https://nordbye.it/api/v1/infra",
+    sample: {
+      generatedAt: "2026-07-19T08:05:03Z",
+      build: "0.0.80",
+      argocd: { sync: "Synced", health: "Healthy" },
+      nodes: { ready: 6, total: 6 },
+      versions: { kubernetes: "v1.34.0", talos: "v1.11.6" },
+      cert: { notAfter: "2026-09-25T11:41:28Z" },
+      history: [{ d: "2026-07-16", ok: 286, total: 288 }],
+    },
+    // Passthrough of the status ConfigMap, so extra keys are allowed. Only
+    // argocd and nodes are guaranteed: the baked fallback carries just those.
+    schema: {
+      type: "object",
+      properties: {
+        generatedAt: dateTime,
+        build: str,
+        deployedAt: dateTime,
+        argocd: obj(
+          { sync: str, health: str, syncedAt: dateTime },
+          ["sync", "health"],
+        ),
+        nodes: obj({ ready: int, total: int }),
+        versions: obj({ kubernetes: str, talos: str }),
+        cert: obj({ notAfter: dateTime }),
+        history: arr(
+          obj({
+            d: { type: "string", format: "date" },
+            ok: int,
+            total: int,
+          }),
+        ),
+        // Present only when serving the baked fallback snapshot.
+        source: { type: "string", enum: ["snapshot"] },
+      },
+      required: ["argocd", "nodes"],
+      additionalProperties: true,
+    },
+  },
+  {
+    method: "GET",
+    operationId: "getBlog",
+    path: "/api/v1/blog",
+    auth: "public",
+    summary: "Latest five posts from blog.nordbye.it.",
+    detail:
+      "Parses the Hugo RSS feed and revalidates hourly, which keeps the blog origin from being hit once per request. Returns 502 with the standard error envelope when the feed is unreachable.",
+    caching: "revalidated hourly",
+    curl: "curl -s https://nordbye.it/api/v1/blog",
+    errors: [
+      {
+        status: 502,
+        description:
+          "The blog feed could not be reached, or answered with a non-2xx status.",
+        message: "blog feed unreachable",
+      },
+    ],
+    sample: {
+      source: "https://blog.nordbye.it/index.xml",
+      count: 5,
+      posts: [
+        {
+          title: "Tuning Azure WAF Without Paying Log Analytics Prices",
+          url: "https://blog.nordbye.it/blog/lawless-waf/",
+          publishedAt: "2026-07-16T00:00:00.000Z",
+          published: "Thu, 16 Jul 2026 00:00:00 +0000",
+        },
+      ],
+    },
+    schema: obj({
+      source: uri,
+      count: int,
+      posts: arr(
+        obj({
+          title: str,
+          url: uri,
+          // Null when the feed item carries no parseable pubDate.
+          publishedAt: { type: ["string", "null"], format: "date-time" },
+          published: { type: ["string", "null"] },
+        }),
+      ),
+    }),
+  },
+  {
+    method: "POST",
+    operationId: "postEcho",
+    path: "/api/v1/echo",
+    auth: "api key",
+    summary: "Authenticated write example.",
+    detail:
+      "A reference write that proves the authenticated POST seam without persisting anything. The key is compared in constant time, and writes are refused outright when no key is configured on the server. Real stateful writes build on this pattern and add a datastore.",
+    caching: "no-store",
+    curl: `curl -s -X POST https://nordbye.it/api/v1/echo \\
+  -H 'authorization: Bearer $PORTFOLIO_API_KEY' \\
+  -H 'content-type: application/json' \\
+  -d '{"hello":"world"}'`,
+    sample: { ok: true, echo: { hello: "world" } },
+    errors: [
+      {
+        status: 400,
+        description: "The request body was present but not valid JSON.",
+        message: "body must be valid JSON",
+      },
+    ],
+    schema: obj({
+      ok: { ...bool, const: true },
+      // Whatever JSON the caller sent back verbatim, or null for an empty body.
+      echo: {},
+    }),
+  },
+];
+
+/** The uniform error shape every route returns on failure. */
+export const errorEnvelope = {
+  error: { status: 401, message: "missing or invalid API key" },
+};
+
+/** Pretty-print a sample body for display or embedding. */
+export function formatSample(sample: unknown): string {
+  return JSON.stringify(sample, null, 2);
+}
+
+/** Payload served by the discovery index at /api/v1. */
+export function buildIndex() {
+  return {
+    name: `${site.name} — portfolio API`,
+    version: API_VERSION,
+    docs: `${site.url}/api`,
+    openapi: `${site.url}/api/${API_VERSION}/openapi.json`,
+    endpoints: endpoints.map((e) => ({
+      method: e.method,
+      path: e.path,
+      desc: e.summary,
+    })),
+    notes: "Reads are public. Writes require an API key.",
+  };
+}
+
+/** OpenAPI 3.1 document describing the whole surface. */
+export function buildOpenApi() {
+  const paths: Record<string, Record<string, unknown>> = {};
+
+  for (const e of endpoints) {
+    const secured = e.auth === "api key";
+
+    // Message strings mirror what the route handlers actually return.
+    const errorResponse = (
+      status: number,
+      description: string,
+      message: string,
+    ) => ({
+      [status]: {
+        description,
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+            example: { error: { status, message } },
+          },
+        },
+      },
+    });
+
+    const operation: Record<string, unknown> = {
+      operationId: e.operationId,
+      summary: e.summary,
+      description: e.detail,
+      // Explicit on every operation: [] means the route needs no credentials.
+      security: secured ? [{ bearerAuth: [] }] : [],
+      responses: {
+        "200": {
+          description: "Success.",
+          content: {
+            "application/json": {
+              schema: e.schema,
+              example: e.sample,
+            },
+          },
+        },
+        ...(secured
+          ? errorResponse(
+              401,
+              "Missing or invalid API key.",
+              "missing or invalid API key",
+            )
+          : {}),
+        ...(e.errors ?? []).reduce(
+          (acc, err) => ({
+            ...acc,
+            ...errorResponse(err.status, err.description, err.message),
+          }),
+          {},
+        ),
+      },
+    };
+
+    if (secured) {
+      operation.requestBody = {
+        required: false,
+        description:
+          "Any JSON value. Returned verbatim under the echo key. An empty body echoes null.",
+        content: {
+          "application/json": {
+            schema: {},
+            example: { hello: "world" },
+          },
+        },
+      };
+    }
+
+    paths[e.path] = {
+      ...(paths[e.path] ?? {}),
+      [e.method.toLowerCase()]: operation,
+    };
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: `${site.name} — portfolio API`,
+      version: API_VERSION,
+      description: apiIntro.blurb,
+      contact: { name: site.name, url: `${site.url}/api` },
+      license: {
+        name: "Apache-2.0",
+        identifier: "Apache-2.0",
+      },
+    },
+    servers: [{ url: site.url, description: "Production." }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          description:
+            "Static API key presented as a Bearer token, or via the x-api-key header.",
+        },
+      },
+      schemas: {
+        Error: {
+          type: "object",
+          properties: {
+            error: {
+              type: "object",
+              properties: {
+                status: { type: "integer" },
+                message: { type: "string" },
+              },
+              required: ["status", "message"],
+            },
+          },
+          required: ["error"],
+        },
+      },
+    },
+    paths,
+  };
+}

--- a/portfolio/src/lib/api.ts
+++ b/portfolio/src/lib/api.ts
@@ -58,5 +58,3 @@ export function requireApiKey(req: Request): boolean {
   const b = Buffer.from(expected);
   return a.length === b.length && timingSafeEqual(a, b);
 }
-
-export const API_VERSION = "v1";


### PR DESCRIPTION
## Why

The API had a machine-readable index at `/api/v1` but nothing a human could read, and that index hardcoded its own copy of the endpoint list. Any new route meant editing two places with nothing to keep them honest.

## What

A static reference page at `/api` and an OpenAPI 3.1 document at `/api/v1/openapi.json`.

Both derive from a new content module, `portfolio/src/content/api.ts`, as does the existing discovery index. The endpoint list now lives in one array; adding a route means editing that array and nothing else.

The spec carries field-level response schemas rather than a loose `type: object`, the bearer security scheme, explicit `security: []` on public operations, and the failure responses the handlers actually return: 401 on echo without a key, 400 on echo with unparseable JSON, 502 on blog when the feed is unreachable.

Also removes `API_VERSION` from `lib/api.ts`, which the rewritten index route left unused.

## Verification

Lint (0 errors), typecheck, and the production image build are green. The 9 lint warnings are pre-existing react-hooks findings in unrelated components.

Redocly reports no errors against the spec. Live responses from both localhost and production validate against the schemas with ajv, as does every documented example. That check earned its place: it caught `skills[].level` being a 0-100 percentage rather than the 1-5 scale I first wrote, which Redocly passed happily. Both `/api/v1/infra` branches were covered, production serving the real ConfigMap and local the baked fallback.

All three echo paths were exercised against the built image with a key configured (401 without, 400 on bad JSON, 200 on success), confirming the documented message strings match the handlers.

Page checked in the browser at 1440px and 390px; `/` and `/infrastructure` still render.

Six `operation-4xx-response` warnings remain from Redocly's default ruleset. These are public GETs with no 4xx path, and documenting 404s the routes never return would make the spec inaccurate to satisfy a linter.

The first commit is unrelated backlog housekeeping: three portfolio entries whose premises no longer hold, and the ESLint/TypeScript entry narrowed to ESLint now that TypeScript 6 has shipped.
