### PR TITLE
feat(apps): add batmotor-storehaug static site

### DIFF
--- a/k8s/talos/apps/batmotor-storehaug/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/batmotor-storehaug/ciliumnetworkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: batmotor-storehaug-policy
+  namespace: batmotor-storehaug
+spec:
+  endpointSelector:
+    matchLabels:
+      app: batmotor-storehaug
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": traefik
+            "k8s:app.kubernetes.io/instance": traefik-traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - health

--- a/k8s/talos/apps/batmotor-storehaug/deployment.yaml
+++ b/k8s/talos/apps/batmotor-storehaug/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: batmotor-storehaug
+  namespace: batmotor-storehaug
+  labels:
+    app: batmotor-storehaug
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: batmotor-storehaug
+  template:
+    metadata:
+      labels:
+        app: batmotor-storehaug
+    spec:
+      containers:
+        - name: batmotor-storehaug
+          image: nginxinc/nginx-unprivileged:1.29-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: html
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 20
+            failureThreshold: 3
+      volumes:
+        - name: html
+          configMap:
+            name: batmotor-storehaug-html

--- a/k8s/talos/apps/batmotor-storehaug/httproute.yaml
+++ b/k8s/talos/apps/batmotor-storehaug/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: batmotor-storehaug
+  namespace: batmotor-storehaug
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-public
+      namespace: traefik
+  hostnames:
+    - batmotor-storehaug.bigd.no
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: batmotor-storehaug-service
+          port: 80
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/k8s/talos/apps/batmotor-storehaug/index.html
+++ b/k8s/talos/apps/batmotor-storehaug/index.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Båtmotor Storehaug — kjøper og selger brukte båtmotorer</title>
+  <meta name="description" content="Aleksander Storehaug kjøper gamle båtmotorer og selger renoverte. Alle merker og årsmodeller, også defekte. Henting etter avtale.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚓</text></svg>">
+  <style>
+    :root {
+      --bg: #0d1b26;
+      --bg-alt: #122431;
+      --line: #1e3a4a;
+      --text: #e8eef2;
+      --muted: #9db0bd;
+      --accent: #3fb8a5;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap { max-width: 880px; margin: 0 auto; padding: 0 24px; }
+
+    header {
+      background: linear-gradient(170deg, #0d1b26 0%, #143040 70%, #17414f 100%);
+      border-bottom: 1px solid var(--line);
+      padding: 88px 0 72px;
+    }
+    .eyebrow {
+      font-size: .78rem;
+      letter-spacing: 3px;
+      text-transform: uppercase;
+      color: var(--accent);
+      font-weight: 600;
+    }
+    h1 {
+      margin-top: 14px;
+      font-size: clamp(2.2rem, 6.5vw, 3.6rem);
+      line-height: 1.1;
+      letter-spacing: -1px;
+      font-weight: 800;
+    }
+    .lede {
+      margin-top: 20px;
+      font-size: clamp(1.05rem, 2.2vw, 1.25rem);
+      color: var(--muted);
+      max-width: 560px;
+    }
+    .cta {
+      display: inline-block;
+      margin-top: 32px;
+      background: var(--accent);
+      color: #06202a;
+      font-weight: 700;
+      text-decoration: none;
+      padding: 13px 26px;
+      border-radius: 6px;
+    }
+    .cta:hover { background: #4fd0bb; }
+
+    section { padding: 64px 0; border-bottom: 1px solid var(--line); }
+    section:nth-of-type(even) { background: var(--bg-alt); }
+    h2 {
+      font-size: clamp(1.4rem, 3.5vw, 1.8rem);
+      letter-spacing: -.5px;
+      margin-bottom: 8px;
+    }
+    .sub { color: var(--muted); margin-bottom: 28px; max-width: 620px; }
+
+    ul { list-style: none; display: grid; gap: 12px; }
+    ul li {
+      padding-left: 28px;
+      position: relative;
+      color: var(--text);
+    }
+    ul li::before {
+      content: "";
+      position: absolute;
+      left: 4px;
+      top: .62em;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent);
+    }
+
+    .steps { display: grid; gap: 20px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .step {
+      background: rgba(255,255,255,.03);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px;
+    }
+    .step .num {
+      font-size: .75rem;
+      font-weight: 700;
+      letter-spacing: 2px;
+      color: var(--accent);
+    }
+    .step h3 { margin: 8px 0 6px; font-size: 1.05rem; }
+    .step p { color: var(--muted); font-size: .95rem; }
+
+    .contact { display: grid; gap: 10px; margin-top: 24px; }
+    .contact a { color: var(--accent); text-decoration: none; font-size: 1.15rem; font-weight: 600; }
+    .contact a:hover { text-decoration: underline; }
+    .contact span { color: var(--muted); font-size: .95rem; }
+
+    footer {
+      padding: 40px 0 56px;
+      color: #6f8492;
+      font-size: .85rem;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <p class="eyebrow">Aleksander Storehaug</p>
+    <h1>Kjøper gamle båtmotorer.<br>Selger renoverte.</h1>
+    <p class="lede">
+      Har du en gammel påhengsmotor stående i garasjen? Jeg kjøper den — også om
+      den ikke går. Og har du bruk for en rimelig, gjennomgått motor, har jeg som
+      regel noe på lager.
+    </p>
+    <a class="cta" href="#kontakt">Ta kontakt</a>
+  </div>
+</header>
+
+<section>
+  <div class="wrap">
+    <h2>Jeg kjøper</h2>
+    <p class="sub">Send noen bilder og motortype, så får du en pris.</p>
+    <ul>
+      <li>Påhengsmotorer og innenbordsmotorer</li>
+      <li>Alle merker og årsmodeller — Yamaha, Mercury, Evinrude, Johnson, Suzuki, Honda, Tohatsu</li>
+      <li>Defekte og ikke-gående motorer, også til deler</li>
+      <li>Henting etter avtale</li>
+      <li>Oppgjør på stedet</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <h2>Jeg selger</h2>
+    <p class="sub">Brukte motorer som er gjennomgått før de går ut døra.</p>
+    <ul>
+      <li>Renoverte og servicede bruktmotorer</li>
+      <li>Prøvekjørt i kar før salg</li>
+      <li>Brukte deler fra demonterte motorer — propeller, tennplugger, impellere, tanker</li>
+      <li>Ærlig beskrivelse av tilstand, ingen overraskelser</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <h2>Slik fungerer det</h2>
+    <p class="sub">Tre steg, som regel unnagjort på en uke.</p>
+    <div class="steps">
+      <div class="step">
+        <p class="num">STEG 1</p>
+        <h3>Send bilder</h3>
+        <p>Bilder av motoren, merke, modell og årsmodell hvis du vet det.</p>
+      </div>
+      <div class="step">
+        <p class="num">STEG 2</p>
+        <h3>Få pris</h3>
+        <p>Du får et konkret tilbud tilbake, uten forpliktelser.</p>
+      </div>
+      <div class="step">
+        <p class="num">STEG 3</p>
+        <h3>Henting og oppgjør</h3>
+        <p>Vi avtaler tid, jeg henter motoren og gjør opp på stedet.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="kontakt">
+  <div class="wrap">
+    <h2>Kontakt</h2>
+    <p class="sub">Ring, send melding eller e-post — bilder på melding går raskest.</p>
+    <!-- PLACEHOLDER: bytt ut telefonnummer og e-postadresse med de riktige. -->
+    <div class="contact">
+      <a href="tel:+4700000000">000 00 000</a>
+      <a href="mailto:post@batmotor-storehaug.bigd.no">post@batmotor-storehaug.bigd.no</a>
+      <span>Aleksander Storehaug</span>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    batmotor-storehaug.bigd.no
+  </div>
+</footer>
+
+</body>
+</html>

--- a/k8s/talos/apps/batmotor-storehaug/kustomization.yaml
+++ b/k8s/talos/apps/batmotor-storehaug/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "0"
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - ciliumnetworkpolicy.yaml
+
+configMapGenerator:
+  - name: batmotor-storehaug-html
+    namespace: batmotor-storehaug
+    files:
+      - index.html

--- a/k8s/talos/apps/batmotor-storehaug/namespace.yaml
+++ b/k8s/talos/apps/batmotor-storehaug/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: batmotor-storehaug

--- a/k8s/talos/apps/batmotor-storehaug/service.yaml
+++ b/k8s/talos/apps/batmotor-storehaug/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: batmotor-storehaug-service
+  namespace: batmotor-storehaug
+spec:
+  selector:
+    app: batmotor-storehaug
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
Landing page for Aleksander Storehaug — buys old boat motors, sells refurbished ones.

## What

New app `k8s/talos/apps/batmotor-storehaug/`, cloned from the `bigd` pattern:

- `nginxinc/nginx-unprivileged:1.29-alpine` serving a single self-contained `index.html`
- `index.html` shipped via kustomize `configMapGenerator` — the hash suffix means editing the page rolls the pods, no image build, no CI pipeline
- `HTTPRoute` on `traefik-gateway-public` for **batmotor-storehaug.bigd.no**
- `CiliumNetworkPolicy` allowing ingress only from the Traefik pods plus `host`/`health`

Nothing else needed: the `*.bigd.no` wildcard cert is already on the public gateway, external-dns creates the Cloudflare CNAME from the route, and the `apps` ApplicationSet picks up the directory automatically (app name and namespace both `batmotor-storehaug`).

## Notes

- The requested hostname was `båtmotor-storehaug.bigd.no`; `å` is not valid in a Kubernetes HTTPRoute hostname, so the ASCII spelling is used.
- **Contact details are placeholders** (`000 00 000`, `post@batmotor-storehaug.bigd.no`) — flagged with an HTML comment in `index.html` for easy replacement.

## Verification

- `kustomize build k8s/talos/apps/batmotor-storehaug` renders cleanly; the Deployment volume references the hashed ConfigMap.
- Page served locally from the same nginx image and checked in a browser at 1280px and 390px — content in Norwegian, layout holds at both widths.