### PR TITLE
portfolio: hint the LCP image and fix the contact list markup

### DIFF
--- a/portfolio/src/components/PortraitCard.tsx
+++ b/portfolio/src/components/PortraitCard.tsx
@@ -9,6 +9,9 @@ export function PortraitCard() {
           alt="Morten Nordbye, Cloud Engineer & Architect, Oslo"
           fill
           priority
+          // `priority` emits the preload link but not the attribute itself;
+          // this image is the measured LCP element, so hint it explicitly.
+          fetchPriority="high"
           sizes="(max-width: 768px) 100vw, 33vw"
           className="object-cover saturate-[0.92] contrast-[1.05]"
           style={{ objectPosition: "center top" }}

--- a/portfolio/src/components/sections/CtaContact.tsx
+++ b/portfolio/src/components/sections/CtaContact.tsx
@@ -63,15 +63,19 @@ function Row({
   label: string;
   value: string;
 }) {
+  // A <dl> may only contain <dt>/<dd> groups, optionally wrapped in a single
+  // <div> — the icon <span> sitting alongside them failed axe's definition-list
+  // rule. `display: contents` on the <dt> keeps the icon and label as direct
+  // grid items, so the rendered layout is unchanged.
   return (
-    <div className="flex items-start gap-4 py-5">
-      <span className="mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-md border border-line-2 text-accent">
-        {icon}
-      </span>
-      <div>
-        <dt className="eyebrow">{label}</dt>
-        <dd className="mt-1 text-fg">{value}</dd>
-      </div>
+    <div className="grid grid-cols-[2rem_1fr] items-start gap-x-4 py-5">
+      <dt className="contents">
+        <span className="col-start-1 row-span-2 mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-md border border-line-2 text-accent">
+          {icon}
+        </span>
+        <span className="eyebrow col-start-2">{label}</span>
+      </dt>
+      <dd className="col-start-2 mt-1 text-fg">{value}</dd>
     </div>
   );
 }


### PR DESCRIPTION
## Why

A fresh Lighthouse run on real runners puts the site at performance 79 and accessibility 93, against 94 and 100 for the blog. This addresses the two findings from that report that are fixable without changing how the site looks.

## What

The portrait in `AboutSection` is the measured LCP element. It already passes `priority`, which emits the `<link rel="preload" as="image">`, but the rendered `<img>` carried no `fetchpriority` attribute, so Lighthouse's `lcp-discovery` check reported the priority hint as missing. I confirmed this against both the production HTML and a fresh local build, so it is a real gap rather than a stale deploy. Now set explicitly.

The contact `<dl>` wrapped each `dt`/`dd` pair in a `div` that also contained the icon `span`. A `<dl>` may only hold `dt`/`dd`, optionally grouped in a `div` containing nothing else, so this broke axe's `definition-list` and `dlitem` rules and was the sole cause of the accessibility score. Restructured so the `dl` contains only `div` wrappers holding `dt`/`dd`, with `display: contents` on the `dt` keeping the icon and label as direct grid items.

## Verification

Lint (0 errors), typecheck, and the production image build are green.

A full-page pixel diff of the homepage before and after the change shows the contact block byte-identical. The only differing regions are the animated hero and the footer's render-time stamp, both of which vary between any two renders.

A DOM assertion of axe's `definition-list` and `dlitem` conditions passes: the one `<dl>` on the page contains only `div` wrappers holding exactly `dt`/`dd`, with no orphaned items.

## Measured and deliberately not done

Two changes that looked promising did not survive measurement.

Adding `preconnect` for Cloudflare Insights is reported by Lighthouse as a 300ms saving, but the blog carries the identical finding with the identical 301.8ms estimate and still scores 94. It is a generic heuristic, not a per-site measurement, and would not have moved the score.

`experimental.inlineCss` removes the page's only render-blocking resource. Built both ways from the same commit and compared like for like: inlining costs 27.7 KB more gzipped on every cold load in order to save one 13 KB request that is cacheable and shared across routes. Net loss, so it was dropped.

## Still open

LCP is 4.4s and 65% of it (2834ms) is render delay, not download. Attributing that needs a proper performance trace rather than guesswork; the globe is not the cause, since `InlineGlobe` already defers WebGL behind a user-input facade that Lighthouse never triggers.
