### PR TITLE
portfolio(fun): fix the room's dead ends, and make entering it a choice

### DIFF
--- a/portfolio/src/components/CommandPalette.tsx
+++ b/portfolio/src/components/CommandPalette.tsx
@@ -128,6 +128,12 @@ export function CommandPalette({ work, services }: Props) {
           ]),
       },
       {
+        id: "cd fun",
+        label: "cd fun",
+        hint: "/fun",
+        run: () => jump("/fun"),
+      },
+      {
         id: "clear",
         label: "clear",
         hint: "clear buffer",

--- a/portfolio/src/components/fun/FunRoom.tsx
+++ b/portfolio/src/components/fun/FunRoom.tsx
@@ -24,6 +24,8 @@ import {
   LANTERN,
   ROOM,
   Room,
+  type LightKey,
+  type Lights,
   type Placement,
 } from "./Room";
 import { CodeScreen, type Tab } from "./CodeScreen";
@@ -377,8 +379,19 @@ function TerminalFocus({
 }
 
 /** Screens are the light source, so the fill has to follow them on. */
-function Lighting({ poweredCount }: { poweredCount: number }) {
+function Lighting({
+  poweredCount,
+  lights,
+}: {
+  poweredCount: number;
+  lights: Lights;
+}) {
   const lit = poweredCount / POWER_STEPS;
+  /* Each fitting reads its own switch. The two sources that are not
+     fittings follow something else: the ceiling bounce belongs to the lantern
+     that throws it, and the door-end fill is spill, so it tracks whether the
+     room is lit at all rather than glowing with no source behind it. */
+  const anyOn = lights.lantern || lights.desk || lights.shelf;
   return (
     <>
       {/* A room lit the way a living room is at nine in the evening: nothing
@@ -398,8 +411,14 @@ function Lighting({ poweredCount }: { poweredCount: number }) {
           surface the same sepia and the sage walls disappeared entirely. This
           is the blue evening light in the room the lamps are fighting, and it
           is what leaves the walls green and the lamplight orange. */}
-      <ambientLight intensity={0.16} color="#9fb2b8" />
-      <hemisphereLight args={["#aac2c8", "#4a3a2c", 0.38]} />
+      {/* With the lamps off these come up rather than staying put. At the lit
+          values the room goes almost black, and a visitor who switched the
+          light off across the room then cannot see the lamp well enough to
+          switch it back on — the same dead end the terminal used to be. Raised,
+          it reads as a room at night with the lamps off: cool, low, navigable,
+          and still obviously unlit, because the warmth is what actually left. */}
+      <ambientLight intensity={anyOn ? 0.16 : 0.34} color="#9fb2b8" />
+      <hemisphereLight args={["#aac2c8", "#4a3a2c", anyOn ? 0.38 : 0.62]} />
 
       {/* The lantern. Main light and the only shadow caster, sitting inside
           the shade at the height the shade actually is. A point light this low
@@ -407,7 +426,7 @@ function Lighting({ poweredCount }: { poweredCount: number }) {
           down, which is most of what separates lamplight from daylight. */}
       <pointLight
         position={[LANTERN.x, 0.96, LANTERN.z]}
-        intensity={26}
+        intensity={lights.lantern ? 26 : 0}
         distance={8.5}
         decay={1.5}
         color="#ffa758"
@@ -422,7 +441,7 @@ function Lighting({ poweredCount }: { poweredCount: number }) {
           ceiling stays flat grey and quietly contradicts the fitting. */}
       <pointLight
         position={[LANTERN.x - 0.5, ROOM.h - 0.5, LANTERN.z]}
-        intensity={5}
+        intensity={lights.lantern ? 5 : 0}
         distance={4.4}
         decay={1.9}
         color="#ff9a45"
@@ -430,7 +449,7 @@ function Lighting({ poweredCount }: { poweredCount: number }) {
       {/* the mushroom lamp on the desk, the second pool of warm */}
       <pointLight
         position={[-1.0, 1.0, -ROOM.d / 2 + 0.55]}
-        intensity={8.5}
+        intensity={lights.desk ? 8.5 : 0}
         distance={3.6}
         decay={1.9}
         color="#ffb066"
@@ -440,7 +459,7 @@ function Lighting({ poweredCount }: { poweredCount: number }) {
           visitor can never find. */}
       <pointLight
         position={[-0.4, 1.5, ROOM.d / 2 - 1.4]}
-        intensity={3.6}
+        intensity={anyOn ? 3.6 : 0}
         distance={5.4}
         decay={1.8}
         color="#ffb877"
@@ -519,6 +538,8 @@ function Scene({
   paused,
   coarse,
   touchMove,
+  lights,
+  onToggleLight,
 }: {
   data: PanelProps;
   source: SourceExcerpt;
@@ -542,6 +563,8 @@ function Scene({
   onTerminalEnter: () => void;
   onTerminalExit: () => void;
   paused: boolean;
+  lights: Lights;
+  onToggleLight: (k: LightKey) => void;
 }) {
   const [poweredCount, setPoweredCount] = useState(0);
   /* True while the camera is easing back out of the terminal. `paused` has
@@ -592,7 +615,7 @@ function Scene({
     <>
       <color attach="background" args={["#1b1410"]} />
       <fog attach="fog" args={["#241a13", 16, 42]} />
-      <Lighting poweredCount={poweredCount} />
+      <Lighting poweredCount={poweredCount} lights={lights} />
       <InteractionProvider enabled={interacting && !paused} onPrompt={onPrompt}>
       <Suspense fallback={null}>
         {/* Image-based lighting. Does most of the work on specular: without an
@@ -616,6 +639,8 @@ function Scene({
           onOpenCert={onOpenCert}
           onOpenCard={onOpenCard}
           onExitRoom={onExitRoom}
+          lights={lights}
+          onToggleLight={onToggleLight}
         />
         <Post />
         {/* Fires only once everything above has resolved, which is the honest
@@ -649,7 +674,23 @@ function Scene({
         enabled={phase === "exploring" && !paused && !settling}
         move={touchMove}
       />
-      <PointerLockControls ref={controlsRef} selector="#fun-lock-target" />
+      {/* The selector is swapped for one that matches nothing while something
+          has focus, and that is load-bearing rather than cosmetic. drei binds
+          a click -> lock() handler to every element matching `selector`, and
+          it does that regardless of `enabled`. The terminal's `Html` portals
+          into the canvas wrapper, so it lives *inside* #fun-lock-target: the
+          very click that focuses the shell input bubbles up and re-locks the
+          pointer. Esc is then eaten by the browser to release that lock and
+          never reaches the handler below, which left the visitor stuck at the
+          terminal with no way out but leaving the site. Pointing the selector
+          at nothing unbinds the handler (`selector` is in drei's effect deps,
+          so it genuinely rebinds). Cards are unaffected either way — they
+          render outside the lock target — but they go through the same gate
+          so a future zoomed surface cannot reintroduce this. */}
+      <PointerLockControls
+        ref={controlsRef}
+        selector={paused ? "#fun-lock-inert" : "#fun-lock-target"}
+      />
     </>
   );
 }
@@ -730,6 +771,19 @@ export default function FunRoom({
   const onContextLost = useCallback(() => setContextLost(true), []);
   const [card, setCard] = useState<InfoCard | null>(null);
   const [terminalActive, setTerminalActive] = useState(false);
+  /* All on from the start, always. The room is a lamplit evening and that is
+     what it should be the first time you see it — the switches are something to
+     find, not a state to arrive in. Not persisted for the same reason: a return
+     visit opening into a dark room would read as broken, not as remembered. */
+  const [lights, setLights] = useState<Lights>({
+    lantern: true,
+    desk: true,
+    shelf: true,
+  });
+  const toggleLight = useCallback(
+    (k: LightKey) => setLights((l) => ({ ...l, [k]: !l[k] })),
+    [],
+  );
   const controlsRef = useRef<PointerLockControlsImpl | null>(null);
 
   /* Movement and look-at picking stop whenever something has taken focus.
@@ -753,9 +807,14 @@ export default function FunRoom({
     setTerminalActive(true);
     controlsRef.current?.unlock();
   }, []);
+  /* Deliberately does not re-lock. requestPointerLock needs transient user
+     activation, and Esc does not grant it — the call was silently rejected on
+     the most common way out of the terminal, so the visitor landed back in the
+     room unlocked anyway. Leaving the lock to the visitor's next click makes
+     both exits behave the same, and that click is how they locked on the way
+     in. Movement is already restored by `paused` going false. */
   const exitTerminal = useCallback(() => {
     setTerminalActive(false);
-    controlsRef.current?.lock();
   }, []);
 
   /* Walking out of the door leaves the room. Uses the router rather than
@@ -768,9 +827,13 @@ export default function FunRoom({
     router.push("/");
   }, [router]);
 
+  /* Does not re-lock, for the same reason exitTerminal does not — see there.
+     Closing with Esc carries no transient user activation, so the lock request
+     was rejected on that path anyway, and on a touch device it was asking a
+     browser with no pointer lock at all to grant one. Both exits now behave
+     the same, and the next click re-locks. */
   const closeCard = useCallback(() => {
     setCard(null);
-    controlsRef.current?.lock();
   }, []);
 
   useEffect(() => {
@@ -979,6 +1042,8 @@ export default function FunRoom({
             onTerminalEnter={enterTerminal}
             onTerminalExit={exitTerminal}
             paused={paused}
+            lights={lights}
+            onToggleLight={toggleLight}
             coarse={coarse}
             touchMove={touchMove}
           />

--- a/portfolio/src/components/fun/Hud.tsx
+++ b/portfolio/src/components/fun/Hud.tsx
@@ -229,7 +229,7 @@ const BINDS: Bind[] = [
   },
   { keys: <Key wide>shift</Key>, action: "run" },
   { keys: <Key>E</Key>, action: "interact" },
-  { keys: <Key wide>esc</Key>, action: "release cursor" },
+  { keys: <Key wide>esc</Key>, action: "back / release cursor" },
   { keys: <Key>H</Key>, action: "hide these" },
 ];
 

--- a/portfolio/src/components/fun/Room.tsx
+++ b/portfolio/src/components/fun/Room.tsx
@@ -28,6 +28,14 @@ import { useSurface } from "./textures";
 // lives in.
 export const ROOM = { w: 5.2, d: 4.8, h: 2.5 };
 
+/** The room's three switchable fittings, each with its own switch.
+ *  The two point lights that are not fittings — the lantern's ceiling bounce
+ *  and the door-end fill — are not keys here: the bounce belongs to the
+ *  lantern, and the fill is spill that follows whether anything is lit at all.
+ *  See the rig in FunRoom. */
+export type LightKey = "lantern" | "desk" | "shelf";
+export type Lights = Record<LightKey, boolean>;
+
 /** Where the lantern stands. The lighting rig hangs its sources off this, so
  *  the fitting and the light it casts cannot drift apart. */
 export const LANTERN = { x: ROOM.w / 2 - 0.34, z: -1.25 };
@@ -140,7 +148,15 @@ function Stand({ position }: { position: [number, number, number] }) {
  * The shade sits high on the frame so the light source is near eye height. A
  * lantern glowing down by your ankles lights the floor and nothing else.
  */
-function Lantern({ position }: { position: [number, number, number] }) {
+function Lantern({
+  position,
+  on,
+  onToggle,
+}: {
+  position: [number, number, number];
+  on: boolean;
+  onToggle: () => void;
+}) {
   const S = 0.3; // outside width and depth
   const H = 1.46; // overall height
   const POST = 0.028;
@@ -157,102 +173,135 @@ function Lantern({ position }: { position: [number, number, number] }) {
   ];
 
   return (
-    <group position={position}>
-      {/* Four corner posts, full height. Nothing on the frame casts — see the
-          rails below. The posts were left casting at first on the theory that
-          striping the floor pool would look good; what they actually did was
-          throw two hard diagonal streaks up the wall and across the ceiling,
-          because the light is level with them and they are thin. A fitting
-          should not shadow the room from a light it encloses, and that turns
-          out to apply to every part of it. */}
-      {corners.map(([x, z], i) => (
-        <mesh key={i} position={[x, H / 2, z]}>
-          <boxGeometry args={[POST, H, POST]} />
-          <meshStandardMaterial color={oakCol} roughness={0.6} />
+    <Interactive
+      label="the lantern"
+      verb={on ? "turn off" : "turn on"}
+      detail="the room's main light"
+      onActivate={onToggle}
+    >
+      <group position={position}>
+        {/* Four corner posts, full height. Nothing on the frame casts — see the
+            rails below. The posts were left casting at first on the theory that
+            striping the floor pool would look good; what they actually did was
+            throw two hard diagonal streaks up the wall and across the ceiling,
+            because the light is level with them and they are thin. A fitting
+            should not shadow the room from a light it encloses, and that turns
+            out to apply to every part of it. */}
+        {corners.map(([x, z], i) => (
+          <mesh key={i} position={[x, H / 2, z]}>
+            <boxGeometry args={[POST, H, POST]} />
+            <meshStandardMaterial color={oakCol} roughness={0.6} />
+          </mesh>
+        ))}
+
+        {/* Rails: at the foot, under and over the shade, and at the top. A
+            casting top rail silhouettes itself onto the ceiling directly above
+            as a hard-edged floating box. */}
+        {[0.07, SHADE_Y, SHADE_Y + SHADE_H, H - POST / 2].map((y) => (
+          <group key={y} position={[0, y, 0]}>
+            {[-half, half].map((z) => (
+              <mesh key={`x${z}`} position={[0, 0, z]}>
+                <boxGeometry args={[S - POST, POST, POST]} />
+                <meshStandardMaterial color={oakCol} roughness={0.6} />
+              </mesh>
+            ))}
+            {[-half, half].map((x) => (
+              <mesh key={`z${x}`} position={[x, 0, 0]}>
+                <boxGeometry args={[POST, POST, S - POST]} />
+                <meshStandardMaterial color={oakCol} roughness={0.6} />
+              </mesh>
+            ))}
+          </group>
+        ))}
+
+        {/* a board across the foot rails, so it stands like furniture */}
+        <mesh position={[0, 0.086, 0]} receiveShadow>
+          <boxGeometry args={[S - POST, 0.014, S - POST]} />
+          <meshStandardMaterial color={oakCol} roughness={0.68} />
         </mesh>
-      ))}
 
-      {/* Rails: at the foot, under and over the shade, and at the top. A
-          casting top rail silhouettes itself onto the ceiling directly above
-          as a hard-edged floating box. */}
-      {[0.07, SHADE_Y, SHADE_Y + SHADE_H, H - POST / 2].map((y) => (
-        <group key={y} position={[0, y, 0]}>
-          {[-half, half].map((z) => (
-            <mesh key={`x${z}`} position={[0, 0, z]}>
-              <boxGeometry args={[S - POST, POST, POST]} />
-              <meshStandardMaterial color={oakCol} roughness={0.6} />
-            </mesh>
-          ))}
-          {[-half, half].map((x) => (
-            <mesh key={`z${x}`} position={[x, 0, 0]}>
-              <boxGeometry args={[POST, POST, S - POST]} />
-              <meshStandardMaterial color={oakCol} roughness={0.6} />
-            </mesh>
-          ))}
-        </group>
-      ))}
-
-      {/* a board across the foot rails, so it stands like furniture */}
-      <mesh position={[0, 0.086, 0]} receiveShadow>
-        <boxGeometry args={[S - POST, 0.014, S - POST]} />
-        <meshStandardMaterial color={oakCol} roughness={0.68} />
-      </mesh>
-
-      {/* The four paper panels.
-          The base colour is nearly black on purpose. These sit directly in
-          front of the lamp's own point light, so a light base colour gets lit
-          *and* emits, the two sum past what the tone mapper can hold, and the
-          shade clips to flat white — a paper lantern rendered as a lightbulb.
-          Emitting from a dark base is the only way the panel keeps its colour
-          at this brightness. */}
-      {([0, Math.PI / 2, Math.PI, -Math.PI / 2] as const).map((ry, i) => (
-        <mesh
-          key={i}
-          position={[
-            Math.sin(ry) * (S / 2 - 0.004),
-            SHADE_Y + SHADE_H / 2,
-            Math.cos(ry) * (S / 2 - 0.004),
-          ]}
-          rotation={[0, ry, 0]}
-        >
-          <planeGeometry args={[S - POST * 1.6, SHADE_H - POST]} />
-          <meshStandardMaterial
-            color="#2a1405"
-            emissive="#ff6408"
-            emissiveIntensity={2.3}
-            roughness={0.92}
-            side={THREE.DoubleSide}
-          />
-        </mesh>
-      ))}
-    </group>
+        {/* The four paper panels.
+            The base colour is nearly black on purpose. These sit directly in
+            front of the lamp's own point light, so a light base colour gets lit
+            *and* emits, the two sum past what the tone mapper can hold, and the
+            shade clips to flat white — a paper lantern rendered as a lightbulb.
+            Emitting from a dark base is the only way the panel keeps its colour
+            at this brightness. */}
+        {([0, Math.PI / 2, Math.PI, -Math.PI / 2] as const).map((ry, i) => (
+          <mesh
+            key={i}
+            position={[
+              Math.sin(ry) * (S / 2 - 0.004),
+              SHADE_Y + SHADE_H / 2,
+              Math.cos(ry) * (S / 2 - 0.004),
+            ]}
+            rotation={[0, ry, 0]}
+          >
+            <planeGeometry args={[S - POST * 1.6, SHADE_H - POST]} />
+            <meshStandardMaterial
+              color="#2a1405"
+              emissive="#ff6408"
+              /* Goes fully dark with the light. The base colour is nearly black
+                 by design (see above), so dropping the emission leaves unlit
+                 paper rather than a grey panel — a shade that stops glowing but
+                 still reads as a shade. */
+              emissiveIntensity={on ? 2.3 : 0}
+              roughness={0.92}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+        ))}
+      </group>
+    </Interactive>
   );
 }
 
-/** Mushroom lamp: cream glass dome on a small base. */
-function MushroomLamp({ position }: { position: [number, number, number] }) {
+/** Mushroom lamp: cream glass dome on a small base.
+ *  Takes its own label because there are two of them — one on the desk, one on
+ *  top of the bookshelf — and "the lamp" twice would name them identically in
+ *  the crosshair prompt. */
+function MushroomLamp({
+  position,
+  label,
+  detail,
+  on,
+  onToggle,
+}: {
+  position: [number, number, number];
+  label: string;
+  detail: string;
+  on: boolean;
+  onToggle: () => void;
+}) {
   return (
-    <group position={position}>
-      <mesh castShadow receiveShadow>
-        <cylinderGeometry args={[0.052, 0.062, 0.014, 24]} />
-        <meshStandardMaterial color="#cfc3ae" roughness={0.6} />
-      </mesh>
-      <mesh position={[0, 0.05, 0]} castShadow>
-        <cylinderGeometry args={[0.032, 0.04, 0.086, 20]} />
-        <meshStandardMaterial color="#e0d5c0" roughness={0.55} />
-      </mesh>
-      {/* the dome, lit from inside */}
-      <mesh position={[0, 0.118, 0]} castShadow>
-        <sphereGeometry args={[0.078, 24, 16, 0, Math.PI * 2, 0, Math.PI * 0.62]} />
-        <meshStandardMaterial
-          color="#ffdcae"
-          roughness={0.42}
-          emissive="#ffa74e"
-          emissiveIntensity={1.5}
-          side={THREE.DoubleSide}
-        />
-      </mesh>
-    </group>
+    <Interactive
+      label={label}
+      verb={on ? "turn off" : "turn on"}
+      detail={detail}
+      onActivate={onToggle}
+    >
+      <group position={position}>
+        <mesh castShadow receiveShadow>
+          <cylinderGeometry args={[0.052, 0.062, 0.014, 24]} />
+          <meshStandardMaterial color="#cfc3ae" roughness={0.6} />
+        </mesh>
+        <mesh position={[0, 0.05, 0]} castShadow>
+          <cylinderGeometry args={[0.032, 0.04, 0.086, 20]} />
+          <meshStandardMaterial color="#e0d5c0" roughness={0.55} />
+        </mesh>
+        {/* the dome, lit from inside */}
+        <mesh position={[0, 0.118, 0]} castShadow>
+          <sphereGeometry args={[0.078, 24, 16, 0, Math.PI * 2, 0, Math.PI * 0.62]} />
+          <meshStandardMaterial
+            color="#ffdcae"
+            roughness={0.42}
+            emissive="#ffa74e"
+            emissiveIntensity={on ? 1.5 : 0}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      </group>
+    </Interactive>
   );
 }
 
@@ -391,6 +440,8 @@ export function Room({
   onOpenCert,
   onOpenCard,
   onExitRoom,
+  lights,
+  onToggleLight,
 }: {
   onPrinterStatus: (msg: string | null) => void;
   shelf: ShelfData;
@@ -400,6 +451,8 @@ export function Room({
   onOpenCert: (c: ShelfCert) => void;
   onOpenCard: (c: InfoCard) => void;
   onExitRoom: () => void;
+  lights: Lights;
+  onToggleLight: (k: LightKey) => void;
 }) {
   const hw = ROOM.w / 2;
   const hd = ROOM.d / 2;
@@ -624,7 +677,13 @@ export function Room({
             cannot be nudged without the feet following. */}
         <Stand position={[DESK_SCREEN.position[0], 0.755, SCREEN_DZ]} />
         <Stand position={[DESK_TERMINAL.position[0], 0.755, SCREEN_DZ]} />
-        <MushroomLamp position={[-1.02, 0.755, -0.1]} />
+        <MushroomLamp
+          position={[-1.02, 0.755, -0.1]}
+          label="the desk lamp"
+          detail="the desk"
+          on={lights.desk}
+          onToggle={() => onToggleLight("desk")}
+        />
 
         {/* The stack of printed blog posts that used to sit by the lamp is
             gone. The whiteboard on the left wall carries the blog now, with
@@ -658,7 +717,11 @@ export function Room({
       {/* The lantern, in the gap on the right wall between the desk end and the
           sideboard. It stands where the room was previously darkest and where
           it is in view from the door, which is the whole point of it. */}
-      <Lantern position={[LANTERN.x, 0, LANTERN.z]} />
+      <Lantern
+        position={[LANTERN.x, 0, LANTERN.z]}
+        on={lights.lantern}
+        onToggle={() => onToggleLight("lantern")}
+      />
 
       {/* y=0: Prop seats a model on its own base, so no manual lift. */}
       <Plant position={[hw - 0.42, 0, hd - 0.55]} />
@@ -694,10 +757,16 @@ export function Room({
           the edge. Reading the shelf's own position is the only way this stays
           right if the unit ever moves or gets deeper. */}
       <group position={[SHELF_AT[0], shelfHeight(shelf), SHELF_AT[2]]}>
-        <MushroomLamp position={[0, 0, 0]} />
+        <MushroomLamp
+          position={[0, 0, 0]}
+          label="the shelf lamp"
+          detail="the case studies"
+          on={lights.shelf}
+          onToggle={() => onToggleLight("shelf")}
+        />
         <pointLight
           position={[0, 0.12, 0]}
-          intensity={4.2}
+          intensity={lights.shelf ? 4.2 : 0}
           distance={3.2}
           decay={1.9}
           color="#ffb066"

--- a/portfolio/src/components/fun/Terminal.tsx
+++ b/portfolio/src/components/fun/Terminal.tsx
@@ -416,9 +416,30 @@ export function TerminalScreen({
             >
               SHELL
             </span>
-            <span className="text-[10px] tracking-[0.14em] text-[#3f4d5c]">
-              {active ? "esc to step back" : "press E to use"}
-            </span>
+            {/* A real target, not just the `esc` hint this used to be. Touch
+                visitors have no Esc key, and entering the terminal pauses the
+                room — which hides the walk stick and the look handler — so the
+                hint was advertising a key they could not press while every
+                other way back was gone. A click also carries user activation,
+                which a keypress does not. */}
+            {active ? (
+              <button
+                type="button"
+                aria-label="leave the terminal"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onExit();
+                }}
+                className="focus-ring border px-2 py-0.5 text-[10px] tracking-[0.14em] transition-colors"
+                style={{ borderColor: `${ACCENT}3d`, color: ACCENT }}
+              >
+                close
+              </button>
+            ) : (
+              <span className="text-[10px] tracking-[0.14em] text-[#3f4d5c]">
+                press E to use
+              </span>
+            )}
           </div>
 
           <div ref={scrollRef} className="flex-1 overflow-y-auto pr-1 leading-[1.5]">

--- a/portfolio/src/components/fun/Touch.tsx
+++ b/portfolio/src/components/fun/Touch.tsx
@@ -31,7 +31,7 @@ const TAP_SLOP_PX = 9;
 const TAP_MS = 400;
 
 export function TouchLook({ enabled }: { enabled: boolean }) {
-  const { camera, gl } = useThree();
+  const { camera, gl, events } = useThree();
   const activateAt = useActivateAt();
   const euler = useRef(new THREE.Euler(0, 0, 0, "YXZ"));
   const ndc = useRef(new THREE.Vector2());
@@ -47,7 +47,45 @@ export function TouchLook({ enabled }: { enabled: boolean }) {
 
   useEffect(() => {
     if (!enabled) return;
-    const el = gl.domElement;
+    /* r3f's own event target, not the canvas and not the canvas's parent.
+       Two separate things push this outwards, and stopping at either one
+       leaves a hole:
+
+       The canvas itself is never a hit target. drei's `Html` sets
+       `pointer-events: none` straight onto gl.domElement whenever any instance
+       uses occlude="blending" (the layout effect in drei/web/Html.js), and
+       every in-world screen here does. Touches fall through it, so listeners
+       bound there never fire at all — which is why look-drag was dead on every
+       phone while the walk stick, its own DOM outside the canvas, kept working.
+       Desktop never noticed, because PointerLockControls listens on `document`.
+
+       One level up is still too shallow. r3f nests an outer div over the
+       canvas's container, and drei portals every `Html` into `events.connected`
+       — the outer one. So the screens, the shell, the blog wall and the GitHub
+       wall are all *siblings* of the canvas's container, not descendants: a
+       drag or tap starting on any panel bubbles past a listener bound there.
+       That left the terminal untappable on touch, which is worth spelling out,
+       because the close button was added for exactly the visitors who could
+       not get in to use it.
+
+       `events.connected` is the element r3f binds its own pointer events to,
+       so it is the one place guaranteed to see both. It fills the same rect as
+       the canvas, so the tap-to-NDC maths below is unchanged. */
+    const el =
+      (events.connected as HTMLElement | null) ??
+      gl.domElement.parentElement?.parentElement ??
+      gl.domElement;
+
+    /* No `touch-action: none` to go with this, deliberately. It looks like the
+       obvious companion fix and it is measurably unnecessary: `move` below
+       preventDefaults on a non-passive listener, which already stops the
+       browser panning, and look-drag behaves identically with and without it.
+       It would also cost something. Pointer Events L3 checks panning only up to
+       the nearest scroll container, but checks *zooming* all the way to the
+       document element, so `none` anywhere above here takes pinch-zoom away
+       from the whole room — including the terminal's 13px scrollback, where a
+       visitor is most likely to want it. */
+
     /* Gesture state in a ref rather than closure locals. Same behaviour, but
        plain `let`s captured by handlers read as mutate-after-render to the
        react-hooks immutability rule, and a drag is exactly the kind of state a
@@ -119,7 +157,7 @@ export function TouchLook({ enabled }: { enabled: boolean }) {
       el.removeEventListener("touchend", end);
       el.removeEventListener("touchcancel", end);
     };
-  }, [enabled, camera, gl, activateAt]);
+  }, [enabled, camera, gl, events.connected, activateAt]);
 
   return null;
 }

--- a/portfolio/src/components/layout/Footer.tsx
+++ b/portfolio/src/components/layout/Footer.tsx
@@ -30,6 +30,13 @@ export function Footer() {
             >
               JSON over the public API
             </Link>
+            . If you would rather look around than read, the same work is{" "}
+            <Link
+              href="/fun"
+              className="focus-ring text-fg underline decoration-accent decoration-2 underline-offset-4 hover:text-accent"
+            >
+              a room you can walk through
+            </Link>
             .
           </p>
         </div>

--- a/portfolio/src/content/site.ts
+++ b/portfolio/src/content/site.ts
@@ -50,7 +50,6 @@ export const site = {
     { label: "Infrastructure", href: "/infrastructure" },
     { label: "Blog", href: "/#blog" },
     { label: "Contact", href: "/#contact" },
-    { label: "Fun", href: "/fun" },
   ] as readonly { href: string; label: string }[],
 } as const;
 


### PR DESCRIPTION
## Why

Two unrelated problems with the explorable room, both about how a visitor moves in and out of it.

Inside the room there were interactions you could enter but not leave. The terminal had no visible exit and Esc did not work, look-drag never worked on touch at all, and the lamps were a single fixed state.

Outside it, the room sat in the top nav between the resume and contact, which put a first-person 3D toy at the same level as the case studies. The `/fun` page has always described itself in its own header comment as "an alternative way into the portfolio, never the only one", and the nav placement did not match that.

## What

`997c2027` covers the in-room fixes: a close button and working Esc on the terminal, no re-lock on exit paths that cannot grant pointer lock, touch look-drag bound to `events.connected` so it survives drei's `occlude="blending"` pointer-events handling, and three independently switchable lamps with fallback lighting so an unlit room stays navigable.

`5a135bfe` moves the entry point. `Fun` is out of `site.nav`, which clears it from the desktop header, the mobile menu, and the palette's generated `cd <page>` list in one deletion. It is offered instead as a third link in the footer colophon, beside the existing infrastructure and API links, and as an explicit `cd fun` command in the palette. The palette entry had to be re-added by hand for exactly the reason above: dropping the nav item silently dropped the generated command with it.

## Verification

`make typecheck` clean. `make lint` reports 0 errors and 24 warnings, all pre-existing, none in the touched files.

Browser-verified on localhost:3000: header ends at `contact` with no `fun`; footer renders the invitation and links to `/fun`; palette filters to `cd fun → /fun`, still 15 commands total since one generated entry was swapped for one explicit one. `/fun` loads, and `/infrastructure` is unaffected.

Not chased down: every route logs one console error in dev, `/infrastructure` included. It predates these commits and is untouched here.