### PR TITLE
feat(reelsmith): deploy the DM gateway

### DIFF
--- a/k8s/talos/apps/reelsmith/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/reelsmith/ciliumnetworkpolicy.yaml
@@ -1,0 +1,43 @@
+# Ingress from Traefik only, egress to Meta only.
+#
+# The egress half is the interesting one. This service holds Instagram tokens
+# with publishing and messaging rights, and it is reachable from the internet
+# because Meta has to POST to it. Pinning egress to graph.instagram.com means a
+# compromise of the process cannot turn those tokens into calls to anywhere
+# else.
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: reelsmith-gateway-policy
+  namespace: reelsmith
+spec:
+  endpointSelector:
+    matchLabels:
+      app: reelsmith-gateway
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": traefik
+            "k8s:app.kubernetes.io/instance": traefik-traefik
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # kubelet probes and the health checker.
+    - fromEntities:
+        - host
+        - health
+  egress:
+    # DNS to CoreDNS. Required for toFQDNs below to resolve.
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports: [{ port: "53", protocol: ANY }]
+    # The Meta Graph API, which is every outbound call this service makes:
+    # private replies, DMs, follower checks, comment polls, token refreshes.
+    - toFQDNs:
+        - matchName: "graph.instagram.com"
+      toPorts:
+        - ports: [{ port: "443", protocol: TCP }]

--- a/k8s/talos/apps/reelsmith/deployment.yaml
+++ b/k8s/talos/apps/reelsmith/deployment.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reelsmith-gateway
+  namespace: reelsmith
+  annotations:
+    # The Meta app secret starts as a placeholder and is replaced once the app
+    # exists in the dashboard. Reloader restarts the pod when the secret changes,
+    # so that swap needs no manual rollout.
+    reloader.stakater.com/auto: "true"
+spec:
+  # One replica, deliberately. The state is a single SQLite file on a
+  # ReadWriteOnce volume, and the comment poller is a singleton: two replicas
+  # would poll the same posts and race for the one private reply each comment
+  # gets. Scaling this means moving to Postgres and electing a poller first.
+  replicas: 1
+  strategy:
+    # RollingUpdate would briefly run two pods, which is the exact thing the
+    # single-writer database and the singleton poller cannot tolerate.
+    type: Recreate
+  selector:
+    matchLabels:
+      app: reelsmith-gateway
+  template:
+    metadata:
+      labels:
+        app: reelsmith-gateway
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          # Pinned tag, rewritten by Kargo's kustomize-set-image promotion via
+          # the images: block in kustomization.yaml. Never :latest.
+          image: ghcr.io/mortennordbye/reelsmith-gateway:0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            # Without all three of these the process refuses to start, rather
+            # than serving an unsigned webhook route and a bearer route with an
+            # empty token.
+            - name: GATEWAY_APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: reelsmith-secret
+                  key: GATEWAY_APP_SECRET
+            - name: GATEWAY_VERIFY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: reelsmith-secret
+                  key: GATEWAY_VERIFY_TOKEN
+            - name: GATEWAY_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: reelsmith-secret
+                  key: GATEWAY_API_TOKEN
+            - name: GATEWAY_DB_PATH
+              value: /state/gateway.sqlite3
+            - name: GATEWAY_COVERS_DIR
+              value: /state/covers
+            # Meta fetches cover images from this host, so it has to be the
+            # external name rather than the service address.
+            - name: GATEWAY_PUBLIC_BASE_URL
+              value: "https://gate.nordbye.it"
+          volumeMounts:
+            - name: state
+              mountPath: /state
+            # readOnlyRootFilesystem is on, and Python still wants somewhere to
+            # write. Everything real lives on the state volume.
+            - name: tmp
+              mountPath: /tmp
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "25m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: reelsmith-state
+        - name: tmp
+          emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reelsmith-gateway
+  namespace: reelsmith
+spec:
+  selector:
+    app: reelsmith-gateway
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+  type: ClusterIP

--- a/k8s/talos/apps/reelsmith/externalsecret.yaml
+++ b/k8s/talos/apps/reelsmith/externalsecret.yaml
@@ -1,0 +1,45 @@
+# The three values the gateway refuses to start without.
+#
+# GATEWAY_APP_SECRET is a placeholder until the Meta app exists. With a wrong
+# secret the service still runs and still serves /healthz and /covers; only
+# webhook deliveries fail signature verification, which is the correct
+# behaviour for a secret that does not match. Replacing the Bitwarden value is
+# enough: ESO refreshes hourly and Reloader restarts the pod.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: reelsmith-secret
+  namespace: reelsmith
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: reelsmith-secret
+    creationPolicy: Owner
+  data:
+    # Meta app secret. Signs every webhook delivery.
+    - secretKey: GATEWAY_APP_SECRET
+      remoteRef:
+        key: "REPLACE-WITH-BITWARDEN-UUID-app-secret"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    # Echoed back during the Meta subscription handshake. Must match the value
+    # entered in the dashboard exactly.
+    - secretKey: GATEWAY_VERIFY_TOKEN
+      remoteRef:
+        key: "REPLACE-WITH-BITWARDEN-UUID-verify-token"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    # Bearer token the Mac pipeline presents on /api/*.
+    - secretKey: GATEWAY_API_TOKEN
+      remoteRef:
+        key: "REPLACE-WITH-BITWARDEN-UUID-api-token"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/k8s/talos/apps/reelsmith/externalsecret.yaml
+++ b/k8s/talos/apps/reelsmith/externalsecret.yaml
@@ -24,7 +24,7 @@ spec:
     # Meta app secret. Signs every webhook delivery.
     - secretKey: GATEWAY_APP_SECRET
       remoteRef:
-        key: "REPLACE-WITH-BITWARDEN-UUID-app-secret"
+        key: "e1fc86fe-0289-46cf-b3cb-b498013da019"
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
@@ -32,14 +32,14 @@ spec:
     # entered in the dashboard exactly.
     - secretKey: GATEWAY_VERIFY_TOKEN
       remoteRef:
-        key: "REPLACE-WITH-BITWARDEN-UUID-verify-token"
+        key: "f28ab9d9-cb08-4afa-8df1-b498013dc6af"
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
     # Bearer token the Mac pipeline presents on /api/*.
     - secretKey: GATEWAY_API_TOKEN
       remoteRef:
-        key: "REPLACE-WITH-BITWARDEN-UUID-api-token"
+        key: "aae017ad-34e3-4e50-9edd-b498013de2f2"
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None

--- a/k8s/talos/apps/reelsmith/httproute.yaml
+++ b/k8s/talos/apps/reelsmith/httproute.yaml
@@ -1,0 +1,33 @@
+# Public gateway, not private: Meta's servers have to reach /webhook and fetch
+# cover images from /covers, and they need a publicly valid certificate to do
+# it. cert-manager and external-dns both pick the hostname up from here.
+#
+# Only Meta and the Mac agent ever call this host, so the name is not a
+# doxxing surface. The admin UI (PLAN.md section F) will sit behind Authentik
+# forward-auth on this same route when it lands.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: reelsmith
+  namespace: reelsmith
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-public
+      namespace: traefik
+  hostnames:
+    - "gate.nordbye.it"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: reelsmith-gateway
+          port: 8000
+          weight: 1

--- a/k8s/talos/apps/reelsmith/kustomization.yaml
+++ b/k8s/talos/apps/reelsmith/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "0"
+resources:
+- namespace.yaml
+- externalsecret.yaml
+- state-pvc.yaml
+- deployment.yaml
+- httproute.yaml
+- ciliumnetworkpolicy.yaml
+# newTag via the kustomize-set-image promotion step (Kargo). Overrides the inline
+# tag in deployment.yaml; the reelsmith-cd Warehouse/promotion rewrites it to
+# 0.0.N as the reelsmith repo's build-gateway workflow publishes them.
+images:
+- name: ghcr.io/mortennordbye/reelsmith-gateway
+  newTag: 0.0.1

--- a/k8s/talos/apps/reelsmith/namespace.yaml
+++ b/k8s/talos/apps/reelsmith/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reelsmith
+  # The gateway image runs as uid 10001 with no capabilities, so unlike the
+  # older apps here it does not need the privileged profile.
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"

--- a/k8s/talos/apps/reelsmith/state-pvc.yaml
+++ b/k8s/talos/apps/reelsmith/state-pvc.yaml
@@ -1,0 +1,21 @@
+# Holds the gateway's SQLite file and the cover images it serves to Meta.
+#
+# Small and it stays small: the database is conversations and post rows, and a
+# cover is a ~1 MB PNG that Meta fetches once at container creation.
+#
+# The database runs in WAL mode so the comment poller writing does not block the
+# webhook handler reading. WAL on NFS is the one combination worth remembering
+# if locking ever misbehaves; the fix would be a journal-mode change in
+# gateway/db.py, not a storage migration.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: reelsmith-state
+  namespace: reelsmith
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: syno-nfs-csi
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -58,7 +58,7 @@ spec:
   # non-Kargo app matches nothing and renders no patch.
   templatePatch: |
     {{- $base := .path.basename }}
-    {{- range $app := list "portfolio" "blog" "logeverylift" "headroom" "verksted" }}
+    {{- range $app := list "portfolio" "blog" "logeverylift" "headroom" "verksted" "reelsmith" }}
     {{- if eq $base $app }}
     metadata:
       annotations:

--- a/k8s/talos/infra/kargo-projects/kustomization.yaml
+++ b/k8s/talos/infra/kargo-projects/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - logeverylift.yaml
   - headroom.yaml
   - verksted.yaml
+  - reelsmith.yaml

--- a/k8s/talos/infra/kargo-projects/reelsmith.yaml
+++ b/k8s/talos/infra/kargo-projects/reelsmith.yaml
@@ -1,0 +1,185 @@
+# Kargo project for the reelsmith DM gateway. Single-environment, same shape as
+# logeverylift: one Warehouse feeds one `prod` Stage directly, auto-promoted
+# through promote-via-pr. Flow: reelsmith CI pushes a new gateway image ->
+# Warehouse creates Freight -> Kargo auto-opens a homelab PR -> merging it
+# deploys -> the smoke test verifies.
+#
+# The image source and CI live in the separate mortennordbye/reelsmith repo,
+# which also holds the render pipeline. Only the gateway ships as a container,
+# and its build workflow there is path-filtered to gateway/ so a pipeline-only
+# commit never produces Freight for a byte-identical image.
+
+# --- Project namespace ------------------------------------------------------
+# Named `reelsmith-cd` (not `reelsmith`) to avoid colliding with the app
+# namespace. The label lets the Project adopt this pre-created namespace instead
+# of racing to create it, keeping Argo CD sync ordering clean.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reelsmith-cd
+  labels:
+    kargo.akuity.io/project: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: reelsmith-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: reelsmith-cd
+  namespace: reelsmith-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  promotionPolicies:
+    - stage: prod
+      autoPromotionEnabled: true
+---
+# Git write credential for Kargo's git-push/PR, using the existing GitHub App
+# `mortennordbye-homelab-deployer`. Same App and Bitwarden keys as the other
+# -cd projects; only the namespace differs, because Kargo cred lookup is
+# per-Project.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kargo-git-homelab
+  namespace: reelsmith-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: kargo-git-homelab
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git
+      data:
+        repoURL: https://github.com/mortennordbye/homelab.git
+        githubAppClientID: "{{ .githubAppClientID }}"
+        githubAppInstallationID: "{{ .githubAppInstallationID }}"
+        githubAppPrivateKey: "{{ .githubAppPrivateKey }}"
+  data:
+    - secretKey: githubAppClientID
+      remoteRef:
+        key: "a6b2b4ea-fa97-4d5c-bd74-b489010c5fab"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppInstallationID
+      remoteRef:
+        key: "aabab894-a09a-415c-ba17-b489010c8df5"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: githubAppPrivateKey
+      remoteRef:
+        key: "fc775dd0-1b67-4dfa-b2e9-b489010d0359"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: reelsmith
+  namespace: reelsmith-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  # interval as Kargo normalizes it (1m -> 1m0s), to avoid ArgoCD drift.
+  interval: 1m0s
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/mortennordbye/reelsmith-gateway
+        # reelsmith CI tags every gateway build 0.0.<run_number>; SemVer picks
+        # the greatest. strictSemvers keeps the sha-/latest tags out of
+        # selection.
+        imageSelectionStrategy: SemVer
+        strictSemvers: true
+        discoveryLimit: 20
+---
+# prod verification: a one-shot Job that curls the gateway and fails on any
+# non-2xx. Unlike logeverylift this host is on the public gateway with a real
+# certificate, so no -k. /healthz is the right target: it needs no secrets and
+# no Instagram account, so it is green from the first deploy, before any of the
+# Meta setup exists.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: reelsmith-prod-smoke
+  namespace: reelsmith-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: reelsmith-prod-http-200
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - >
+                        curl -fsS --retry 10 --retry-delay 6 --retry-all-errors
+                        -o /dev/null -w '%{http_code}\n'
+                        https://gate.nordbye.it/healthz
+---
+# prod: the only Stage. Receives Freight straight from the Warehouse
+# (sources.direct), auto-promoted per ProjectConfig through promote-via-pr,
+# then verified by the smoke test. Merging the PR in GitHub is the deploy gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: reelsmith-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    # Cosmetic UI colour, kept identical across apps: prod = red.
+    kargo.akuity.io/color: "#e11d48"
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse via a homelab PR; smoke-tested on gate.nordbye.it after merge."
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: reelsmith
+      sources:
+        direct: true
+  verification:
+    analysisTemplates:
+      - name: reelsmith-prod-smoke
+  promotionTemplate:
+    spec:
+      vars:
+        - name: appName
+          value: reelsmith
+        - name: appPath
+          value: k8s/talos/apps/reelsmith
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/reelsmith-gateway
+        - name: argocdApp
+          value: reelsmith
+      steps:
+        - task:
+            name: promote-via-pr
+            kind: ClusterPromotionTask


### PR DESCRIPTION
## Why

`reelsmith` renders and publishes Instagram Reels from a laptop. The growth mechanic it needs, "comment SEND and I will DM you the link", has to answer Meta webhooks around the clock, so that half runs here. It also serves the cover images Meta fetches at publish time, which is the last thing the pipeline wanted a public URL for.

## What

- `k8s/talos/apps/reelsmith/`: namespace, ExternalSecret, state PVC, Deployment, Service, HTTPRoute on `gate.nordbye.it`, CiliumNetworkPolicy.
- `kargo-projects/reelsmith.yaml`: Warehouse on `ghcr.io/mortennordbye/reelsmith-gateway` plus one auto-promoted `prod` Stage via `promote-via-pr`, following the logeverylift shape. Registered in the kustomization and in the `apps.yaml` authorized-stage list.

## Decisions worth reviewing

- **Public gateway, not private.** Meta's servers have to reach `/webhook` and fetch covers, with a publicly valid certificate.
- **Egress pinned to `graph.instagram.com`.** The service holds Instagram tokens with publishing and messaging rights and is internet-reachable by design, so a compromise should not be able to reach anywhere else. Follows the DNS-to-CoreDNS plus `toFQDNs` pattern already used in `infra/`.
- **One replica, `strategy: Recreate`.** State is a single SQLite file on a RWO volume and the comment poller is a singleton: two pods would race for the one private reply Meta allows per comment. Scaling means Postgres and a leader election first.
- **`restricted` pod security**, unlike the older apps here. The image already runs as uid 10001 with no capabilities and a read-only root filesystem.
- **NFS for the state volume**, per the storage convention here.

## Blocked on

`externalsecret.yaml` carries **placeholder Bitwarden UUIDs**. Three items are needed:

| Secret key | Item | Value |
|---|---|---|
| `GATEWAY_APP_SECRET` | `reelsmith-gateway-app-secret` | placeholder until the Meta app exists |
| `GATEWAY_VERIFY_TOKEN` | `reelsmith-gateway-verify-token` | generated, also goes in the Meta dashboard |
| `GATEWAY_API_TOKEN` | `reelsmith-gateway-api-token` | generated, the pipeline presents it on `/api/*` |

Merging before those UUIDs are real leaves the pod unable to start: the gateway refuses to boot without all three, rather than serving an unsigned webhook route.

A wrong `GATEWAY_APP_SECRET` is safe by comparison. The service still runs and still serves `/healthz` and `/covers`; only webhook deliveries fail signature verification, which is correct for a secret that does not match. Swapping the Bitwarden value later is enough, since ESO refreshes hourly and Reloader restarts the pod.

## Verification

- `kubectl kustomize` renders both the app dir and the full kargo-projects dir.
- `ghcr.io/mortennordbye/reelsmith-gateway:0.0.1` is published and public, and is the tag seeded here.
- The image was run locally and in its container: `/healthz`, the webhook handshake, a 403 on an unsigned POST, bearer auth, and a cover round-tripping byte-identical. Audited for secrets in every layer, runs as non-root.
- No server-side dry run: the local kubeconfig for `admin@hyper-cluster` no longer verifies its CA, so I could not reach the cluster from here.