### PR TITLE
fix(verksted): stop the liveness probe from killing live agent sessions

### DIFF
--- a/k8s/talos/apps/verksted/deployment.yaml
+++ b/k8s/talos/apps/verksted/deployment.yaml
@@ -39,26 +39,47 @@ spec:
           # The backend serves the built SPA at / — a plain 200 once it is up.
           # Agent auth (claude/codex/agy tokens) is configured interactively in
           # the pod terminal afterwards and persists under HOME=/data/home.
+          # Stays on / — serving the SPA is what "ready" means here. The timeout
+          # matters as much as the liveness one though: a failed readiness probe
+          # pulls the pod out of the Service, which drops every open terminal
+          # websocket. The default 1s was well inside normal NFS jitter.
           readinessProbe:
             httpGet:
               path: /
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # Deliberately hard to trip: a restart kills the tmux server and with
+          # it every running agent session, so this must fire only for a backend
+          # that is genuinely wedged — never for one that is merely slow. Hence
+          # /api/health (a constant, no disk behind it, unlike / which reads
+          # index.html through the same libuv threadpool as the NFS volume), a
+          # timeout above the default 1s, and 3 minutes of failures before the
+          # kill. CPU throttling and NFS stalls both used to fit inside the old
+          # ~40s window.
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/health
               port: http
             initialDelaySeconds: 30
-            periodSeconds: 20
-            failureThreshold: 3
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          # Sized to what a working pod actually holds: agent CLIs, headless
+          # chromium per session, and whatever dev servers the agents start add
+          # up to several GiB. The old 512Mi request left the pod many times
+          # over its request and first in line for eviction; the old 2-core
+          # limit had it CFS-throttled ~7% of all scheduling periods, which is
+          # what stalled the health check.
           resources:
             requests:
-              cpu: 250m
-              memory: 512Mi
-            limits:
-              cpu: "2"
+              cpu: "1"
               memory: 4Gi
+            limits:
+              cpu: "6"
+              memory: 8Gi
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
Verksted sessions were dying during work, roughly once a day. The cause is here, not in the app: this pod was being restarted, and the tmux server — and therefore every running agent session — dies with the container.

Evidence from inside the pod: PID 1 up 9 minutes, and `/data/sessions/*.json` shows sessions ending in the *same second* as each other, which only happens when the tmux server goes away, at 07‑26 14:03, 07‑27 21:08, 07‑28 06:09, 07‑30 07:57 and 07‑30 14:14.

## What was wrong

`livenessProbe` on `/` with **no `timeoutSeconds` — so the default 1 second**, 3 strikes over ~40 s. `/` is served by `@fastify/static`, which reads `index.html` through the libuv threadpool that every NFS call on `/data` also uses. Two things push it past a second regularly:

| | |
|---|---|
| CPU throttling | `nr_throttled 475 / 6550` periods, 92 s throttled in 11 min against the 2-core limit |
| Memory | anon **3.85 GiB of the 4 GiB limit**, `memory.events max = 1665` in 9 min |

`readinessProbe` had the same 1 s default. That one does not restart anything, but it pulls the pod out of the Service, which drops every open terminal websocket.

## Changes

- Liveness → `/api/health` (a constant, no disk), `timeoutSeconds: 5`, `periodSeconds: 30`, `failureThreshold: 6`. Three minutes of genuinely dead before a kill, instead of forty seconds of merely slow.
- Readiness stays on `/` — serving the SPA is what ready means here — but gets `timeoutSeconds: 5` and `failureThreshold: 3`.
- `requests: cpu 1, memory 4Gi` (was `250m` / `512Mi`, ~7× under actual). `limits: cpu 6, memory 8Gi`.

## Before applying

Push the verksted image from mortennordbye/verksted#23 and bump the tag with this, so the restart this causes is the last one that loses sessions. `strategy: Recreate` means the currently-running sessions die when this rolls; restore cannot save them, since it needs a conversation id that only sessions started on the new image record.

If the pod goes `Pending` on the 4Gi request, the node is tighter than it looked (16 GB total, ~6.7 GB free) — drop the request to 2Gi. The limit is the part that matters for survival.
