### PR TITLE
fix(authentik): order secrets before pods, declare argocd-admins membership

### DIFF
--- a/k8s/talos/infra/authentik/argocd-blueprint.yaml
+++ b/k8s/talos/infra/authentik/argocd-blueprint.yaml
@@ -21,6 +21,11 @@ data:
           name: argocd-admins
         attrs:
           is_superuser: false
+          # Membership is declared here on purpose, so a rebuilt cluster grants
+          # Argo CD access without anyone touching the UI. Reconciliation resets
+          # this list, so add members here rather than in authentik.
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
 
       - model: authentik_providers_oauth2.oauth2provider
         id: provider-argocd

--- a/k8s/talos/infra/authentik/authentik-secrets.yaml
+++ b/k8s/talos/infra/authentik/authentik-secrets.yaml
@@ -4,7 +4,10 @@ metadata:
   name: authentik-secrets
   namespace: identity
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    # Ahead of the chart's Deployments (wave 0). envFrom is evaluated once at
+    # container start, so a secret that lands after the pods do leaves them
+    # without the new keys until a manual restart.
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/k8s/talos/infra/authentik/namespace.yaml
+++ b/k8s/talos/infra/authentik/namespace.yaml
@@ -7,4 +7,5 @@ metadata:
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    # First, so the ExternalSecret at -2 has a namespace to land in on a rebuild.
+    argocd.argoproj.io/sync-wave: "-3"


### PR DESCRIPTION
Follow-up to #426, from verifying it against the live cluster.

## Why

Two gaps, both of which would only have surfaced on a cluster rebuild, when it is most painful.

**Ordering.** The `authentik-secrets` ExternalSecret was at sync-wave 1, so it applied *after* the chart's Deployments at wave 0. `envFrom` is evaluated once at container start, so the pods came up 31 seconds before the new OIDC keys landed and never saw them. The blueprint then could not resolve `!Env` and was silently never discovered. Recovering took a manual `rollout restart`, which is not something a GitOps repo should require. The namespace moves to -3 and the ExternalSecret to -2 so both precede the workload.

**Group membership.** This was left to the Authentik UI, which is exactly the clickops this work exists to remove. A rebuilt cluster would have come up with an empty `argocd-admins` group and no way into Argo CD over SSO. `akadmin` is now declared in the blueprint.

Worth knowing: declaring `users` makes that list authoritative. Reconciliation resets it, so members get added in this file, not in the Authentik UI. That is the intended tradeoff, and it is commented in place.

## Verification

- Blueprint re-validated with authentik's `Importer.validate()` against the live 2026.5.4 instance.
- `kustomize build --enable-helm` renders clean.
- Already confirmed working on the live cluster after #426 plus a manual restart: blueprint `argocd-sso` status successful, provider/application/group created, issuer matches, and argocd-server logs `Initializing OIDC provider` with scopes `[openid email profile offline_access]` and `sso: true`. This PR makes that state reproducible from scratch rather than dependent on the manual restart.