### PR TITLE
fix(loki): actually apply retention, and keep a week rather than a day

### DIFF
--- a/k8s/talos/infra/loki/values.yaml
+++ b/k8s/talos/infra/loki/values.yaml
@@ -9,12 +9,23 @@ loki:
     allow_structured_metadata: true
     reject_old_samples: true
     reject_old_samples_max_age: 24h
-    retention_period: 24h
+    # Enforced from the day the compactor block below moved under `loki:`.
+    # Before that this was a number nobody applied, and the volume held every
+    # log line written since the install: 120 days on a 20Gi disk, and a live
+    # Instagram token that a pod had printed for ten minutes four weeks after
+    # it should have aged out.
+    #
+    # 7d rather than the 24h that was written here, deliberately. 24h was never
+    # lived with, so it was a guess either way, and a week of history is worth
+    # more than the disk it costs. Lower it once you have watched retention
+    # actually run.
+    retention_period: 168h
     # Keep Kubernetes events longer than pod logs for incident troubleshooting.
+    # Raised with the default so it stays longer rather than equal.
     retention_stream:
       - selector: '{job="kubernetes-events"}'
         priority: 1
-        period: 168h
+        period: 720h
     unordered_writes: true
   
   commonConfig:
@@ -37,10 +48,23 @@ loki:
           prefix: index_
           period: 24h
 
-compactor:
-  working_directory: /var/loki/compactor
-  shared_store: filesystem
-  retention_enabled: true
+  # Retention is the compactor's job, and nothing else does it. This block used
+  # to sit at the top level of this file, where the chart has no such value and
+  # dropped it silently: `retention_period` was set, `retention_enabled` read
+  # back as false from Loki's own /config endpoint, and no log line had ever
+  # been deleted. A retention policy that is configured but not applied is
+  # worse than none, because it is believed.
+  #
+  # `shared_store` went with the move rather than under it. Loki 3 removed the
+  # field, so carrying it across would have turned a silently ignored block
+  # into a pod that will not start.
+  compactor:
+    working_directory: /var/loki/compactor
+    retention_enabled: true
+    # Required for the delete API, which `deletion_mode: filter-and-delete` in
+    # limits_config already assumes exists. Without it a delete request is
+    # accepted and never acted on.
+    delete_request_store: filesystem
 
 read:
   replicas: 0


### PR DESCRIPTION
## Why

`compactor.retention_enabled` sat at the top level of `k8s/talos/infra/loki/values.yaml`, where the chart has no such value and dropped it silently. Loki's own `/config` endpoint reports `retention_enabled: false`, so `retention_period` was a number nobody applied and no log line has ever been deleted. The volume holds 120 days of logs on a 20Gi disk.

This came out of chasing a live Instagram token that the reelsmith gateway printed in a request URL for about ten minutes on 1 August. It is still queryable in Grafana now, 35 hours into what the file documents as 24 hour retention. A retention policy that is configured but not applied is worse than none, because it is believed.

## What

- Moves the compactor block under `loki:` so the chart passes it through, and adds `delete_request_store: filesystem`, which `deletion_mode: filter-and-delete` in `limits_config` already assumes exists.
- Drops `shared_store`. Loki 3 removed the field, so carrying it across would turn a silently ignored block into a pod that will not start. Verified against the compactor keys the running 3.7.4 reports.
- `retention_period` 24h to 168h. 24h was never lived with, so it was a guess either way, and a week of history is worth the disk. Lower it once retention has been seen to run.
- `kubernetes-events` stream 168h to 720h, so it stays longer than pod logs rather than equal to them, which is what the comment there always said.

First compaction after this lands deletes everything older than 7 days, across every namespace. That is the intended effect and it is not reversible.

## Verification

- [x] Kubernetes manifests: `kustomize build --enable-helm k8s/talos/infra/loki` renders clean, and the generated `loki/config.yaml` now carries `retention_enabled: true`, `delete_request_store: filesystem`, `retention_period: 168h`, no `shared_store`
- [x] Every key checked against the compactor config the live Loki 3.7.4 reports on `/config`