### PR TITLE
blog: drop the black hero band, match the portfolio blue, and bump the theme to 0.6.0

### DIFF
--- a/blog/assets/css/custom.css
+++ b/blog/assets/css/custom.css
@@ -1,0 +1,31 @@
+/* Northlight picks this file up automatically and appends it to its own stylesheet,
+   so it is minified and fingerprinted with everything else and costs no extra request.
+   Being last in the cascade, a rule at the same specificity wins.
+
+   One job: retune the `slate` palette to the arctic blue the portfolio at nordbye.it
+   uses, so the two sites read as one brand. The source of truth for these values is
+   portfolio/src/styles/tokens.css in this repository — `--accent` there.
+
+   The light tone is #1e6ad1 rather than the portfolio's exact #1f6fda. Same hue, same
+   saturation, two percent darker. Northlight measures every shipped accent against its
+   own --accent-tint, which is where a featured card's eyebrow lands, and requires 4.5:1
+   there; #1f6fda measures 4.33 and #1e6ad1 measures 4.66, against slate's own 4.97. The
+   theme dropped a candidate palette for missing that floor by less, so matching the
+   portfolio exactly here would mean shipping something it rejected. The difference is
+   not visible side by side. Dark mode takes the portfolio value unchanged — #5db7ff
+   measures 7.76 on its tint.
+
+   The three tokens below are the whole palette contract: --accent is the readable tone
+   (links, active TOC item, progress bar), --accent-pastel is the soft one (fills, hover
+   borders) and swaps roles between modes, --accent-tint is the low-alpha wash. The
+   syntax-highlighting tokens are deliberately left on the theme's own values; they are
+   tuned per palette in both modes and are not part of this. */
+
+html[data-palette="slate"] {
+  --accent: #1e6ad1;
+  --accent: light-dark(#1e6ad1, #5db7ff);
+  --accent-pastel: #5db7ff;
+  --accent-pastel: light-dark(#5db7ff, #3789e3);
+  --accent-tint: rgba(30, 106, 209, 0.08);
+  --accent-tint: light-dark(rgba(30, 106, 209, 0.08), rgba(93, 183, 255, 0.11));
+}

--- a/blog/config/_default/params.toml
+++ b/blog/config/_default/params.toml
@@ -9,6 +9,12 @@ colorScheme = "slate"
 defaultAppearance = "dark"
 autoSwitchAppearance = true
 
+# Lets the accent reach section headings, the year rules on the post index, tag
+# chips, a card's hover border and the blockquote edge. New in theme 0.6.0 and off
+# by default there; on here because the arctic blue is the point of the retune
+# above and it was only showing up on links.
+accentEmphasis = true
+
 enableSearch = true
 enableCodeCopy = true
 

--- a/blog/config/_default/params.toml
+++ b/blog/config/_default/params.toml
@@ -1,8 +1,11 @@
 description = "Kubernetes, cloud infrastructure and homelab engineering from a Talos cluster I actually run. Practical guides on observability, networking and GitOps."
 
 # periwinkle | sage | clay | plum | slate | rose
-# periwinkle was picked as the theme default; the others are worth comparing.
-colorScheme = "periwinkle"
+# slate is the theme's blue, retuned to the portfolio's arctic blue in
+# assets/css/custom.css so the two sites read as one brand. Dropping that file
+# leaves the site blue, just muted — which is why slate is the base rather than
+# the periwinkle default.
+colorScheme = "slate"
 defaultAppearance = "dark"
 autoSwitchAppearance = true
 
@@ -31,8 +34,12 @@ links = [
 layout = "basic"
 
 [home]
-layout = "background"
-backgroundImage = "images/background.png"
+# The `background` layout pins its scrim and text to light-on-dark in both colour
+# modes, because the image behind them does not invert when the palette does. With
+# a near-black backdrop that reads as a solid black band on a light page, so this
+# site takes the ordinary intro instead. `backgroundImage` is gone with it — only
+# the background layout reads it.
+layout = "stack"
 recentCount = 5
 
 [article]
@@ -62,6 +69,10 @@ showTermCount = true
 cardView = false
 
 [footer]
+# The theme cannot default this to its own repository — that URL carries its
+# author's name, and no file inside the theme is allowed to. Unset, the theme name
+# in the attribution line renders as plain text.
+themeURL = "https://github.com/mortennordbye/northlight"
 showMenu = true
 showCopyright = true
 showThemeAttribution = true


### PR DESCRIPTION
## Why

Three things on the blog.

The `background` home layout pins its scrim (`rgb(12 12 16 / 68%)`) and its heading, tagline and byline to light-on-dark in **both** colour modes. That is deliberate in the theme: the photograph behind the text does not invert when the palette does, so a band that followed the theme would be legible in one mode and unreadable in the other over the same image. Our backdrop is a near-black grid pattern, so 68% black over near-black leaves a solid black band across a light page.

The accent was the theme's periwinkle default, a blue-violet. The portfolio at nordbye.it uses an arctic blue, and the two sites should read as one brand.

And with only the accent retuned, the new colour was showing up on links and almost nowhere else.

## What

- `home.layout` moves from `background` to `stack`, the ordinary intro. `home.backgroundImage` goes with it, since only the background layout reads it.
- `colorScheme` moves from `periwinkle` to `slate`, the theme's blue.
- New `blog/assets/css/custom.css` retunes slate to the portfolio's arctic blue. The theme picks that file up automatically and appends it to its own stylesheet, so it is minified and fingerprinted with everything else and costs no extra request. Source of truth for the values is `portfolio/src/styles/tokens.css`.
- `footer.themeURL` links the theme name in the attribution line. The theme cannot default this to its own repository, because that URL carries its author's name and no file inside the theme is allowed to.
- The theme submodule moves to **v0.6.0**, and `accentEmphasis = true` turns on the switch it adds: the accent now also carries section headings, the year rules on the post index, tag chips, a card's hover border and the blockquote edge. Off by default in the theme, so this is an opt-in on our side.

The light tone is `#1e6ad1` rather than the portfolio's exact `#1f6fda`. Same hue, same saturation, two percent darker. Northlight measures every shipped accent against its own `--accent-tint`, which is where a featured card's eyebrow lands, and holds a 4.5:1 floor there. `#1f6fda` measures 4.33 and `#1e6ad1` measures 4.66, against slate's own 4.97. The theme dropped a candidate palette for missing that floor by less. The difference is not visible side by side. Dark mode takes the portfolio value unchanged: `#5db7ff` measures 7.76 on its tint.

Base palette is `slate` rather than `periwinkle` so that deleting `custom.css` leaves the site blue, just muted, instead of snapping back to violet.

## Verification

`docker build -t blog:dev blog/` and `docker run -p 8081:80 blog:dev`, then in the browser:

- Home page in light mode: no black band, arctic blue accent on the eyebrow, logo dot and "All 6 posts" link.
- Home page in dark mode: same, accent reads as the portfolio's `#5db7ff`.
- `/blog/` in light and dark after the 0.6.0 bump: tag chips carry the accent on its tint in both.
- `/blog/kubernetes-quick-start/` in light as an unrelated route: no regression.
- Confirmed in the built CSS that `custom.css` reaches the bundle and wins: `html[data-palette=slate]{--accent:#1e6ad1;...}` appears after the theme's own slate block, and `data-accent-emphasis` reaches `<html>`.

Not checked: the remaining routes, and mobile widths.

## Noticed, not changed

`defaultBackgroundImage` at the top of `params.toml` is a Blowfish leftover. Northlight has never read it and removed the key outright in 0.5.0. Left in place rather than folded into this change.