### PR TITLE
feat(homepage): link the reelsmith panel and gateway

### DIFF
--- a/k8s/talos/apps/homepage/values.yaml
+++ b/k8s/talos/apps/homepage/values.yaml
@@ -151,6 +151,14 @@ config:
             icon: mdi-wrench
             href: https://verksted.local.bigd.no
             description: Workshop app
+        - Reelsmith:
+            icon: mdi-movie-open-play
+            href: https://reelsmith.local.bigd.no/admin/
+            description: Reel queue, posting slots and DM funnel
+        - Reelsmith Gateway:
+            icon: si-instagram
+            href: https://gate.nordbye.it/healthz
+            description: Public endpoint Meta fetches Reels from
         - BigD:
             icon: mdi-web
             href: https://bigd.no


### PR DESCRIPTION
## Why

The reelsmith control panel moved to a LAN-only hostname in #497, so it needs
somewhere to be found from. Neither reelsmith URL has ever been on the
dashboard.

## What

Two entries under Public Sites, next to the other app UIs:

| Entry | Href | What it is |
|---|---|---|
| Reelsmith | `https://reelsmith.local.bigd.no/admin/` | the queue, posting slots and DM funnel |
| Reelsmith Gateway | `https://gate.nordbye.it/healthz` | the public endpoint Meta fetches Reels from |

The gateway entry points at `/healthz` because that is the only path it serves
publicly now: #497 turned its route into an allowlist, so `/` returns 404.

No `siteMonitor` on either, because nothing else in this file uses one and a
status dot that cannot reach its target reads as an outage rather than as a
missing feature.

## Verification

`helm template` renders the chart with the new values, and the file parses with
both entries landing in the Public Sites group.

Depends on #497 for the `reelsmith.local.bigd.no` link to resolve. Merging this
first only means that one entry 404s until #497 syncs.