### PR TITLE
feat(portfolio): surface the explorable room and make the desk usable

### DIFF
--- a/portfolio/src/components/fun/FunRoom.tsx
+++ b/portfolio/src/components/fun/FunRoom.tsx
@@ -24,18 +24,26 @@ import {
   LANTERN,
   ROOM,
   Room,
+  SEAT,
   type LightKey,
   type Lights,
   type Placement,
 } from "./Room";
 import { CodeScreen, type Tab } from "./CodeScreen";
 import { Dashboard } from "./Screen";
-import { Crosshair, InfoPanel, InteractPrompt, Keybinds, type InfoCard } from "./Hud";
+import {
+  Crosshair,
+  InfoPanel,
+  InteractPrompt,
+  Keybinds,
+  SeatedHint,
+  type InfoCard,
+} from "./Hud";
 import type { Hardware } from "./hardware";
 import type { CareerData, ShelfBook, ShelfCert, ShelfData } from "./shelf";
 import type { SourceExcerpt } from "@/lib/source-excerpt";
 import { TerminalScreen } from "./Terminal";
-import { InteractionProvider, type Prompt } from "./interaction";
+import { Interactive, InteractionProvider, type Prompt } from "./interaction";
 import { useInfraFeed } from "./feed";
 import { preloadProps } from "./props";
 import { preloadSurfaces } from "./textures";
@@ -137,24 +145,38 @@ function ScreenWall({
   data,
   source,
   deskTab,
+  onSwitchTab,
   poweredCount,
 }: {
   data: PanelProps;
   source: SourceExcerpt;
   deskTab: Tab;
+  onSwitchTab: () => void;
   poweredCount: number;
 }) {
   return (
     <>
-      <CodeScreen
-        source={source}
-        data={data}
-        tab={deskTab}
-        position={DESK_SCREEN.position}
-        rotation={DESK_SCREEN.rotation}
-        width={DESK_SCREEN.width}
-        powered={poweredCount > 0}
-      />
+      {/* The monitor draws a tab bar, and a tab bar is a promise. It used to be
+          one the room could not keep: the two views alternated on a timer with
+          no input path to them at all, so the highlighted tab read as something
+          you could click and then ignored you. Pressing E switches it and pins
+          it — see the interval in Scene. */}
+      <Interactive
+        label="the desk monitor"
+        verb="switch view"
+        detail={deskTab === "code" ? "show the ArgoCD view" : "show deployment.yaml"}
+        onActivate={onSwitchTab}
+      >
+        <CodeScreen
+          source={source}
+          data={data}
+          tab={deskTab}
+          position={DESK_SCREEN.position}
+          rotation={DESK_SCREEN.rotation}
+          width={DESK_SCREEN.width}
+          powered={poweredCount > 0}
+        />
+      </Interactive>
       <Dashboard
         panels={WALL_PANELS}
         data={data}
@@ -378,6 +400,102 @@ function TerminalFocus({
   return null;
 }
 
+/** How close the seat move has to get before the camera is handed back. */
+const SEAT_ARRIVE = 0.02;
+
+/**
+ * Sits the visitor down at the desk, and stands them back up exactly where they
+ * were.
+ *
+ * Shares its shape with TerminalFocus above, and differs in the one way that
+ * matters: once the move in has landed this lets go of the camera completely.
+ * The terminal zoom holds its quaternion for as long as it is active, which is
+ * right for a single panel you are reading and wrong for a chair — sitting is
+ * somewhere you look around *from*, between the two monitors, up at the prints,
+ * over at the shelf. Holding the view would make the chair a cutscene.
+ *
+ * Letting go is only safe because FirstPerson stays switched off for the whole
+ * time seated, not just for the move. Position frozen, rotation free: that is
+ * the difference between sitting in a chair and hovering in front of one.
+ */
+function SeatedFocus({
+  active,
+  onStandingUp,
+}: {
+  active: boolean;
+  onStandingUp: (busy: boolean) => void;
+}) {
+  const { camera } = useThree();
+  const saved = useRef<{ pos: THREE.Vector3; quat: THREE.Quaternion } | null>(null);
+  const mode = useRef<"idle" | "in" | "held" | "out">("idle");
+
+  const view = useMemo(() => {
+    // Aim at the midpoint of the pair rather than at either panel, so neither
+    // is the one you are "really" looking at. Read off the placements so the
+    // seat cannot drift when the monitors are nudged.
+    const look = new THREE.Vector3(...DESK_SCREEN.position)
+      .add(new THREE.Vector3(...DESK_TERMINAL.position))
+      .multiplyScalar(0.5);
+    const pos = new THREE.Vector3(0, SEAT.eye, SEAT.z);
+    const quat = new THREE.Quaternion().setFromRotationMatrix(
+      new THREE.Matrix4().lookAt(pos, look, new THREE.Vector3(0, 1, 0)),
+    );
+    return { pos, quat };
+  }, []);
+
+  useEffect(() => {
+    if (active) mode.current = "in";
+    else if (saved.current) {
+      mode.current = "out";
+      onStandingUp(true);
+    }
+  }, [active, onStandingUp]);
+
+  useFrame((_, rawDelta) => {
+    if (mode.current === "idle" || mode.current === "held") return;
+    const delta = Math.min(rawDelta, 0.05);
+    const k = 1 - Math.pow(0.0004, delta);
+
+    if (mode.current === "in") {
+      if (!saved.current) {
+        saved.current = {
+          pos: camera.position.clone(),
+          quat: camera.quaternion.clone(),
+        };
+      }
+      camera.position.lerp(view.pos, k);
+      camera.quaternion.slerp(view.quat, k);
+      if (camera.position.distanceTo(view.pos) < SEAT_ARRIVE) {
+        camera.position.copy(view.pos);
+        /* Position is snapped, the quaternion deliberately is not. It is within
+           a degree or so by now, and the visitor's own mouse takes it from
+           here — a snap they did not ask for would be more noticeable than the
+           rounding error it fixes. */
+        mode.current = "held";
+      }
+      return;
+    }
+
+    const back = saved.current;
+    if (!back) {
+      mode.current = "idle";
+      onStandingUp(false);
+      return;
+    }
+    camera.position.lerp(back.pos, k);
+    camera.quaternion.slerp(back.quat, k);
+    if (camera.position.distanceTo(back.pos) < 0.005) {
+      camera.position.copy(back.pos);
+      camera.quaternion.copy(back.quat);
+      saved.current = null;
+      mode.current = "idle";
+      onStandingUp(false);
+    }
+  });
+
+  return null;
+}
+
 /** Screens are the light source, so the fill has to follow them on. */
 function Lighting({
   poweredCount,
@@ -540,6 +658,9 @@ function Scene({
   touchMove,
   lights,
   onToggleLight,
+  seated,
+  onSit,
+  onStand,
 }: {
   data: PanelProps;
   source: SourceExcerpt;
@@ -565,8 +686,16 @@ function Scene({
   paused: boolean;
   lights: Lights;
   onToggleLight: (k: LightKey) => void;
+  seated: boolean;
+  onSit: () => void;
+  onStand: () => void;
 }) {
   const [poweredCount, setPoweredCount] = useState(0);
+  /* True only while the camera is easing back out of the chair. `seated` has
+     already gone false by then, and it is the flag that was keeping FirstPerson
+     off, so without this the walk controller grabs the camera mid-move and
+     snaps it to standing height halfway across the room. */
+  const [standingUp, setStandingUp] = useState(false);
   /* True while the camera is easing back out of the terminal. `paused` has
      already gone false by then, so without this FirstPerson would grab the
      camera mid-move and snap it to eye height. */
@@ -574,14 +703,23 @@ function Scene({
   /* The desk monitor alternates between the manifest and the ArgoCD view.
      Held here rather than inside CodeScreen — see the note on its `tab` prop. */
   const [deskTab, setDeskTab] = useState<Tab>("code");
+  /* Set the first time the visitor switches the monitor themselves. The
+     rotation exists so the second view is seen at all by someone who never
+     touches the monitor; once they have, a timer yanking the screen out from
+     under them is the room overriding a deliberate choice. */
+  const [deskTabPinned, setDeskTabPinned] = useState(false);
   useEffect(() => {
-    if (phase !== "exploring") return;
+    if (phase !== "exploring" || deskTabPinned) return;
     const t = setInterval(
       () => setDeskTab((v) => (v === "code" ? "argocd" : "code")),
       9000,
     );
     return () => clearInterval(t);
-  }, [phase]);
+  }, [phase, deskTabPinned]);
+  const switchDeskTab = useCallback(() => {
+    setDeskTabPinned(true);
+    setDeskTab((v) => (v === "code" ? "argocd" : "code"));
+  }, []);
   const { camera } = useThree();
 
   // Screens come on once the room is up.
@@ -616,7 +754,11 @@ function Scene({
       <color attach="background" args={["#1b1410"]} />
       <fog attach="fog" args={["#241a13", 16, 42]} />
       <Lighting poweredCount={poweredCount} lights={lights} />
-      <InteractionProvider enabled={interacting && !paused} onPrompt={onPrompt}>
+      <InteractionProvider
+        enabled={interacting && !paused}
+        onPrompt={onPrompt}
+        onEmptyActivate={onStand}
+      >
       <Suspense fallback={null}>
         {/* Image-based lighting. Does most of the work on specular: without an
             environment map, metal and plastic have nothing to reflect and every
@@ -641,6 +783,8 @@ function Scene({
           onExitRoom={onExitRoom}
           lights={lights}
           onToggleLight={onToggleLight}
+          seated={seated}
+          onSit={onSit}
         />
         <Post />
         {/* Fires only once everything above has resolved, which is the honest
@@ -650,7 +794,13 @@ function Scene({
             blank canvas. */}
         <SceneReady onReady={onSceneReady} />
       </Suspense>
-      <ScreenWall data={data} source={source} deskTab={deskTab} poweredCount={poweredCount} />
+      <ScreenWall
+        data={data}
+        source={source}
+        deskTab={deskTab}
+        onSwitchTab={switchDeskTab}
+        poweredCount={poweredCount}
+      />
       <TerminalScreen
         position={DESK_TERMINAL.position}
         rotation={DESK_TERMINAL.rotation}
@@ -666,12 +816,23 @@ function Scene({
           resolves through the same pick registry the crosshair uses, and
           outside this boundary that context reads null and every tap silently
           does nothing. */}
-      <TouchLook enabled={coarse && phase === "exploring" && !paused && !settling} />
+      {/* Stays on while seated — look is exactly what the chair keeps — but off
+          for the move back out, which would otherwise fight the drag. */}
+      <TouchLook
+        enabled={
+          coarse && phase === "exploring" && !paused && !settling && !standingUp
+        }
+      />
       </InteractionProvider>
       <TempCam />
       <TerminalFocus active={terminalActive} onSettling={setSettling} />
+      <SeatedFocus active={seated} onStandingUp={setStandingUp} />
+      {/* `seated` covers the move in and the whole time in the chair;
+          `standingUp` covers the move back out, after seated has gone false. */}
       <FirstPerson
-        enabled={phase === "exploring" && !paused && !settling}
+        enabled={
+          phase === "exploring" && !paused && !settling && !seated && !standingUp
+        }
         move={touchMove}
       />
       {/* The selector is swapped for one that matches nothing while something
@@ -771,6 +932,7 @@ export default function FunRoom({
   const onContextLost = useCallback(() => setContextLost(true), []);
   const [card, setCard] = useState<InfoCard | null>(null);
   const [terminalActive, setTerminalActive] = useState(false);
+  const [seated, setSeated] = useState(false);
   /* All on from the start, always. The room is a lamplit evening and that is
      what it should be the first time you see it — the switches are something to
      find, not a state to arrive in. Not persisted for the same reason: a return
@@ -816,6 +978,14 @@ export default function FunRoom({
   const exitTerminal = useCallback(() => {
     setTerminalActive(false);
   }, []);
+
+  const sitDown = useCallback(() => setSeated(true), []);
+  /* Reached by every interact that hit nothing, not only the ones made while
+     seated. That is fine and is why it is written as a plain set rather than a
+     toggle: standing when already standing is a no-op React bails out of, and
+     an empty press should never be able to seat someone who was not aiming at
+     the chair. */
+  const standUp = useCallback(() => setSeated(false), []);
 
   /* Walking out of the door leaves the room. Uses the router rather than
      window.location so it is a client navigation like any other nav link —
@@ -1046,6 +1216,9 @@ export default function FunRoom({
             onToggleLight={toggleLight}
             coarse={coarse}
             touchMove={touchMove}
+            seated={seated}
+            onSit={sitDown}
+            onStand={standUp}
           />
           <ContextGuard onLost={onContextLost} />
         </Canvas>
@@ -1092,6 +1265,10 @@ export default function FunRoom({
         <div className="pointer-events-none absolute inset-0 z-20">
           <Crosshair active={prompt !== null} />
           <InteractPrompt prompt={prompt} touch={coarse} />
+          {/* Both occupy the same spot under the crosshair, so a live prompt
+              wins: while seated and looking at the shell the useful line is
+              "open the terminal", not the way out of a chair. */}
+          {seated && prompt === null && <SeatedHint touch={coarse} />}
           {/* Every bind on that card is a key, and touch has no keyboard —
               it would sit under the walk stick advertising controls that do
               not exist. The touch hint bottom-right says the equivalent. */}
@@ -1133,7 +1310,11 @@ export default function FunRoom({
       {/* Touch walk stick, and the one line that explains the controls it does
           not cover. Both drop away while a card or the terminal has focus —
           the stick would sit on top of the panel, and the hint is answered. */}
-      {coarse && phase === "exploring" && !paused && (
+      {/* The stick goes while seated too: the chair switches walking off, and a
+          joystick that visibly does nothing reads as the room having broken
+          rather than as the chair holding you. Look-drag survives, which is
+          what the remaining hint says. */}
+      {coarse && phase === "exploring" && !paused && !seated && (
         <>
           <TouchStick move={touchMove} />
           <div className="pointer-events-none absolute bottom-8 right-8 z-30 max-w-[46vw]">

--- a/portfolio/src/components/fun/Hud.tsx
+++ b/portfolio/src/components/fun/Hud.tsx
@@ -213,6 +213,27 @@ export function InfoPanel({
   );
 }
 
+/**
+ * The way out of the chair, shown for as long as you are in it.
+ *
+ * Sitting takes walking away, so unlike every other state in the room there is
+ * no way to leave it by accident and no object to look at that offers the exit.
+ * A prompt that only appeared on hover would leave the visitor holding W at a
+ * view that will not move.
+ */
+export function SeatedHint({ touch = false }: { touch?: boolean }) {
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-[calc(50%+30px)] -translate-x-1/2">
+      <div className="rounded-[5px] border border-white/15 bg-black/70 px-3.5 py-2.5 text-center shadow-lg">
+        <p className="flex items-center justify-center gap-2 font-mono text-[11px] text-white/70">
+          {touch ? "tap to" : <Key>E</Key>}
+          stand up
+        </p>
+      </div>
+    </div>
+  );
+}
+
 type Bind = { keys: React.ReactNode; action: string };
 
 const BINDS: Bind[] = [

--- a/portfolio/src/components/fun/Room.tsx
+++ b/portfolio/src/components/fun/Room.tsx
@@ -49,6 +49,22 @@ export const DESK_D = 0.72;
  *  than no chair. */
 export const CHAIR_Z = -1.32;
 
+/**
+ * Where the camera goes when the visitor takes the chair.
+ *
+ * Pulled in from CHAIR_Z rather than sat on it: the chair's origin is its
+ * centre, and a camera there is behind the backrest looking through it. The
+ * offset puts the eye where a head actually is once you are sitting in it,
+ * which lands ~0.7m off the panels — the same distance the terminal zoom uses,
+ * arrived at independently and a decent sign both are right.
+ *
+ * The height is a seated eye, not a standing one docked downward. At 1.25 the
+ * landscape panel's centre at 1.09 sits just below the horizon and the portrait
+ * one at 1.19 is level, which is the geometry of a desk that has been set up
+ * properly rather than one being loomed over.
+ */
+export const SEAT = { z: CHAIR_Z - 0.18, eye: 1.25 };
+
 /** Where the bookshelf stands. The lamp on top reads its x and z from here. */
 const SHELF_AT: [number, number, number] = [-ROOM.w / 2 + 0.16, 0, 0.72];
 
@@ -442,6 +458,8 @@ export function Room({
   onExitRoom,
   lights,
   onToggleLight,
+  seated,
+  onSit,
 }: {
   onPrinterStatus: (msg: string | null) => void;
   shelf: ShelfData;
@@ -453,6 +471,8 @@ export function Room({
   onExitRoom: () => void;
   lights: Lights;
   onToggleLight: (k: LightKey) => void;
+  seated: boolean;
+  onSit: () => void;
 }) {
   const hw = ROOM.w / 2;
   const hd = ROOM.d / 2;
@@ -725,7 +745,19 @@ export function Room({
 
       {/* y=0: Prop seats a model on its own base, so no manual lift. */}
       <Plant position={[hw - 0.42, 0, hd - 0.55]} />
-      <Chair position={[0, 0, CHAIR_Z]} />
+      {/* Disabled rather than relabelled once seated. Looking down at the chair
+          you are already in should not offer to seat you again, and standing up
+          is handled by the interact-with-nothing path instead — see
+          onEmptyActivate in interaction.tsx for why it cannot live here. */}
+      <Interactive
+        label="the desk chair"
+        verb="sit down"
+        detail="both screens, at reading distance"
+        onActivate={onSit}
+        disabled={seated}
+      >
+        <Chair position={[0, 0, CHAIR_Z]} />
+      </Interactive>
 
       {/* The homelab, in an open-fronted sideboard against the right wall.
           Every device in it is named from the README hardware tables. */}

--- a/portfolio/src/components/fun/interaction.tsx
+++ b/portfolio/src/components/fun/interaction.tsx
@@ -69,10 +69,21 @@ export type Prompt = { label: string; verb: string; detail?: string } | null;
 export function InteractionProvider({
   enabled,
   onPrompt,
+  /**
+   * Called when the visitor presses interact with nothing under the crosshair.
+   *
+   * Sitting down needs this. Standing back up is the one action whose affordance
+   * you cannot look at — you are in the chair, so the chair is under you rather
+   * than in front of you, and there is no object left to aim at. Rather than
+   * bolt a second global key handler onto the window and race this one for the
+   * same keystroke, the registry that already owns E hands the miss back.
+   */
+  onEmptyActivate,
   children,
 }: {
   enabled: boolean;
   onPrompt: (p: Prompt) => void;
+  onEmptyActivate?: () => void;
   children: React.ReactNode;
 }) {
   const targets = useRef(new Map<THREE.Object3D, React.RefObject<Target>>());
@@ -85,6 +96,14 @@ export function InteractionProvider({
   const raycaster = useMemo(() => new THREE.Raycaster(), []);
   const centre = useMemo(() => new THREE.Vector2(0, 0), []);
   const { camera } = useThree();
+
+  /* Held in a ref for the same reason targets are: the callback is inline at
+     the call site, so putting it in the key effect's deps would rebind the
+     listener on every render. */
+  const emptyActivate = useRef(onEmptyActivate);
+  useEffect(() => {
+    emptyActivate.current = onEmptyActivate;
+  });
 
   const register = useCallback(
     (obj: THREE.Object3D, target: React.RefObject<Target>) => {
@@ -153,9 +172,13 @@ export function InteractionProvider({
     const onKey = (e: KeyboardEvent) => {
       if (e.code !== "KeyE" && e.code !== "Enter") return;
       const obj = hoveredRef.current;
-      if (!obj) return;
-      const t = targets.current.get(obj)?.current;
-      if (!t || t.disabled) return;
+      const t = obj ? targets.current.get(obj)?.current : null;
+      if (!t || t.disabled) {
+        if (!emptyActivate.current) return;
+        e.preventDefault();
+        emptyActivate.current();
+        return;
+      }
       e.preventDefault();
       t.onActivate();
     };
@@ -179,9 +202,16 @@ export function InteractionProvider({
           best = { root, dist: hits[0].distance };
         }
       }
-      if (!best) return false;
-      const t = targets.current.get(best.root)?.current;
-      if (!t || t.disabled) return false;
+      const t = best ? targets.current.get(best.root)?.current : null;
+      /* Same fallback as the key path, and load-bearing rather than symmetric:
+         sitting freezes movement, so a touch visitor whose tap on empty floor
+         did nothing would be stuck in the chair with no keyboard to press E on
+         and no walk stick to leave with. */
+      if (!t || t.disabled) {
+        if (!emptyActivate.current) return false;
+        emptyActivate.current();
+        return true;
+      }
       t.onActivate();
       return true;
     },

--- a/portfolio/src/components/sections/Hero.tsx
+++ b/portfolio/src/components/sections/Hero.tsx
@@ -2,8 +2,10 @@
 
 import { motion, useReducedMotion, useScroll, useTransform } from "motion/react";
 import { useEffect, useRef, useState } from "react";
+import { ArrowRight } from "lucide-react";
 import { site } from "@/content/site";
 import { InlineGlobe } from "@/components/InlineGlobe";
+import { Button } from "@/components/primitives/Button";
 import { Tag } from "@/components/primitives/Tag";
 
 export function Hero() {
@@ -64,6 +66,20 @@ export function Hero() {
             <Tag variant="accent">AZ-305</Tag>
             <Tag variant="muted">4+ yrs production cloud</Tag>
             <Tag variant="muted">Public &amp; private · enterprise scale</Tag>
+          </div>
+
+          <div className="mt-10 flex flex-wrap items-center gap-x-4 gap-y-2">
+            <Button
+              href="/fun"
+              variant="secondary"
+              size="lg"
+              iconRight={<ArrowRight size={16} aria-hidden />}
+            >
+              Walk through the room
+            </Button>
+            <p className="text-sm text-fg-3">
+              The same work, as a place you can move around in.
+            </p>
           </div>
         </div>
 

--- a/portfolio/src/content/site.ts
+++ b/portfolio/src/content/site.ts
@@ -48,6 +48,7 @@ export const site = {
     { label: "Resume", href: "/#resume" },
     { label: "Work", href: "/#portfolio" },
     { label: "Infrastructure", href: "/infrastructure" },
+    { label: "Room", href: "/fun" },
     { label: "Blog", href: "/#blog" },
     { label: "Contact", href: "/#contact" },
   ] as readonly { href: string; label: string }[],


### PR DESCRIPTION
## Why

The room at `/fun` was reachable only from one sentence of footer prose, so
almost nobody found it. Two things inside it were also hard to use once you did.

Reading either desk screen meant standing over the desk at 1.66m, where text
sized for a monitor is illegible.

The desk monitor drew a tab bar that nothing could switch. The two views
alternated on a nine second timer and `CodeScreen` was never wrapped in
`Interactive`, so a highlighted tab with a coloured top border read as
clickable and then ignored you.

## What

Discoverability: `/fun` is in the site nav as "Room" between Infrastructure and
Blog, plus a secondary CTA under the hero tags. One nav entry feeds both the
desktop bar and the mobile menu, so `Header` is unchanged. The CTA reuses the
existing `Button` primitive and the `ArrowRight` pattern from `CtaContact`. The
footer sentence stays and now reinforces the room rather than being the only
route to it.

Sitting: look at the chair and press E. The camera eases to a seated eye height
of 1.25m, about 0.7m off the panels, matching the distance the terminal zoom
already used. Unlike that zoom, sitting releases the camera once it lands, so
free look still works from the chair. Walking is disabled until you stand, and
standing restores the exact pose you sat down from.

Standing up has no object to aim at, since the chair is under you rather than in
front of you. Rather than add a second global key handler racing the existing
one, `InteractionProvider` hands back presses that hit nothing through
`onEmptyActivate`. The same fallback covers touch, where a tap on empty floor
would otherwise leave a seated visitor with no keyboard and no walk stick.

Monitor tabs: the desk monitor is interactive, prompt reads "switch view" and
the detail line names the view the press will bring up. The first manual switch
pins it and stops the timer. The rotation exists so the second view is seen at
all, not to override a deliberate choice.

## Verification

`make typecheck` clean. `make lint` at 0 errors and 24 warnings, identical to the
`main` baseline confirmed by stashing, so no new warnings.

Browser verified at 1440x900 and 390x844, since none of the 3D behaviour is
provable by types:

- Nav item and hero CTA render on desktop and in the mobile menu. `/`, `/fun`
  and `/infrastructure` all return 200.
- Sit and stand round trip: prompt reads "the desk chair", sitting lands the
  camera at exactly `(0, 1.25, -1.5)`, turning the view leaves that position
  frozen with no snap back, standing restores an identical view.
- Aiming at the shell while seated correctly yields to the terminal's own
  prompt instead of the stand up hint.
- Monitor switching flips the view and inverts the prompt, and the tab then
  holds for 24s with no auto rotation.

Two notes. There are now three E driven states at the desk (switch the monitor,
sit, zoom the terminal) and only monitor-while-seated was tested across
orderings. The tab bar styling is unchanged, so before the first press it still
looks mouse clickable on desktop, where it is not.
