### PR TITLE
feat(reelsmith): alert while a post is stuck in failed

### DIFF
--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -149,3 +149,28 @@ spec:
             description: |
               Meta rejected a publish or the upload did not complete. The queue entry stays for a retry.
               Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i publish
+
+        # The counter above catches the moment and then resolves an hour later
+        # whether or not anything was fixed, because `increase` over a window
+        # falls back to zero on its own. This is the state rather than the
+        # event: a row in `failed` has stopped retrying and will not move again
+        # without a person, so the alert should stay up until one arrives.
+        #
+        # Three paths land here and only one of them is ordinary bad luck. A
+        # publish that failed *after* the container existed may already be live
+        # on the account, which is why the gateway refuses to retry it on its
+        # own and why re-arming it in the admin UI can post the same Reel twice.
+        - alert: ReelsmithPostStuck
+          expr: reelsmith_queue_depth{state="failed"} > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith has {{ $value | printf "%.0f" }} queued post(s) stuck in failed'
+            description: |
+              These have stopped retrying and stay put until someone decides what to do with them.
+              Check the account for a duplicate before re-arming: a container may have become a Reel.
+              Queue: https://reelsmith.local.bigd.no/admin/
+              A "no video file" failure specifically means the retention sweep ate a queued
+              file: _prune_media sweeps by mtime and db.live_media_names is the exemption
+              that should have covered it.


### PR DESCRIPTION
## Why

`ReelsmithPublishFailing` alerts on `increase(reelsmith_publish_failures_total[1h])`.
That catches the moment a publish fails and then resolves an hour later whether
or not anything was fixed, because `increase` over a window falls back to zero
on its own. A row sitting in `failed` has stopped retrying and will not move
again without a person, so there should be an alert that stays up until one
arrives.

Three paths land in `failed` and only one of them is ordinary bad luck. A
publish that failed *after* the container existed may already be live on the
account, which is why the gateway refuses to retry it on its own and why
re-arming it in the admin UI can post the same Reel twice. The description says
so, next to the queue link.

## What

One alert, `ReelsmithPostStuck`, on `reelsmith_queue_depth{state="failed"} > 0`
for 15m, severity warning. It complements the counter alert rather than
replacing it: one is the event, this is the state.

## Verification

Depends on reelsmith `0.0.20`, promoted in #513, which is what first populates
`reelsmith_queue_depth`. The gauge had been declared in `metrics.py` and written
by nothing, so this rule was not expressible before and would have sat silent
against `0.0.19`. That ordering is why this PR was held until the promotion
merged.

Confirmed against the live pod after the rollout:

```
reelsmith_queue_depth{state="draft"} 0.0
reelsmith_queue_depth{state="approved"} 18.0
reelsmith_queue_depth{state="claimed"} 0.0
reelsmith_queue_depth{state="published"} 4.0
reelsmith_queue_depth{state="failed"} 0.0
reelsmith_queue_depth{state="cancelled"} 1.0
```

Every state is published including the empty ones, so a row leaving `failed`
takes the series back to zero and the alert resolves rather than sticking at its
last non-zero value.

The same reelsmith change also makes the `no video file` failure increment
`publish_failures_total`. That path never asks Meta for anything and was the only
failure Prometheus could not see, so a post dying because the retention sweep ate
its file was invisible to `ReelsmithPublishFailing` while every other failure
fired it.