### PR TITLE
fix(blog): give the stage smoke Job a deadline it can actually meet

### DIFF
--- a/docs/northlight-migration.md
+++ b/docs/northlight-migration.md
@@ -245,6 +245,20 @@ Proven to fail, not just to pass. Against the real built site it reports
 marker renamed it stops at the grep and exits 1; against a copy with `/tags/` and `/index.json`
 removed it stops at the `/tags/` request and exits 22.
 
+**The first version of this gate was too slow for its own Job deadline.** `activeDeadlineSeconds`
+was 180, sized for the single curl it replaced. Eight requests with generous retries put the
+worst-case retry delay alone at 132s before a byte moves, on top of the KEDA cold start, so the
+Job hit its deadline and stage verification failed — which is why no prod PR opened for 0.0.88.
+The site was fine; the gate was not. Fixed by raising the deadline to 300s, bounding every
+request with `--max-time`, and cutting the follow-up retries from 3x4s to 2x3s, since the
+deployment is already awake after the first request and long retries there buy nothing. Worst
+case is now 78s of retry delay inside a 300s budget.
+
+The requests that get grepped also send `Accept-Encoding: identity`. The stage route runs through
+a Traefik compress middleware; curl sends no `Accept-Encoding` by default so it should never have
+been compressed, but a `grep` against a gzipped body fails in a way that looks like a missing
+string rather than an encoding problem, and that is an expensive hour for whoever hits it.
+
 **`blog-prod-smoke` was deliberately left as the single one-line curl.** The same assertions would
 be just as valuable there, but prod is served through Cloudflare while stage goes straight to
 Traefik, so the response reaching the check may not be byte-identical to what nginx emitted —

--- a/k8s/talos/infra/kargo-projects/blog.yaml
+++ b/k8s/talos/infra/kargo-projects/blog.yaml
@@ -137,7 +137,7 @@ spec:
         job:
           spec:
             backoffLimit: 2
-            activeDeadlineSeconds: 180
+            activeDeadlineSeconds: 300
             template:
               spec:
                 restartPolicy: Never
@@ -153,6 +153,7 @@ spec:
                         # First request carries the long retry: it wakes the
                         # KEDA-scaled deployment from zero.
                         curl -fsSk --retry 10 --retry-delay 6 --retry-all-errors \
+                          --max-time 30 -H 'Accept-Encoding: identity' \
                           -o /tmp/home.html "$BASE/"
 
                         # Which theme rendered this. baseof.html emits this block and
@@ -169,13 +170,14 @@ spec:
                         # One request per page kind. A template that fails to build
                         # takes its whole kind down while the home page stays fine.
                         for p in /blog/ /tags/ /404.html /index.xml; do
-                          curl -fsSk --retry 3 --retry-delay 4 --retry-all-errors \
-                            -o /dev/null "$BASE$p"
+                          curl -fsSk --retry 2 --retry-delay 3 --retry-all-errors \
+                            --max-time 20 -o /dev/null "$BASE$p"
                         done
 
                         # The search index. Missing or empty is a silent search
                         # outage: the modal opens and simply finds nothing.
-                        curl -fsSk --retry 3 --retry-delay 4 --retry-all-errors \
+                        curl -fsSk --retry 2 --retry-delay 3 --retry-all-errors \
+                          --max-time 20 -H 'Accept-Encoding: identity' \
                           -o /tmp/index.json "$BASE/index.json"
                         grep -q '"title"' /tmp/index.json
 
@@ -188,8 +190,8 @@ spec:
                         POST=$(tr ',' '\n' < /tmp/index.json \
                           | sed -n 's|.*"url":"\([^"]*\)".*|\1|p' | head -1)
                         test -n "$POST"
-                        curl -fsSk --retry 3 --retry-delay 4 --retry-all-errors \
-                          -o /dev/null "$BASE$POST"
+                        curl -fsSk --retry 2 --retry-delay 3 --retry-all-errors \
+                          --max-time 20 -o /dev/null "$BASE$POST"
 
                         echo "smoke OK (theme, 4 kinds, search index, $POST)"
 ---


### PR DESCRIPTION
Stage verification failed for `0.0.88`, so no prod PR ever opened. **The site was fine — the gate was broken, and I broke it in #463.**

`activeDeadlineSeconds` stayed at `180`, the value sized for the single curl the check replaced. Going to eight requests put the worst-case retry delay alone at **132s** — 60s on the first request, 48s across the page-kind loop, 12s each for the search index and the article — before a byte moves, and on top of the KEDA scale-from-zero wait.

## Fix

- Deadline `180 → 300`
- Every request bounded with `--max-time`
- Follow-up retries `3×4s → 2×3s` — the deployment is awake after the first request, so long retries there spend budget for nothing

Worst-case retry delay is now **78s inside a 300s budget**.

Also: the two responses that get grepped now send `Accept-Encoding: identity`. The stage route runs through a Traefik compress middleware; curl sends no `Accept-Encoding` by default so this should be inert, but a `grep` against a gzipped body fails as though the string were missing rather than as an encoding problem. Cheap insurance against an expensive hour.

`blog-prod-smoke` is untouched — still one request, still a 180s deadline.

## Verified

Re-extracted the script from this manifest and ran it against the real v0.5.0 image:

- passes: `smoke OK (theme, 4 kinds, search index, /blog/lawless-waf/)`
- still fails where it must: **exit 1** at the theme grep with the marker renamed, **exit 22** at `/tags/` with that page and the search index removed

Once this lands, Kargo re-verifies `0.0.88` on stage and the prod PR should open on its own.

**Note: #464 (`promote 0.0.87 to prod`) should be closed, not merged.** It carries v0.4.1 rather than the v0.5.0 reviewed on stage, and it opened before ArgoCD had synced the hardened template — so it passed the old trivial gate.