### PR TITLE
fix(reelsmith): label the Service so the ServiceMonitor can find it

### DIFF
--- a/k8s/talos/apps/reelsmith/deployment.yaml
+++ b/k8s/talos/apps/reelsmith/deployment.yaml
@@ -132,6 +132,12 @@ kind: Service
 metadata:
   name: reelsmith-gateway
   namespace: reelsmith
+  # A ServiceMonitor selects Services by the labels on the Service, not by the
+  # pod selector below. Without this label `monitoring.yaml` matches nothing
+  # and Prometheus never creates a target at all, which is quieter than a
+  # target that is down: there is nothing in the UI to notice.
+  labels:
+    app: reelsmith-gateway
 spec:
   selector:
     app: reelsmith-gateway


### PR DESCRIPTION
## Why

A ServiceMonitor selects Services by the labels on the Service, not by the pod selector. `reelsmith-gateway` has no labels, so the ServiceMonitor merged in #503 matched nothing and Prometheus never created a target. Confirmed against the live cluster: `up{namespace="reelsmith"}` returns no series, and `kubectl get svc reelsmith-gateway -o jsonpath='{.metadata.labels}'` is empty.

This is quieter than the failure the network policy would have caused. A blocked scrape shows up as a target that is down. A selector matching nothing shows up as no target, which is nothing to notice.

## What

Adds `labels.app: reelsmith-gateway` to the Service metadata, matching the ServiceMonitor's `selector.matchLabels` and the convention `k8s/talos/apps/arr-stack/exportarr.yaml` already uses.

## Verification

- [x] Kubernetes manifests: `kustomize build k8s/talos/apps/reelsmith` renders clean
- [x] Cause confirmed on the live cluster: ServiceMonitor `matchLabels` is `{"app":"reelsmith-gateway"}` and the Service's `metadata.labels` is empty