### PR TITLE
feat(authentik): extend declarative SSO to Kargo and Grafana

### DIFF
--- a/k8s/talos/infra/authentik/authentik-secrets.yaml
+++ b/k8s/talos/infra/authentik/authentik-secrets.yaml
@@ -43,3 +43,17 @@ spec:
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
+    # Consumed by grafana-blueprint.yaml. Kargo needs no entry here: it is a
+    # public PKCE client, so it has no client secret at all.
+    - secretKey: GRAFANA_OIDC_CLIENT_ID
+      remoteRef:
+        key: "f4825e2c-5f3b-46ba-87b0-b48d013b73ac"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: GRAFANA_OIDC_CLIENT_SECRET
+      remoteRef:
+        key: "8618a4d2-7461-4346-9577-b48d013bbdd3"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/k8s/talos/infra/authentik/grafana-blueprint.yaml
+++ b/k8s/talos/infra/authentik/grafana-blueprint.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-grafana
+  namespace: identity
+  annotations:
+    # Ahead of the chart-inflated worker Deployment (wave 0), which mounts this.
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  grafana.yaml: |
+    version: 1
+    metadata:
+      name: grafana-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        id: group-grafana-admins
+        state: present
+        identifiers:
+          name: grafana-admins
+        attrs:
+          is_superuser: false
+          # Membership is declared here on purpose, so a rebuilt cluster grants
+          # Grafana access without anyone touching the UI. Reconciliation resets
+          # this list, so add members here rather than in authentik.
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
+
+      - model: authentik_providers_oauth2.oauth2provider
+        id: provider-grafana
+        state: present
+        identifiers:
+          name: grafana
+        attrs:
+          name: grafana
+          client_type: confidential
+          # Sourced from authentik-secrets via envFrom on the worker pod, so the
+          # credentials never land in git.
+          client_id: !Env GRAFANA_OIDC_CLIENT_ID
+          client_secret: !Env GRAFANA_OIDC_CLIENT_SECRET
+          # Empty by default in 2026.5. Unset here means every grant is rejected.
+          # No refresh_token: Grafana's use_refresh_token defaults to false, so a
+          # refresh token would be issued and never redeemed.
+          grant_types:
+            - authorization_code
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://grafana.local.bigd.no/login/generic_oauth
+          # The groups claim that role_attribute_path keys on is emitted by
+          # profile; authentik has no groups scope. No offline_access, matching
+          # the grant_types above.
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+          sub_mode: hashed_user_id
+          issuer_mode: per_provider
+          include_claims_in_id_token: true
+
+      - model: authentik_core.application
+        id: app-grafana
+        state: present
+        identifiers:
+          slug: grafana
+        attrs:
+          name: Grafana
+          # The slug forms the issuer URL. Note only the issuer and the
+          # discovery document are per-application; authorize/token/userinfo are
+          # mounted globally without the slug.
+          slug: grafana
+          provider: !KeyOf provider-grafana
+          policy_engine_mode: any
+          meta_launch_url: https://grafana.local.bigd.no

--- a/k8s/talos/infra/authentik/kargo-blueprint.yaml
+++ b/k8s/talos/infra/authentik/kargo-blueprint.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-kargo
+  namespace: identity
+  annotations:
+    # Ahead of the chart-inflated worker Deployment (wave 0), which mounts this.
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  kargo.yaml: |
+    version: 1
+    metadata:
+      name: kargo-sso
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        id: group-kargo-admins
+        state: present
+        identifiers:
+          name: kargo-admins
+        attrs:
+          is_superuser: false
+          # Membership is declared here on purpose, so a rebuilt cluster grants
+          # Kargo access without anyone touching the UI. Reconciliation resets
+          # this list, so add members here rather than in authentik.
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
+
+      - model: authentik_providers_oauth2.oauth2provider
+        id: provider-kargo
+        state: present
+        identifiers:
+          name: kargo
+        attrs:
+          name: kargo
+          # Public, not confidential: Kargo's UI sends
+          # token_endpoint_auth_method=none and its CLI never sets a client
+          # secret. It is a PKCE client by design, so there is no credential to
+          # store and client_id is safe in git.
+          client_type: public
+          client_id: kargo
+          # Empty by default in 2026.5. Unset here means every grant is rejected.
+          grant_types:
+            - authorization_code
+            - refresh_token
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          redirect_uris:
+            # The UI computes this in the browser from window.location.
+            - matching_mode: strict
+              url: https://kargo.local.bigd.no/login
+            # `kargo login` binds an ephemeral localhost port (--port defaults to
+            # 0, meaning any free port), so no strict URI can cover the CLI.
+            - matching_mode: regex
+              url: http://localhost:[0-9]{1,5}/auth/callback
+          # Kargo reads claims from the ID token only, never from userinfo, so
+          # the groups claim has to be minted into the token. offline_access is
+          # auto-requested by both UI and CLI when discovery advertises it.
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-offline_access]]
+          sub_mode: hashed_user_id
+          issuer_mode: per_provider
+          include_claims_in_id_token: true
+
+      - model: authentik_core.application
+        id: app-kargo
+        state: present
+        identifiers:
+          slug: kargo
+        attrs:
+          name: Kargo
+          # The slug forms the issuer URL that api.oidc.issuerURL must match:
+          # https://auth.local.bigd.no/application/o/kargo/
+          slug: kargo
+          provider: !KeyOf provider-kargo
+          policy_engine_mode: any
+          meta_launch_url: https://kargo.local.bigd.no

--- a/k8s/talos/infra/authentik/kustomization.yaml
+++ b/k8s/talos/infra/authentik/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - namespace.yaml
   - authentik-secrets.yaml
   - argocd-blueprint.yaml
+  - kargo-blueprint.yaml
+  - grafana-blueprint.yaml
 
 helmCharts:
   - name: authentik

--- a/k8s/talos/infra/authentik/values.yaml
+++ b/k8s/talos/infra/authentik/values.yaml
@@ -16,6 +16,8 @@ authentik:
 blueprints:
   configMaps:
     - authentik-blueprint-argocd
+    - authentik-blueprint-kargo
+    - authentik-blueprint-grafana
 
 server:
   env:

--- a/k8s/talos/infra/kargo/values.yaml
+++ b/k8s/talos/infra/kargo/values.yaml
@@ -18,8 +18,28 @@ api:
   tls:
     enabled: false
     terminatedUpstream: true
-  # Homelab: admin-account login only for now, bundled Dex OIDC disabled.
+  # SSO via authentik. The admin account stays enabled (chart default) as
+  # break-glass: an authentik outage must not lock us out of promotions.
   oidc:
+    enabled: true
+    # Trailing slash is load-bearing; it must match authentik's advertised
+    # issuer exactly or OIDC discovery fails. The path segment is the
+    # authentik application slug.
+    issuerURL: https://auth.local.bigd.no/application/o/kargo/
+    # Public PKCE client, so this is not a credential.
+    clientID: kargo
+    # Must be explicitly emptied. The chart default is ["groups"], and authentik
+    # has no groups scope, so the default returns invalid_scope. openid, profile
+    # and email are always sent regardless, and profile is what carries groups.
+    additionalScopes: []
+    usernameClaim: email
+    admins:
+      # Rendered onto the chart's kargo-admin ServiceAccount as
+      # rbac.kargo.akuity.io/claims. kargo-admin is cluster-wide across every
+      # Project, which is all a single-operator homelab needs.
+      claims:
+        groups:
+          - kargo-admins
     dex:
       enabled: false
 

--- a/k8s/talos/infra/kube-prometheus-stack/grafana-oidc-secret.yaml
+++ b/k8s/talos/infra/kube-prometheus-stack/grafana-oidc-secret.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oidc
+  namespace: monitoring
+  annotations:
+    # Ahead of the chart's Deployment (wave 0). envFrom is read once at container
+    # start, so a secret landing after the pod leaves Grafana without the vars.
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: grafana-oidc
+    creationPolicy: Owner
+  # Kept separate from grafana-admin-credentials: envFromSecret projects every
+  # key as an env var, and that secret's hyphenated keys are not valid C
+  # identifiers, so the kubelet would silently drop them.
+  data:
+    - secretKey: GF_OAUTH_CLIENT_ID
+      remoteRef:
+        key: "f4825e2c-5f3b-46ba-87b0-b48d013b73ac"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: GF_OAUTH_CLIENT_SECRET
+      remoteRef:
+        key: "8618a4d2-7461-4346-9577-b48d013bbdd3"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/k8s/talos/infra/kube-prometheus-stack/kustomization.yaml
+++ b/k8s/talos/infra/kube-prometheus-stack/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - namespace.yaml
   - httproutes.yaml
   - grafana-admin-credentials-secret.yaml
+  - grafana-oidc-secret.yaml
   - alertmanager-discord-webhook-secret.yaml
   - homelab-alerts.yaml
   - alertmanager-pdb.yaml

--- a/k8s/talos/infra/kube-prometheus-stack/values.yaml
+++ b/k8s/talos/infra/kube-prometheus-stack/values.yaml
@@ -52,10 +52,48 @@ grafana:
     limits:
       memory: 512Mi
 
+  # OIDC client credentials, so they stay out of git. The chart's
+  # assertNoLeakedSecrets helper fails the render on a literal client_secret,
+  # so the $__env indirection below is required rather than stylistic.
+  envFromSecret: grafana-oidc
+
   # Grafana configuration
   grafana.ini:
     server:
       domain: grafana.local.bigd.no
+      # Required. Without it Grafana derives http://grafana.local.bigd.no:3000/
+      # from domain plus http_port and sends that as the OAuth redirect, which
+      # fails authentik's strict matching. TLS terminates at Traefik; this is
+      # the browser-facing URL, not how the pod is reached.
+      root_url: https://grafana.local.bigd.no
+    auth:
+      # Both already default to false. Spelled out because keeping the local
+      # admin login working is a hard requirement, and a later edit flipping
+      # either of these would silently remove the break-glass path.
+      disable_login_form: false
+      oauth_auto_login: false
+    auth.generic_oauth:
+      enabled: true
+      name: authentik
+      client_id: $__env{GF_OAUTH_CLIENT_ID}
+      client_secret: $__env{GF_OAUTH_CLIENT_SECRET}
+      # groups rides on profile; authentik has no groups scope. No
+      # offline_access, since use_refresh_token defaults to false.
+      scopes: openid profile email
+      # Slug-less on purpose: authentik mounts authorize/token/userinfo
+      # globally. Only the issuer and discovery document are per-application.
+      auth_url: https://auth.local.bigd.no/application/o/authorize/
+      token_url: https://auth.local.bigd.no/application/o/token/
+      api_url: https://auth.local.bigd.no/application/o/userinfo/
+      role_attribute_path: contains(groups[*], 'grafana-admins') && 'GrafanaAdmin' || 'Viewer'
+      # GrafanaAdmin above grants server admin rather than just org admin, but
+      # only because this is set; without it the value degrades to org Admin.
+      allow_assign_grafana_admin: true
+      # false so an SSO user in no group lands as Viewer instead of being
+      # denied login outright.
+      role_attribute_strict: false
+      allow_sign_up: true
+      use_pkce: true
 
   additionalDataSources:
     - name: Loki


### PR DESCRIPTION
Follows #426 and #427, reusing the same blueprint pattern for the two remaining native-OIDC services.

## Why

Argo CD proved the pattern. Kargo and Grafana were the obvious next consumers: both support OIDC natively, both are private-only, and both currently sit behind a single shared local password.

## What

One blueprint ConfigMap per consumer, matching the Argo CD file, plus the app-side config.

**Kargo needs no credential at all.** Its UI sends `token_endpoint_auth_method: 'none'` and its CLI never sets a `ClientSecret`, so it is a public PKCE client by design. The provider is declared `client_type: public` and the client ID lives in git, because it is not a secret. Nothing was added to Bitwarden for it.

**Grafana is a confidential client**, so its credentials come from Bitwarden and reach the pod through `envFromSecret`, referenced in `grafana.ini` as `$__env{...}`.

## Three traps worth recording

Each of these would have produced a confusing failure rather than a clear one:

- Kargo's `additionalScopes` defaults to `["groups"]`. Authentik has no `groups` scope, so the default returns `invalid_scope`. It must be explicitly emptied; `openid`, `profile` and `email` are sent regardless, and `profile` is what carries the groups claim.
- Grafana's chart hard-fails the render on a literal `client_secret` via its `assertNoLeakedSecrets` helper, so the `$__env` indirection is required, not stylistic.
- Grafana's authorize/token/userinfo URLs must **not** contain the application slug. Authentik mounts those globally; only the issuer and discovery document are per-application.

Also: `root_url` is required. Without it Grafana derives `http://grafana.local.bigd.no:3000/` from `domain` plus `http_port` and sends that as the OAuth redirect, which fails strict matching.

## Local login preserved

Kargo's `adminAccount` keeps its chart default of enabled, verified in the rendered ConfigMap as `ADMIN_ACCOUNT_ENABLED: true` alongside `OIDC_ENABLED: true`. Grafana pins `disable_login_form: false` and `oauth_auto_login: false` explicitly, so a later edit cannot silently remove the break-glass path.

## Verification

- All three directories render with `kustomize build --enable-helm`.
- Both new blueprints pass authentik's `Importer.validate()` against the live 2026.5.4 instance, confirming a `public` provider with no client secret is accepted.
- The Kargo ConfigMap was dry-run applied server-side: the null `OIDC_ADDITIONAL_SCOPES` coerces to an empty string, which envconfig skips. This was the main open risk.
- Rendered `kargo-admin` ServiceAccount carries `rbac.kargo.akuity.io/claims: '{"groups":["kargo-admins"]}'`.
- Grafana render confirmed to contain no literal secret, with `envFrom: secretRef: grafana-oidc` on the Deployment.

One research finding I checked and did **not** act on: a claim that Grafana's Cilium egress policy would block the server-side token exchange. I tested it live from the Grafana pod, which reached Authentik's discovery endpoint fine, so no policy change is included. Traffic to the LoadBalancer VIP is not caught by the pod egress rules, which is also why Argo CD works without such a rule.

## After merge

Both groups (`kargo-admins`, `grafana-admins`) are created with `akadmin` as the sole member, declared in the blueprints. As with Argo CD, that member list is authoritative and reconciliation resets it, so members get added in git rather than the Authentik UI.