### PR TITLE
feat(authentik): wire Argo CD SSO declaratively via blueprint

### DIFF
--- a/k8s/talos/infra/argocd/argocd-oidc-secret.yaml
+++ b/k8s/talos/infra/argocd/argocd-oidc-secret.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-oidc
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: argocd-oidc
+    creationPolicy: Owner
+    # argocd-server only resolves $secret:key references from secrets carrying
+    # this label, so ESO has to stamp it onto the generated Secret.
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: argocd
+  data:
+    # Same Bitwarden item as ARGOCD_OIDC_CLIENT_SECRET in the identity namespace.
+    - secretKey: clientSecret
+      remoteRef:
+        key: "89206c8b-8f19-480d-973f-b48d01361cb3"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/k8s/talos/infra/argocd/kustomization.yaml
+++ b/k8s/talos/infra/argocd/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - apps.yaml
   - infra.yaml
   - httproute.yaml
+  - argocd-oidc-secret.yaml
   - ciliumnetworkpolicy.yaml
 namespace: argocd
 

--- a/k8s/talos/infra/argocd/values.yaml
+++ b/k8s/talos/infra/argocd/values.yaml
@@ -17,6 +17,35 @@ configs:
           - CiliumIdentity
         clusters:
           - "*"
+    # The provider is defined declaratively in
+    # k8s/talos/infra/authentik/argocd-blueprint.yaml.
+    # `url` is intentionally not set here: the chart derives it from
+    # global.domain, and that is what Argo CD builds the redirect URI from
+    # (so server.insecure still yields an https:// callback).
+    oidc.config: |
+      name: Authentik
+      # Trailing slash required. The path segment is the authentik *application
+      # slug*, not the provider name. Mismatch here gives "oidc: issuer did not match".
+      issuer: https://auth.local.bigd.no/application/o/argocd/
+      clientID: 5dbfc17206b0310cad6e088795218914
+      clientSecret: $argocd-oidc:clientSecret
+      # No `groups` scope exists in authentik; the groups claim rides on `profile`.
+      # Requesting it explicitly would return invalid_scope.
+      requestedScopes:
+        - openid
+        - profile
+        - email
+        - offline_access
+      requestedIDTokenClaims:
+        groups:
+          essential: true
+  rbac:
+    # Authenticated but unmapped SSO users get nothing. The built-in local admin
+    # bypasses RBAC entirely and stays enabled as break-glass.
+    policy.default: ""
+    scopes: "[groups]"
+    policy.csv: |
+      g, argocd-admins, role:admin
 
 server:
   replicas: 2

--- a/k8s/talos/infra/authentik/argocd-blueprint.yaml
+++ b/k8s/talos/infra/authentik/argocd-blueprint.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-argocd
+  namespace: identity
+  annotations:
+    # Ahead of the chart-inflated worker Deployment (wave 0), which mounts this.
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  argocd.yaml: |
+    version: 1
+    metadata:
+      name: argocd-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        id: group-argocd-admins
+        state: present
+        identifiers:
+          name: argocd-admins
+        attrs:
+          is_superuser: false
+
+      - model: authentik_providers_oauth2.oauth2provider
+        id: provider-argocd
+        state: present
+        identifiers:
+          name: argocd
+        attrs:
+          name: argocd
+          client_type: confidential
+          # Sourced from authentik-secrets via envFrom on the worker pod, so the
+          # credentials never land in git. No !Env default: a missing variable
+          # should fail the blueprint import loudly rather than quietly create a
+          # provider with an empty secret.
+          client_id: !Env ARGOCD_OIDC_CLIENT_ID
+          client_secret: !Env ARGOCD_OIDC_CLIENT_SECRET
+          # Empty by default in 2026.5. Unset here means every grant is rejected.
+          grant_types:
+            - authorization_code
+            - refresh_token
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://argocd.local.bigd.no/auth/callback
+            # For `argocd login --sso` from the CLI.
+            - matching_mode: strict
+              url: http://localhost:8085/auth/callback
+          # Matched on `managed`, the stable identifier in authentik's own system
+          # blueprints, rather than the mutable scope_name. The groups claim that
+          # Argo CD RBAC keys on is emitted by `profile`; there is no groups scope.
+          # offline_access is required for the refresh_token grant to issue tokens.
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-offline_access]]
+          sub_mode: hashed_user_id
+          issuer_mode: per_provider
+          include_claims_in_id_token: true
+
+      - model: authentik_core.application
+        id: app-argocd
+        state: present
+        identifiers:
+          slug: argocd
+        attrs:
+          name: ArgoCD
+          # The slug forms the issuer URL that argocd-cm must match exactly:
+          # https://auth.local.bigd.no/application/o/argocd/
+          slug: argocd
+          provider: !KeyOf provider-argocd
+          policy_engine_mode: any
+          meta_launch_url: https://argocd.local.bigd.no

--- a/k8s/talos/infra/authentik/authentik-secrets.yaml
+++ b/k8s/talos/infra/authentik/authentik-secrets.yaml
@@ -26,3 +26,17 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+    # Consumed by argocd-blueprint.yaml through !Env. Keys must be valid C
+    # identifiers or the pod's envFrom silently drops them.
+    - secretKey: ARGOCD_OIDC_CLIENT_ID
+      remoteRef:
+        key: "abd2f0cf-b00c-400e-971d-b48d01355263"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: ARGOCD_OIDC_CLIENT_SECRET
+      remoteRef:
+        key: "89206c8b-8f19-480d-973f-b48d01361cb3"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/k8s/talos/infra/authentik/kustomization.yaml
+++ b/k8s/talos/infra/authentik/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: identity
 resources:
   - namespace.yaml
   - authentik-secrets.yaml
+  - argocd-blueprint.yaml
 
 helmCharts:
   - name: authentik

--- a/k8s/talos/infra/authentik/values.yaml
+++ b/k8s/talos/infra/authentik/values.yaml
@@ -13,6 +13,10 @@ authentik:
   redis:
     enabled: false
 
+blueprints:
+  configMaps:
+    - authentik-blueprint-argocd
+
 server:
   env:
     - name: AUTHENTIK_POSTGRESQL__HOST


### PR DESCRIPTION
## Why

Authentik has been running in the cluster since deploy and is completely unused: no blueprints, no providers, no applications, no consumers. The blocker was that configuring it normally means clicking through the admin UI, which leaves that state only in its Postgres database, invisible to git and lost on a rebuild.

Authentik's blueprints system solves this. The Helm chart exposes `blueprints.configMaps`, so providers, applications and groups can be declared as ordinary manifests here and reconciled by the authentik worker.

Argo CD is the first consumer: it supports OIDC natively, it is private-only so no public gateway work is needed, and it currently has `exec.enabled: "true"` behind nothing but a single shared local admin password.

## What

- `authentik/argocd-blueprint.yaml` declares the OAuth2 provider, the `ArgoCD` application and the `argocd-admins` group.
- `authentik/values.yaml` mounts that ConfigMap via `blueprints.configMaps`.
- `authentik/authentik-secrets.yaml` gains the client ID and secret from Bitwarden. The blueprint reads them with `!Env`, which works because the pods already load the whole secret via `envFrom`, so no credential is committed.
- `argocd/argocd-oidc-secret.yaml` supplies the same client secret to Argo CD, labelled `app.kubernetes.io/part-of: argocd` so `$argocd-oidc:clientSecret` resolves.
- `argocd/values.yaml` adds `oidc.config` and an RBAC block mapping `argocd-admins` to `role:admin`.

The local `admin` account stays enabled as break-glass. SSO-only would mean an authentik outage locks us out of Argo CD, including out of the ability to repair authentik through GitOps.

Scoped to Argo CD deliberately. Kargo and Grafana are copy-paste once this is proven, and no forward-auth or proxy-outpost work is included.

Three details that are easy to get wrong, all verified against the running 2026.5.4 instance rather than assumed:

- `grant_types` defaults to an empty list in 2026.5, so an unset provider rejects every grant. Most published examples predate this.
- There is no `groups` scope in authentik. The groups claim that Argo CD RBAC keys on is emitted by `profile`; requesting `groups` returns `invalid_scope`.
- The issuer path segment is the application slug, and the trailing slash is required.

## Verification

- Blueprint passes authentik's own `Importer.validate()` dry-run against the live models, inside a rolled-back transaction. All `!Find` lookups resolve; group, provider and application construct cleanly.
- `kustomize build --enable-helm` on both directories renders successfully, with the blueprint volume mounted on the worker at `/blueprints/mounted/cm-authentik-blueprint-argocd`.
- `argocd-cm` renders `url: https://argocd.local.bigd.no`, confirming `server.insecure: true` still yields an https callback.
- `argocd-rbac-cm` renders with `policy.default: ""` and the `argocd-admins` mapping.

After merge and sync, before trusting SSO:

1. `kubectl -n identity exec deploy/authentik-worker -- printenv | grep ARGOCD_OIDC`
2. `kubectl -n identity exec deploy/authentik-worker -- ak list_blueprints` shows `argocd-sso` Successful
3. `curl -s https://auth.local.bigd.no/application/o/argocd/.well-known/openid-configuration | jq .issuer` matches `oidc.config` exactly
4. Add your user to `argocd-admins` in the authentik UI. The blueprint creates the group but does not manage membership.
5. Log in at argocd.local.bigd.no via Authentik, then log out and confirm the local admin still works.