### PR TITLE
feat(reelsmith): serve the admin panel on the private gateway only

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,10 +23,10 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Where:** `k8s/talos/apps/mealie/deployment.yaml` (env block).
 
 ### Authentik forward-auth in front of the reelsmith admin panel
-- **What:** `/admin` on `gate.nordbye.it` is a control panel that publishes Reels to a live Instagram account, edits captions, and holds the outbound-DM kill switch. It authenticates itself with `GATEWAY_ADMIN_TOKEN` (a Bitwarden value, minimum 24 characters, Strict SameSite cookie plus an Origin check) and refuses to start with no authentication at all. There is no second layer in front of it.
-- **Why deferred:** The host must stay reachable without a login for `/webhook`, `/media/*` and `/api/*`, because Meta fetches media from its own servers and the Mac posts to the API with a bearer token. So the auth filter has to hang off a `/admin` path rule rather than the whole route, and getting that prefix match wrong fails open. The app-level gate does not have that failure mode, which is why it went first.
-- **Unblock:** Add an Authentik proxy provider and outpost, then a second HTTPRoute rule matching PathPrefix `/admin` with an `ExtensionRef` filter to a forward-auth Middleware (the shape `k8s/talos/apps/homepage/httproute.yaml` uses for basicauth). Set `GATEWAY_ADMIN_TRUST_PROXY_AUTH=true` in the ConfigMap at the same time, or accept two sign-ins. Verify afterwards by curling `/webhook`, `/media/<name>.mp4` and `/api/queue`: all three must still answer without a session.
-- **Where:** `k8s/talos/apps/reelsmith/{httproute,configmap}.yaml`, `k8s/talos/infra/authentik/`.
+- **What:** The reelsmith control panel publishes Reels to a live Instagram account, edits captions, and holds the outbound-DM kill switch. It now has two locks: served only on `reelsmith.local.bigd.no` through the private gateway, and checking `GATEWAY_ADMIN_TOKEN` itself (a Bitwarden value, minimum 24 characters, Strict SameSite cookie plus an Origin check), refusing to start with no password. What it lacks is a real identity in front of it, so the shared token cannot tell one person from another.
+- **Why deferred:** Taking `/admin` off the public route removed the exposure that made this urgent, and a shared token behind a LAN-only hostname is adequate for a single operator. Authentik adds per-user identity and an audit trail, which only start to matter with more than one.
+- **Unblock:** Add an Authentik proxy provider and outpost, then an `ExtensionRef` filter to a forward-auth Middleware on the admin route (the shape `k8s/talos/apps/homepage/httproute.yaml` uses for basicauth). Set `GATEWAY_ADMIN_TRUST_PROXY_AUTH=true` in the ConfigMap at the same time, or accept two sign-ins.
+- **Where:** `k8s/talos/apps/reelsmith/{httproute-admin,configmap}.yaml`, `k8s/talos/infra/authentik/`.
 
 ## AI / RAG POC
 

--- a/k8s/talos/apps/reelsmith/httproute-admin.yaml
+++ b/k8s/talos/apps/reelsmith/httproute-admin.yaml
@@ -1,0 +1,43 @@
+# The control panel, on the private gateway only.
+#
+# The panel publishes to a live Instagram account, rewrites captions and holds
+# the outbound-DM kill switch. It authenticates itself with GATEWAY_ADMIN_TOKEN
+# and will not start without a password, but there is no reason for it to be
+# reachable from the internet at all: nobody outside the LAN needs to open it.
+#
+# So it moves here, and `httproute.yaml` stops serving /admin publicly. Two
+# independent things now have to fail before the panel is exposed, rather than
+# one.
+#
+# The `*.local.bigd.no` listener already carries a wildcard certificate and
+# external-dns manages the zone, so this needs no cert and no DNS record of its
+# own.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: reelsmith-admin
+  namespace: reelsmith
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-private
+      namespace: traefik
+  hostnames:
+    - "reelsmith.local.bigd.no"
+  rules:
+    # The whole app, not just /admin. Reaching /api or /media over the private
+    # name is harmless and occasionally useful for debugging, and restricting
+    # it here would only mean two lists to keep in step.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: reelsmith-gateway
+          port: 8000
+          weight: 1

--- a/k8s/talos/apps/reelsmith/httproute.yaml
+++ b/k8s/talos/apps/reelsmith/httproute.yaml
@@ -1,16 +1,20 @@
 # Public gateway, not private: Meta's servers have to reach /webhook and fetch
-# cover images from /covers, and they need a publicly valid certificate to do
-# it. cert-manager and external-dns both pick the hostname up from here.
+# media from /media and /covers, and they need a publicly valid certificate to
+# do it. cert-manager and external-dns both pick the hostname up from here.
 #
-# Meta, the Mac, and now a browser reaching /admin all use this one host, so
-# the name is not a doxxing surface.
+# These rules are an allowlist rather than a catch-all, and that is the point.
+# Everything Meta and the Mac need is named; anything else 404s at Traefik
+# before it reaches the pod. Two things come off the internet as a result:
 #
-# No auth filter here on purpose. The admin UI authenticates itself with
-# GATEWAY_ADMIN_TOKEN and will not start without a password, which is the right
-# place for it: /webhook, /media/* and /api/* all have to stay reachable
-# without a login, so gating this route by path would put the account's safety
-# in a prefix match. Putting Authentik forward-auth on a /admin rule as a
-# second layer is still worth doing, and is tracked in BACKLOG.md.
+#   /admin    the control panel, which can publish to a live account. It moves
+#             to reelsmith.local.bigd.no (httproute-admin.yaml). It still
+#             checks its own password, so this is a second lock rather than the
+#             only one.
+#   /metrics  the funnel counters and the token expiry gauge. Prometheus
+#             scrapes in-cluster and never needed this to be public.
+#
+# Adding a route to the service means adding it here too. That is the cost of
+# an allowlist, and it is worth paying on a host this exposed.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -28,9 +32,27 @@ spec:
     - "gate.nordbye.it"
   rules:
     - matches:
+        # Meta: the subscription handshake and every message delivery.
         - path:
             type: PathPrefix
-            value: /
+            value: /webhook
+        # Meta: fetches the MP4 and the cover while creating a container. There
+        # is no publish without these.
+        - path:
+            type: PathPrefix
+            value: /media
+        - path:
+            type: PathPrefix
+            value: /covers
+        # The Mac: uploads, post registration and the queue. Bearer token.
+        - path:
+            type: PathPrefix
+            value: /api
+        # Kept public in case anything external is watching it. It answers
+        # "ok" and says nothing else.
+        - path:
+            type: PathPrefix
+            value: /healthz
       backendRefs:
         - group: ""
           kind: Service

--- a/k8s/talos/apps/reelsmith/kustomization.yaml
+++ b/k8s/talos/apps/reelsmith/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - state-pvc.yaml
 - deployment.yaml
 - httproute.yaml
+- httproute-admin.yaml
 - ciliumnetworkpolicy.yaml
 # newTag via the kustomize-set-image promotion step (Kargo). Overrides the inline
 # tag in deployment.yaml; the reelsmith-cd Warehouse/promotion rewrites it to


### PR DESCRIPTION
## Why

The reelsmith control panel can publish to a live Instagram account, rewrite
captions and stop all outbound DMs. It checks its own password and refuses to
start without one, but there is no reason for it to answer from the internet at
all: nobody outside the LAN needs to open it.

`gate.nordbye.it` has to stay public because Meta fetches media from its own
servers and posts webhook deliveries, so the fix is to split the audiences
rather than to lock the host down.

## What

- `httproute-admin.yaml`, new. The whole service on
  `reelsmith.local.bigd.no` via `traefik-gateway-private`. The
  `*.local.bigd.no` listener already carries a wildcard certificate and
  external-dns manages the zone, so this needs no cert and no DNS record.
- `httproute.yaml` becomes an allowlist instead of a `PathPrefix: /`
  catch-all. Named: `/webhook` and `/media` and `/covers` for Meta, `/api` for
  the Mac, `/healthz` in case something external watches it. Anything else now
  404s at Traefik before reaching the pod.

Two things come off the internet as a result:

| Path | Was | Now |
|---|---|---|
| `/admin` | public, password only | private gateway, password as well |
| `/metrics` | public: funnel counts, token expiry gauge | in-cluster only |

The panel keeps its own password, so this is a second lock rather than a
replacement. `GATEWAY_ADMIN_TRUST_PROXY_AUTH` stays off.

The cost is that adding a route to the service now means adding it here too.
Worth paying on a host this exposed, and the comment in the file says so.

## Verification

`kubectl diff` against the cluster shows exactly two changes: the public route
gaining the five prefixes in place of `/`, and the new private route. No change
to the Deployment, the ConfigMap, the ExternalSecret or the image tag.

Not yet verified: that `reelsmith.local.bigd.no` resolves and serves once
external-dns picks it up, and that `/admin` on the public host stops answering.
Both are one curl each after the sync and I will run them.

## Note on the code side

mortennordbye/reelsmith@a180f01 fixes a related bug found opening the panel for
the first time: TLS terminates at Traefik, and without `--proxy-headers`
uvicorn believed every request was plain http, so the login form's action came
out as `http://` and the browser warned the password was being sent insecurely.
That fix applies to any hostname and is needed regardless of this PR.