### PR TITLE
fix(authentik): pin Kargo CLI redirect port so OIDC discovery stops 500ing

### DIFF
--- a/k8s/talos/infra/authentik/kargo-blueprint.yaml
+++ b/k8s/talos/infra/authentik/kargo-blueprint.yaml
@@ -51,10 +51,15 @@ data:
             # The UI computes this in the browser from window.location.
             - matching_mode: strict
               url: https://kargo.local.bigd.no/login
-            # `kargo login` binds an ephemeral localhost port (--port defaults to
-            # 0, meaning any free port), so no strict URI can cover the CLI.
-            - matching_mode: regex
-              url: http://localhost:[0-9]{1,5}/auth/callback
+            # The CLI port is pinned rather than matched by regex, and the port
+            # must stay a literal integer. authentik's cors_allow() runs
+            # urlparse().port over every redirect_uri of the provider without
+            # stopping at the first match, so a regex port raises there and the
+            # discovery endpoint 500s for any request carrying an Origin header.
+            # Kargo's UI resolves discovery in the browser, so that breaks SSO
+            # outright. Use `kargo login --port 8087` from the CLI.
+            - matching_mode: strict
+              url: http://localhost:8087/auth/callback
           # Kargo reads claims from the ID token only, never from userinfo, so
           # the groups claim has to be minted into the token. offline_access is
           # auto-requested by both UI and CLI when discovery advertises it.


### PR DESCRIPTION
Follow-up to #428. Kargo SSO was broken on arrival; this fixes it.

## Why

The browser console on kargo.local.bigd.no showed the OIDC discovery fetch blocked by CORS. The root cause is not a missing header but a server error.

Authentik's `cors_allow()` (`authentik/providers/oauth2/utils.py`) compares the request Origin against every `redirect_uri` on the provider, and it does **not** break on the first match. It calls `urlparse(uri).port` on each one. The regex URI `http://localhost:[0-9]{1,5}/auth/callback` makes `urlparse` treat the bracket as an IPv6 literal and raise, so `ProviderInfoView.dispatch` blew up and the discovery endpoint returned **500 for any request carrying an Origin header**.

This only affects Kargo because its UI resolves discovery **in the browser**. Argo CD does it server-side and never sends an Origin, which is why it was unaffected and why the problem did not show up until Kargo was wired.

Verified directly:

```
kargo   + Origin header -> HTTP 500, no ACAO
grafana + Origin header -> HTTP 200, Access-Control-Allow-Origin: https://grafana.local.bigd.no
```

## What

Any regex port triggers this, since `urlparse().port` must be an integer, so the fix is to pin the CLI port rather than match it. Both redirect URIs are now parseable URLs.

Tradeoff: `kargo login` now needs `--port 8087` rather than picking an ephemeral port. That is recorded in a comment next to the URI, along with the reason the regex form cannot come back.

## Verification

- Blueprint passes `Importer.validate()` against the live instance.
- Both redirect URIs confirmed to parse, yielding `port=None` and `port=8087`.
- `kustomize build --enable-helm` renders clean.
- Post-merge check is that the discovery endpoint returns 200 with an ACAO header and the Kargo login page loads without the OIDC error.