### PR TITLE
feat(reelsmith): publish three Reels a day from the gateway

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,6 +22,12 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Either upstream ships automatic refresh (watch #7835), or add `TOKEN_TIME` to the Deployment env with a longer window and accept the longer-lived tokens.
 - **Where:** `k8s/talos/apps/mealie/deployment.yaml` (env block).
 
+### Authentik forward-auth in front of the reelsmith admin panel
+- **What:** `/admin` on `gate.nordbye.it` is a control panel that publishes Reels to a live Instagram account, edits captions, and holds the outbound-DM kill switch. It authenticates itself with `GATEWAY_ADMIN_TOKEN` (a Bitwarden value, minimum 24 characters, Strict SameSite cookie plus an Origin check) and refuses to start with no authentication at all. There is no second layer in front of it.
+- **Why deferred:** The host must stay reachable without a login for `/webhook`, `/media/*` and `/api/*`, because Meta fetches media from its own servers and the Mac posts to the API with a bearer token. So the auth filter has to hang off a `/admin` path rule rather than the whole route, and getting that prefix match wrong fails open. The app-level gate does not have that failure mode, which is why it went first.
+- **Unblock:** Add an Authentik proxy provider and outpost, then a second HTTPRoute rule matching PathPrefix `/admin` with an `ExtensionRef` filter to a forward-auth Middleware (the shape `k8s/talos/apps/homepage/httproute.yaml` uses for basicauth). Set `GATEWAY_ADMIN_TRUST_PROXY_AUTH=true` in the ConfigMap at the same time, or accept two sign-ins. Verify afterwards by curling `/webhook`, `/media/<name>.mp4` and `/api/queue`: all three must still answer without a session.
+- **Where:** `k8s/talos/apps/reelsmith/{httproute,configmap}.yaml`, `k8s/talos/infra/authentik/`.
+
 ## AI / RAG POC
 
 ### Eval harness

--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -1,0 +1,47 @@
+# The posting schedule, kept out of the deployment so changing when the account
+# posts is a one-line edit that Reloader turns into a restart.
+#
+# The gateway holds a queue of rendered Reels pushed from the Mac and publishes
+# them on these slots, so the laptop is only needed while rendering.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reelsmith-config
+  namespace: reelsmith
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+data:
+  # Publishing to the feed is off unless this is on. The gateway answered
+  # comments for weeks without it, and gaining the ability to post by being
+  # upgraded would have been a surprise rather than a decision.
+  GATEWAY_SCHEDULER_ENABLED: "true"
+
+  # Three posts a day. One slot per line; only the time is required.
+  #
+  # Each firing moves by up to 15 minutes either way, to the second, and never
+  # onto :00, :15, :30 or :45. The offset is derived from the slot and the date
+  # rather than rolled at runtime, so it survives a restart: a random offset
+  # would be re-rolled on every pod start, and a slot judged not-yet-due at
+  # 19:15 could come due at 19:10 after a restart and publish twice.
+  #
+  # A line that does not parse fails the pod's startup on purpose, rather than
+  # quietly dropping that slot from the schedule.
+  #
+  # These attach to the one registered account. Add GATEWAY_SLOTS_ACCOUNT with
+  # an IG user id if a second account is ever registered; until then the
+  # gateway resolves it, and logs rather than guessing if it becomes ambiguous.
+  GATEWAY_SLOTS: |
+    08:10 Europe/Oslo jitter=15
+    12:40 Europe/Oslo jitter=15
+    19:20 Europe/Oslo jitter=15
+
+  # Named zone, not an offset, so the slots stay at the same local hour across
+  # a daylight saving change.
+  GATEWAY_DEFAULT_TIMEZONE: "Europe/Oslo"
+  GATEWAY_DEFAULT_JITTER_MINUTES: "15"
+
+  # The control panel at /admin. It authenticates itself with
+  # GATEWAY_ADMIN_TOKEN and refuses to start with no authentication at all,
+  # which matters here because this host is public: Meta fetches media from it,
+  # so there is no network boundary in front of the panel.
+  GATEWAY_ADMIN_ENABLED: "true"

--- a/k8s/talos/apps/reelsmith/deployment.yaml
+++ b/k8s/talos/apps/reelsmith/deployment.yaml
@@ -13,11 +13,15 @@ spec:
   # One replica, deliberately. The state is a single SQLite file on a
   # ReadWriteOnce volume, and the comment poller is a singleton: two replicas
   # would poll the same posts and race for the one private reply each comment
-  # gets. Scaling this means moving to Postgres and electing a poller first.
+  # gets. The scheduler makes this sharper still, because two of those would
+  # race to publish the same queued Reel, and the claim that prevents it only
+  # works because both would be writing to the one SQLite file. Scaling this
+  # means moving to Postgres and electing a leader first.
   replicas: 1
   strategy:
     # RollingUpdate would briefly run two pods, which is the exact thing the
-    # single-writer database and the singleton poller cannot tolerate.
+    # single-writer database, the singleton poller and the scheduler cannot
+    # tolerate.
     type: Recreate
   selector:
     matchLabels:
@@ -67,6 +71,13 @@ spec:
                 secretKeyRef:
                   name: reelsmith-secret
                   key: GATEWAY_API_TOKEN
+            # The /admin password. Without it the panel refuses to start rather
+            # than serving itself on a host Meta needs to be able to reach.
+            - name: GATEWAY_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: reelsmith-secret
+                  key: GATEWAY_ADMIN_TOKEN
             - name: GATEWAY_DB_PATH
               value: /state/gateway.sqlite3
             - name: GATEWAY_COVERS_DIR
@@ -75,6 +86,11 @@ spec:
             # external name rather than the service address.
             - name: GATEWAY_PUBLIC_BASE_URL
               value: "https://gate.nordbye.it"
+          # The posting schedule. Separate from the env block above so changing
+          # when the account posts does not mean editing the deployment.
+          envFrom:
+            - configMapRef:
+                name: reelsmith-config
           volumeMounts:
             - name: state
               mountPath: /state

--- a/k8s/talos/apps/reelsmith/externalsecret.yaml
+++ b/k8s/talos/apps/reelsmith/externalsecret.yaml
@@ -1,4 +1,4 @@
-# The three values the gateway refuses to start without.
+# The values the gateway refuses to start without, plus the admin password.
 #
 # GATEWAY_APP_SECRET is a placeholder until the Meta app exists. With a wrong
 # secret the service still runs and still serves /healthz and /covers; only
@@ -40,6 +40,16 @@ spec:
     - secretKey: GATEWAY_API_TOKEN
       remoteRef:
         key: "aae017ad-34e3-4e50-9edd-b498013de2f2"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    # Password for the /admin control panel. Separate from GATEWAY_API_TOKEN
+    # because they protect different things: that one is held by a script on
+    # the Mac, this one is typed by a person, and either can be rotated without
+    # the other. The gateway refuses a value under 24 characters.
+    - secretKey: GATEWAY_ADMIN_TOKEN
+      remoteRef:
+        key: "eacd310a-8186-48c6-bf77-b499007a0f8b"
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None

--- a/k8s/talos/apps/reelsmith/httproute.yaml
+++ b/k8s/talos/apps/reelsmith/httproute.yaml
@@ -2,9 +2,15 @@
 # cover images from /covers, and they need a publicly valid certificate to do
 # it. cert-manager and external-dns both pick the hostname up from here.
 #
-# Only Meta and the Mac agent ever call this host, so the name is not a
-# doxxing surface. The admin UI (PLAN.md section F) will sit behind Authentik
-# forward-auth on this same route when it lands.
+# Meta, the Mac, and now a browser reaching /admin all use this one host, so
+# the name is not a doxxing surface.
+#
+# No auth filter here on purpose. The admin UI authenticates itself with
+# GATEWAY_ADMIN_TOKEN and will not start without a password, which is the right
+# place for it: /webhook, /media/* and /api/* all have to stay reachable
+# without a login, so gating this route by path would put the account's safety
+# in a prefix match. Putting Authentik forward-auth on a /admin rule as a
+# second layer is still worth doing, and is tracked in BACKLOG.md.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/k8s/talos/apps/reelsmith/kustomization.yaml
+++ b/k8s/talos/apps/reelsmith/kustomization.yaml
@@ -5,6 +5,7 @@ commonAnnotations:
 resources:
 - namespace.yaml
 - externalsecret.yaml
+- configmap.yaml
 - state-pvc.yaml
 - deployment.yaml
 - httproute.yaml


### PR DESCRIPTION
## Why

Posting needed the Mac awake and present, so it happened whenever the laptop was
open. The gateway already held the account token, already hosted the MP4 that
Meta fetches, and already ran a background tick, so it was most of the way to
doing this itself.

It now holds a queue of rendered Reels pushed from the Mac and publishes them on
a schedule. The laptop is only needed while rendering, which is the one part
that cannot leave it: the voice model and the reference recording stay there.

Gateway side shipped in mortennordbye/reelsmith@c4b2186.

## What

- `configmap.yaml`, new. Three slots a day at 08:10, 12:40 and 19:20
  Europe/Oslo, each moving by up to 15 minutes. Kept out of the deployment so
  changing when the account posts is a one-line edit; Reloader turns it into a
  restart.
- `externalsecret.yaml` gains `GATEWAY_ADMIN_TOKEN` for the `/admin` panel.
  Separate from `GATEWAY_API_TOKEN` because they protect different things: that
  one is held by a script on the Mac, this one is typed by a person, and either
  can be rotated without the other.
- `deployment.yaml` reads the ConfigMap via `envFrom` and the new secret via
  `secretKeyRef`. The `replicas: 1` comment now also names the scheduler: two
  pods would race to publish the same queued Reel, and the claim that prevents
  it only works because both write to the one SQLite file.
- `httproute.yaml` comment corrected. It said the admin UI would sit behind
  Authentik forward-auth when it landed; it has landed and authenticates itself
  instead. Reasoning below.

## The schedule

The offset is derived from the slot and the local date rather than rolled at
runtime, and that is load bearing. A random offset is re-rolled on every pod
start, so a slot judged not-yet-due at 19:15 could come due at 19:10 after a
restart and publish twice. Hashing gives an offset stable for the day and
different the next.

It resolves to seconds and skips :00, :15, :30 and :45. A column of timestamps
on a fifteen minute grid is the cheapest automation tell there is.

    Sun 02 Aug   08:17:45   12:44:22   19:20:41
    Mon 03 Aug   08:24:08   12:50:07   19:28:42
    Tue 04 Aug   08:10:00   12:34:50   19:32:41
    Wed 05 Aug   07:58:44   12:50:12   19:26:11

A line that does not parse fails the pod's startup, rather than quietly dropping
that slot from the schedule.

## Why no auth filter on the route

`/webhook`, `/media/*` and `/api/*` all have to answer without a login, because
Meta fetches media from its own servers and the Mac posts to the API with a
bearer token. Gating `/admin` at the ingress therefore means a path prefix
match, and getting that wrong fails open.

So the panel authenticates itself: a Bitwarden password of at least 24
characters, a Strict SameSite cookie, an Origin check on every control, and a
Referer only honoured for the post-redirect-get when it points back at the
service. It refuses to start with no authentication configured at all. Adding
Authentik forward-auth as a second layer is still worth doing and is tracked in
BACKLOG.md.

## Verification

`kustomize build k8s/talos/apps/reelsmith` renders all eight resources, and the
rendered `GATEWAY_SLOTS` value was fed through the gateway's own parser to
confirm it yields three slots and the firing times above. Gateway test suite is
349 passing, covering the double-publish guard, the retry rules and every auth
and CSRF case.

Not verified against the live cluster: my kubeconfig for `admin@hyper-cluster`
fails certificate validation, so `kubectl diff` could not run. Worth a look at
the ArgoCD diff before syncing.

## After merge

Nothing publishes until Reels are queued from the Mac with
`main.py --enqueue <run> --approve`. An empty queue at a slot is counted and
logged, not an error.