### PR TITLE
feat(reelsmith): scrape the gateway and alert on the ways it goes quiet

### DIFF
--- a/k8s/talos/apps/reelsmith/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/reelsmith/ciliumnetworkpolicy.yaml
@@ -27,6 +27,18 @@ spec:
     - fromEntities:
         - host
         - health
+    # Prometheus, for /metrics on the same port. Without this the ServiceMonitor
+    # in monitoring.yaml is dropped by this policy and the only symptom is a
+    # target sitting at "down" on a service that is otherwise perfectly healthy,
+    # which is exactly the failure the alerts are there to catch.
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": monitoring
+            "k8s:app.kubernetes.io/name": prometheus
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
   egress:
     # DNS to CoreDNS. Required for toFQDNs below to resolve.
     - toEndpoints:

--- a/k8s/talos/apps/reelsmith/kustomization.yaml
+++ b/k8s/talos/apps/reelsmith/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - httproute.yaml
 - httproute-admin.yaml
 - ciliumnetworkpolicy.yaml
+- monitoring.yaml
 # newTag via the kustomize-set-image promotion step (Kargo). Overrides the inline
 # tag in deployment.yaml; the reelsmith-cd Warehouse/promotion rewrites it to
 # 0.0.N as the reelsmith repo's build-gateway workflow publishes them.

--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -1,0 +1,132 @@
+# Scrape the gateway, and alert on the four ways it goes quiet without
+# crashing.
+#
+# The gateway has exported these metrics since it was deployed and nothing has
+# ever read them. There was no ServiceMonitor, so `/metrics` was a page that
+# only a human could look at, on a service whose whole job is to run unattended
+# while nobody is looking at anything.
+#
+# Every alert here is about silence rather than errors. This service fails by
+# continuing to run: the token quietly expires, the poller loop dies while the
+# web server keeps answering health checks, a slot comes due with an empty
+# queue. None of that shows up as a restart or a 500, so none of it would be
+# caught by the workload alerts in kube-prometheus-stack.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: reelsmith-gateway
+  namespace: reelsmith
+  labels:
+    release: kube-prometheus-stack
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  selector:
+    matchLabels:
+      app: reelsmith-gateway
+  endpoints:
+    # `http` is the only port the Service publishes; /metrics is served off the
+    # same app. It is kept off the public HTTPRoute allowlist, so this
+    # in-cluster scrape is the only way anything reads it.
+    - port: http
+      path: /metrics
+      interval: 30s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: reelsmith-alerts
+  namespace: reelsmith
+  labels:
+    # Matches the live Prometheus ruleSelector. Its ruleNamespaceSelector is
+    # empty, so a rule next to its app is picked up the same as one in
+    # monitoring/.
+    release: kube-prometheus-stack
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  groups:
+    - name: reelsmith.gateway
+      rules:
+        # The refresher tries daily from 15 days out (TOKEN_REFRESH_MARGIN_DAYS),
+        # so at 10 days it has failed roughly five times. Under 24 hours no
+        # refresh can help at all: an expired long-lived token cannot be
+        # renewed, only replaced by hand in a browser, and until that happens
+        # nothing publishes, no DM is sent and no insight is read.
+        - alert: ReelsmithTokenExpiring
+          expr: reelsmith_token_days_left < 10
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith token for {{ $labels.ig_user_id }} expires in {{ $value | printf "%.1f" }} days'
+            description: |
+              The automatic refresh has had several days to renew this and has not.
+              Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i token
+
+        - alert: ReelsmithTokenAboutToDie
+          expr: reelsmith_token_days_left < 2
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'reelsmith token for {{ $labels.ig_user_id }} expires in under two days'
+            description: |
+              Past expiry it cannot be refreshed at all and needs re-authorising in a browser.
+              Everything the account does stops: publishing, DMs and insights.
+
+        # The web server answering health checks says nothing about the
+        # background loops. Both are heartbeats written at the end of a
+        # successful pass, at 20s and 60s intervals, so ten minutes of silence
+        # is dozens of missed passes rather than a slow one. The `> 0` guard
+        # keeps a freshly started pod, where the gauge is still zero, from
+        # reading as 56 years of staleness.
+        - alert: ReelsmithPollerStalled
+          expr: |
+            (time() - reelsmith_poller_last_success_timestamp > 600)
+              and (reelsmith_poller_last_success_timestamp > 0)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'reelsmith comment poller has not completed a sweep in {{ $value | printf "%.0f" }}s'
+            description: |
+              Comments are polled every 20s because real-time comment webhooks need App Review.
+              While this is stalled the comment-to-DM mechanic is off and nobody is told.
+
+        - alert: ReelsmithSchedulerStalled
+          expr: |
+            (time() - reelsmith_scheduler_last_success_timestamp > 600)
+              and (reelsmith_scheduler_last_success_timestamp > 0)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: 'reelsmith scheduler has not ticked in {{ $value | printf "%.0f" }}s'
+            description: |
+              The queue publishes on slots at 08:10, 12:40 and 19:20 Europe/Oslo.
+              A stalled scheduler misses them silently, and a missed slot is not retried later.
+
+        # A slot firing into an empty queue is the shape of "the account went
+        # quiet three days ago and nobody noticed". It is not an error anywhere
+        # else: every component is healthy and there is simply nothing to post.
+        - alert: ReelsmithQueueStarved
+          expr: increase(reelsmith_slots_starved_total[6h]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith had {{ $value | printf "%.0f" }} slot(s) come due with nothing approved'
+            description: |
+              Render and enqueue a batch, or approve what is already queued, at reelsmith.local.bigd.no.
+
+        - alert: ReelsmithPublishFailing
+          expr: increase(reelsmith_publish_failures_total[1h]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith failed {{ $value | printf "%.0f" }} publish attempt(s) in the last hour'
+            description: |
+              Meta rejected a publish or the upload did not complete. The queue entry stays for a retry.
+              Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i publish

--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -120,6 +120,25 @@ spec:
             description: |
               Render and enqueue a batch, or approve what is already queued, at reelsmith.local.bigd.no.
 
+        # Backups run every six hours, so a day of silence is four missed
+        # rounds. Warning rather than critical: nothing is broken for viewers
+        # while this is stale. What it protects is the record of which comments
+        # have already been answered, which cannot be rebuilt from anywhere,
+        # and whose loss means re-replying to every comment still inside Meta's
+        # seven day window. Same `> 0` guard as the loops above.
+        - alert: ReelsmithBackupStale
+          expr: |
+            (time() - reelsmith_backup_last_success_timestamp > 86400)
+              and (reelsmith_backup_last_success_timestamp > 0)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith has not backed up its state in {{ $value | printf "%.0f" }}s'
+            description: |
+              Usually a full state volume. The copies live beside the database and the newest 14 are kept.
+              Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i backup
+
         - alert: ReelsmithPublishFailing
           expr: increase(reelsmith_publish_failures_total[1h]) > 0
           for: 5m


### PR DESCRIPTION
## Why

The reelsmith gateway has exported Prometheus metrics since it was deployed and nothing has ever read them. There is no ServiceMonitor, so the token expiry gauge, the poller and scheduler heartbeats and the starved slot counter are written to a page only a human can open, on a service whose whole job is to run unattended.

It also fails by continuing to run. The Instagram token quietly expires and cannot be refreshed after that point, a background loop dies while uvicorn keeps answering health checks, a slot comes due with an empty queue. None of those is a restart or a 500, so none is caught by the workload alerts in `homelab-alerts.yaml`.

## What

- `monitoring.yaml`: a ServiceMonitor on the existing `http` port at `/metrics`, and a PrometheusRule with seven alerts. Token expiry at 10 days warning and 2 days critical, poller and scheduler heartbeats older than 10 minutes critical, starved slots, publish failures and a stale state backup as warnings. The staleness rules carry a `> 0` guard so a freshly started pod does not read as decades of silence.
- `ciliumnetworkpolicy.yaml`: ingress from the Prometheus pod on 8000. Without it the policy drops the scrape and the only symptom is a target stuck at down on a service that looks healthy.
- `kustomization.yaml`: the new file.

Rules sit in the `reelsmith` namespace rather than `monitoring`. The live Prometheus has an empty `ruleNamespaceSelector` and a `ruleSelector` of `release: kube-prometheus-stack`, which the labels match.

`ReelsmithBackupStale` needs gateway 0.0.14 or later, which is where the backup task and its gauge ship. Until that is promoted the rule sits idle rather than firing, because of the `> 0` guard.

## Verification

- [x] Kubernetes manifests: `kustomize build k8s/talos/apps/reelsmith` renders clean
- [x] `kubectl apply --dry-run=server` against hyper-cluster accepts both new resources against the live CRDs
- [x] Every alert expression parses on the live Prometheus via `/api/v1/query`, returning 0 series, which is the gap this closes