### PR TITLE
chore(blog): remove the Blowfish submodule, and fix what it was hiding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "blog/themes/blowfish"]
-	path = blog/themes/blowfish
-	url = https://github.com/nunocoracao/blowfish.git
-	branch = main
 [submodule "blog/themes/northlight"]
 	path = blog/themes/northlight
 	url = https://github.com/mortennordbye/northlight.git

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,12 +4,6 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Apps
 
-### Finish the blog's Blowfish → Northlight migration (phases 5–6)
-- **What:** The theme swap and the stage-gate hardening are both done and verified on `feat/blog-northlight-theme`, pinned to Northlight v0.5.0. Remaining: the cutover (merge, soak on stage, hold the Kargo-opened prod PR, purge Cloudflare) and removing the Blowfish submodule once prod is trusted. Two content decisions stay open — the 13 raw `<img style="width:NN%">` tags that bypass the render hooks, and the palette — plus whether the home background image is worth keeping given it is invisible in dark mode.
-- **Why deferred:** The palette and the image widths are visual judgements that need the stage environment; they cannot be settled from a diff. Blowfish's submodule is kept until prod is trusted so rollback stays a single revert.
-- **Unblock:** Work through phases 5–6 of `docs/northlight-migration.md`, which carries the ordered steps, the verification for each, and the open decisions with the evidence gathered so far.
-- **Where:** `docs/northlight-migration.md`; `blog/config/_default/params.toml`; `.gitmodules` and `blog/themes/blowfish`.
-
 ### `blog-prod-smoke` is still a bare 2xx check
 - **What:** `blog-smoke` (stage) now asserts which theme rendered the page, that each page kind builds, that the search index has content, and that an article page resolves. `blog-prod-smoke` was left as the original single `curl` of `/`, so prod verification still passes on any 2xx — including a blank or half-rendered page.
 - **Why deferred:** Prod is served through Cloudflare; stage goes straight to Traefik. The response reaching the check may not be byte-identical to what nginx emitted, so a `grep` for markup could fail for edge reasons (minification, Rocket Loader) rather than deploy reasons. A gate that fails for the wrong reason is worse than the weak one it replaces, and inventing a prod verification outage during a theme cutover is the wrong time to find out.

--- a/docs/northlight-migration.md
+++ b/docs/northlight-migration.md
@@ -17,8 +17,8 @@ Blowfish — most of the work below is deleting things, not adding them.
 | 2 — params rewrite | **Done** |
 | 3 — delete the overrides | **Done** |
 | 4 — harden the stage gate | **Done** |
-| 5 — cutover | Ready — merge to `main`, then hold the prod PR |
-| 6 — clean up | Not started |
+| 5 — cutover | **Done** — live on blog.nordbye.it since 2026-07-30 |
+| 6 — clean up | **Done** — Blowfish submodule removed |
 
 Phases 1–3 are one commit on `feat/blog-northlight-theme`. Two things went differently
 from this plan, both in the direction of less work:
@@ -301,6 +301,25 @@ Only after prod has been on Northlight long enough to trust it.
 - Consider a `git-submodules` manager entry in `renovate.json`. It currently manages neither
   submodules nor the Hugo version, so both Blowfish and the Hugo pin have been bumped by hand.
   Adding it turns future Northlight releases into reviewable PRs.
+
+---
+
+## Phase 6 found a regression in another app
+
+Removing the submodule meant grepping for what still referenced Blowfish, and one hit was not in
+the blog at all: `portfolio/src/lib/blog.ts` parses the blog's RSS to build its cards, and read
+covers out of `<media:content url="...">` — a Blowfish-ism. **Northlight emits a standard RSS
+`<enclosure>` and declares no media namespace**, so from the moment prod cut over, `cover` was
+`undefined` for every post and the portfolio's blog cards silently lost their images. Nothing
+threw and nothing logged; the field just stopped being populated.
+
+Measured against the live feed: the old pattern matched **0 of 6** items, the new one matches
+**6 of 6**. The fix matches either shape, so the feed's cover convention is no longer something
+that file has to be right about.
+
+Worth remembering as the general lesson: the blog's output is an API that another app in this
+repo consumes, and a theme swap changes it. Grepping for the old theme's name is what surfaced
+it — a build-and-look pass on the blog never would have.
 
 ---
 

--- a/portfolio/src/lib/blog.ts
+++ b/portfolio/src/lib/blog.ts
@@ -46,10 +46,16 @@ function parseItem(itemXml: string): BlogPost | null {
   const pub = pick(itemXml, "pubDate");
   const desc = pick(itemXml, "description");
   if (!title || !link) return null;
-  // Hugo's RSS template emits <media:content url="..."> for feature / cover /
-  // thumbnail images (see blog/themes/blowfish/layouts/_default/rss.xml).
-  const mediaMatch = itemXml.match(/<media:content[^>]*\burl="([^"]+)"/);
-  const cover = mediaMatch ? decode(mediaMatch[1]).trim() : undefined;
+  // The cover image, however the feed chooses to carry it. Blowfish emitted
+  // <media:content url="...">; Northlight emits a standard RSS <enclosure>, and
+  // declares no media namespace at all. Matching only the first meant every card
+  // silently lost its cover the moment the blog changed theme — nothing threw,
+  // `cover` just became undefined. Both are matched so the feed's shape is not a
+  // thing this file has to be right about.
+  const coverMatch =
+    itemXml.match(/<media:content[^>]*\burl="([^"]+)"/) ??
+    itemXml.match(/<enclosure[^>]*\burl="([^"]+)"/);
+  const cover = coverMatch ? decode(coverMatch[1]).trim() : undefined;
   return {
     title: decode(title).trim(),
     url: link.trim(),


### PR DESCRIPTION
Prod has run on Northlight since this morning, so the rollback copy comes out. Reverting this commit restores the gitlink if that turns out to be premature.

## The part that isn't cleanup

Removing the submodule meant grepping for what still referenced Blowfish, and one hit was not in the blog at all.

`portfolio/src/lib/blog.ts` builds its cards from the blog's RSS and read covers out of `<media:content url="...">` — a Blowfish-ism. **Northlight emits a standard RSS `<enclosure>` and declares no media namespace.** So from the moment prod cut over, `cover` was `undefined` for every post and the portfolio's blog cards silently lost their images. Nothing threw, nothing logged; the field just stopped being populated.

Measured against the live feed at `https://blog.nordbye.it/index.xml`:

| pattern | items with a cover |
|---|---|
| old (`media:content` only) | **0 of 6** |
| new (either shape) | **6 of 6** |

It now matches both, so which convention the feed uses is no longer something that file has to be right about.

The general lesson worth keeping: the blog's output is an API another app in this repo consumes, and a theme swap changes it. Grepping for the old theme's name is what surfaced this — a build-and-look pass on the blog never would have.

## Deliberately left

Three Blowfish references stay, all comments explaining *why* something is shaped as it is: the palette note in `params.toml` (that decision is still open), and the rationale comments in `blog.yaml` and `blog.ts`.

A fourth is in the published post `blog/content/blog/i-have-a-blog/index.md`, which tells readers the blog runs Blowfish and shows the `git submodule add` for it. That is now wrong on a live page, but it is your writing and your call — not something to rewrite in a cleanup PR.

## Verified

`--panicOnWarning` build clean, 74 pages, with only `northlight` in `blog/themes`. The portfolio TypeScript change is covered by `ci-portfolio.yaml` on this PR — I could not typecheck it locally (no node_modules, and bind mounts don't work against this remote Docker daemon).