### PR TITLE
portfolio: stop preloading the below-the-fold portrait

### DIFF
--- a/portfolio/src/components/PortraitCard.tsx
+++ b/portfolio/src/components/PortraitCard.tsx
@@ -4,14 +4,18 @@ export function PortraitCard() {
   return (
     <figure className="relative overflow-hidden rounded-lg border border-line bg-surface/40 backdrop-blur-sm">
       <div className="relative aspect-[4/5] w-full overflow-hidden">
+        {/*
+          Deliberately not `priority`. At Lighthouse's 412x823 mobile viewport
+          this portrait sits at y=862 — below the fold — and the LCP element is
+          the hero paragraph, not this image. Preloading it at high priority
+          only makes it compete with the resources that decide first paint.
+          Measured over 3 throttled runs each (4x CPU, 1.6 Mbit): FCP/LCP 1940 ms
+          with the hint, 1852 ms without.
+        */}
         <Image
           src="/images/profile.webp"
           alt="Morten Nordbye, Cloud Engineer & Architect, Oslo"
           fill
-          priority
-          // `priority` emits the preload link but not the attribute itself;
-          // this image is the measured LCP element, so hint it explicitly.
-          fetchPriority="high"
           sizes="(max-width: 768px) 100vw, 33vw"
           className="object-cover saturate-[0.92] contrast-[1.05]"
           style={{ objectPosition: "center top" }}


### PR DESCRIPTION
## Why

#407 added `fetchpriority="high"` to the portrait because Lighthouse's `lcp-discovery` check reported the priority hint as missing. That was the wrong conclusion, and the follow-up Lighthouse run bore it out: LCP went 4.4s to 4.6s and TBT 100ms to 120ms.

Tracing the page in real Chrome under Lighthouse's own conditions (412x823 viewport, 4x CPU throttle, 1.6 Mbit / 150 ms RTT) shows why. The portrait renders at y=862, below the 823 px fold, and the actual LCP element is the hero paragraph. Preloading an image that is neither above the fold nor the LCP candidate just makes it compete with the resources that decide first paint.

## What

Drops both `fetchPriority="high"` and `priority` from the portrait, with a comment recording the measurement so the hint does not get re-added on the strength of the same audit line.

## Verification

Two images built from the same commit, differing only in this prop, traced 3 times each under identical throttling:

```
                  FCP/LCP    portrait download completes
with priority      1940ms    834ms
without priority   1852ms    5591ms
```

Per-run figures were 1936/1940/1944 against 1844/1852/1852 — no overlap between the groups. The portrait now finishes loading well after the critical window, which is correct for a below-the-fold image.

Lint (0 errors) and typecheck are green.

## Note

The accessibility half of #407 is untouched and stays. It took the site from 93 to 100 and is confirmed live.

The remaining performance work is FCP, since the LCP element is hero text and the two land at the same moment. That is a fonts, CSS and hydration question rather than an image one, and is not addressed here.
