### PR TITLE
blog: move the Northlight pin to v0.5.0

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -5,7 +5,7 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 ## Apps
 
 ### Finish the blog's Blowfish → Northlight migration (phases 5–6)
-- **What:** The theme swap and the stage-gate hardening are both done and verified on `feat/blog-northlight-theme`, pinned to Northlight v0.4.1. Remaining: the cutover (merge, soak on stage, hold the Kargo-opened prod PR, purge Cloudflare) and removing the Blowfish submodule once prod is trusted. Two content decisions stay open — the 13 raw `<img style="width:NN%">` tags that bypass the render hooks, and the palette — plus whether the home background image is worth keeping given it is invisible in dark mode.
+- **What:** The theme swap and the stage-gate hardening are both done and verified on `feat/blog-northlight-theme`, pinned to Northlight v0.5.0. Remaining: the cutover (merge, soak on stage, hold the Kargo-opened prod PR, purge Cloudflare) and removing the Blowfish submodule once prod is trusted. Two content decisions stay open — the 13 raw `<img style="width:NN%">` tags that bypass the render hooks, and the palette — plus whether the home background image is worth keeping given it is invisible in dark mode.
 - **Why deferred:** The palette and the image widths are visual judgements that need the stage environment; they cannot be settled from a diff. Blowfish's submodule is kept until prod is trusted so rollback stays a single revert.
 - **Unblock:** Work through phases 5–6 of `docs/northlight-migration.md`, which carries the ordered steps, the verification for each, and the open decisions with the evidence gathered so far.
 - **Where:** `docs/northlight-migration.md`; `blog/config/_default/params.toml`; `.gitmodules` and `blog/themes/blowfish`.

--- a/docs/northlight-migration.md
+++ b/docs/northlight-migration.md
@@ -1,7 +1,7 @@
 # Migrating blog.nordbye.it from Blowfish to Northlight
 
 Ordered plan for replacing the Blowfish theme on `blog/` with
-[Northlight](https://github.com/mortennordbye/northlight), pinned at **v0.4.1**.
+[Northlight](https://github.com/mortennordbye/northlight), pinned at **v0.5.0**.
 
 Northlight exists specifically to replace this blog's theme. `docs/SPEC.md` in that repo is an
 audit of what this site actually uses, so the target is a deliberately *smaller* surface than
@@ -37,7 +37,7 @@ from this plan, both in the direction of less work:
 
 | Decision | Choice | Why |
 |---|---|---|
-| Theme version | Pin **v0.4.1** | Was v0.4.0; bumped because the heading-level bug found during this migration was fixed and released as v0.4.1. |
+| Theme version | Pin **v0.5.0** | Started at v0.4.0. v0.4.1 fixed the heading-level bug this migration found; v0.5.0 then shipped the theme's full code audit, pulled in so stage soaks once on the final theme rather than twice. |
 | Staging | Reuse existing `blog-stage` | It already exists and already auto-promotes. No new infra. |
 | Prod gate | Hold the Kargo-opened PR | The auto-opened prod PR is the human gate; do not merge it until phase 5 verification is done. |
 
@@ -52,6 +52,24 @@ v0.4.0 was already much larger than the migration needs. It ships **38 shortcode
 KaTeX maths, series navigation, ten home-page layouts, RTL support and Firebase-backed view/like
 counters. This blog uses none of it, which means the migration has no feature cliff to negotiate:
 nothing has to be given up to make the swap, and anything wanted later is already there.
+
+### Why v0.5.0 rather than v0.4.1
+
+The theme had an open audit branch (`cleanup/audit-findings`, 76 files) that was rebased, merged
+and released as v0.5.0 so the stage soak happens once against the theme prod will actually run.
+
+Two things were worth catching there. The branch predated the heading fix and touched
+`section.html`, so a careless rebase would have silently reverted it — confirmed after rebasing
+that both `(dict "ctx" . "level" 2)` and its test assertion survived. And release-please proposed
+**0.4.2**, a patch, because the squash title said `fix:`; the branch adds a print stylesheet,
+`theme-color` meta tags and ~28 documented config keys, so it was forced to a minor with
+`Release-As: 0.5.0`. Shipping features in a patch would break the version contract for a theme
+published for other people.
+
+Re-verified against v0.5.0 rather than assumed: strict build clean at 74 pages, structural sweep
+69 pages / 0 problems, smoke green, and the home page renders identically to v0.4.1 with
+`recentCount = 5` intact — the audit consolidated the Recent-posts section and had a documented
+3-vs-6 default drift, so that one was checked specifically.
 
 ---
 


### PR DESCRIPTION
Follows #463. Moves the theme pin from v0.4.1 to **v0.5.0** so stage soaks once against the theme prod will actually run.

v0.5.0 is the theme's full code audit — 76 files of bug fixes, consolidation, i18n and accessibility work — plus a print stylesheet and `theme-color` meta tags.

## Two things worth catching

**The audit branch would have reverted the heading fix.** It was branched before v0.4.1 and touches `layouts/section.html`. After rebasing, confirmed both `(dict "ctx" . "level" 2)` and its test assertion survived — `/blog/` still renders `h1 → h2`.

**release-please proposed 0.4.2, a patch.** The squash title said `fix:`, so it never saw the `feat:` commit inside. The branch adds a print stylesheet, `theme-color` meta and ~28 documented config keys — that's a minor. Forced with `Release-As: 0.5.0`. Shipping features in a patch would break the version contract for a theme published for other people.

## Re-verified, not carried over

- `--panicOnWarning` build clean, 74 pages
- Structural sweep: **69 pages, 0 problems, 0 dead internal links**
- Hardened smoke script green: `smoke OK (theme, 4 kinds, search index, /blog/lawless-waf/)`
- `theme-color` pair present and `#0b0b0e` matches the measured dark `--bg`
- Home page renders identically to v0.4.1 with `recentCount = 5` intact — checked specifically, because the audit consolidated the Recent-posts section and had a documented 3-vs-6 default drift
- No horizontal overflow at 375px; both colour modes correct

## Not re-run

`make fuzz` needs bind mounts and this environment drives a remote Docker daemon, so it could not run meaningfully here — and CI doesn't run it either. It was green on the branch author's machine before the rebase, and the rebase touched only `section.html`, `tests/run.sh` and changelog files, none of which are shortcode parameters. Flagging rather than claiming it.

**Merging this puts stage on v0.5.0 and auto-opens the prod PR. Hold that one until the soak is done.**