### PR TITLE
feat(reelsmith): authentik forward-auth on the control panel

### DIFF
--- a/k8s/talos/apps/reelsmith/httproute-admin.yaml
+++ b/k8s/talos/apps/reelsmith/httproute-admin.yaml
@@ -28,6 +28,33 @@ spec:
   hostnames:
     - "reelsmith.local.bigd.no"
   rules:
+    # authentik's callback, and the only rule here without the auth filter.
+    #
+    # `forward_single` keeps the whole sign-in on the app's own hostname, so
+    # after authenticating the browser is sent back to
+    # reelsmith.local.bigd.no/outpost.goauthentik.io/callback. That has to
+    # reach authentik rather than the gateway, and it has to be reachable
+    # while the user is still unauthenticated. Putting the filter on this rule
+    # deadlocks the sign-in against the sign-in it is trying to complete, and
+    # pointing it at the gateway returns a 404 from the panel instead.
+    #
+    # A longer prefix wins over `/` by Gateway API's matching precedence, so
+    # this takes effect regardless of rule order.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /outpost.goauthentik.io/
+      backendRefs:
+        # Cross-namespace, so a ReferenceGrant in `identity` permits it. Named
+        # rather than the embedded outpost's own Service because the embedded
+        # outpost is served by authentik-server itself.
+        - group: ""
+          kind: Service
+          name: authentik-server
+          namespace: identity
+          port: 80
+          weight: 1
+
     # The whole app, not just /admin. Reaching /api or /media over the private
     # name is harmless and occasionally useful for debugging, and restricting
     # it here would only mean two lists to keep in step.
@@ -35,6 +62,15 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      filters:
+        # authentik in front. The panel still checks GATEWAY_ADMIN_TOKEN behind
+        # this, so both have to be satisfied: forward-auth adds per-user
+        # identity, it does not replace the password.
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: reelsmith-authentik
       backendRefs:
         - group: ""
           kind: Service

--- a/k8s/talos/apps/reelsmith/kustomization.yaml
+++ b/k8s/talos/apps/reelsmith/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - deployment.yaml
 - httproute.yaml
 - httproute-admin.yaml
+- middleware-authentik.yaml
 - ciliumnetworkpolicy.yaml
 - monitoring.yaml
 # newTag via the kustomize-set-image promotion step (Kargo). Overrides the inline

--- a/k8s/talos/apps/reelsmith/middleware-authentik.yaml
+++ b/k8s/talos/apps/reelsmith/middleware-authentik.yaml
@@ -1,0 +1,41 @@
+# Forward-auth for the control panel, calling authentik's embedded outpost.
+#
+# Lives in this namespace rather than next to authentik because Traefik
+# resolves an HTTPRoute `ExtensionRef` filter in the route's own namespace.
+# The address it calls is cross-namespace, which is fine: that is an ordinary
+# in-cluster HTTP request and not a Gateway API reference.
+#
+# The panel keeps GATEWAY_ADMIN_TOKEN as well. This is a second lock rather
+# than a replacement, so a mistake here costs a password prompt and not an open
+# control panel for a live Instagram account.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: reelsmith-authentik
+  namespace: reelsmith
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  forwardAuth:
+    # The embedded outpost, served by authentik-server itself. A separate
+    # outpost Deployment would work the same way and is not worth running for
+    # one application.
+    address: http://authentik-server.identity.svc.cluster.local/outpost.goauthentik.io/auth/traefik
+    # authentik builds the redirect back to the app from X-Forwarded-*. Without
+    # this it sees the in-cluster request instead and sends the browser
+    # somewhere it cannot reach.
+    #
+    # Safe because the only route to this middleware is through the private
+    # Gateway, which sets those headers itself and overwrites whatever the
+    # client sent.
+    trustForwardHeader: true
+    # Copied onto the request that reaches the pod. The gateway does not read
+    # them today, since trusting a header for auth is exactly what its config
+    # refuses to do, but they are what an audit trail would be built from and
+    # they cost nothing to pass through.
+    authResponseHeaders:
+      - X-authentik-username
+      - X-authentik-groups
+      - X-authentik-email
+      - X-authentik-name
+      - X-authentik-uid

--- a/k8s/talos/infra/authentik/kustomization.yaml
+++ b/k8s/talos/infra/authentik/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - argocd-blueprint.yaml
   - kargo-blueprint.yaml
   - grafana-blueprint.yaml
+  - reelsmith-blueprint.yaml
+  - referencegrant-reelsmith.yaml
 
 helmCharts:
   - name: authentik

--- a/k8s/talos/infra/authentik/reelsmith-blueprint.yaml
+++ b/k8s/talos/infra/authentik/reelsmith-blueprint.yaml
@@ -1,0 +1,109 @@
+# Forward-auth in front of the reelsmith control panel.
+#
+# Unlike argocd, grafana and kargo, the reelsmith panel speaks no OIDC. It has
+# its own password and nothing else, so the provider here is a proxy provider
+# rather than an oauth2 one: authentik authenticates the request at Traefik,
+# before it ever reaches the pod.
+#
+# `forward_single` rather than `forward_domain` because this protects one host.
+# Domain mode needs a cookie domain shared by every protected app and an
+# authentik host inside it, which is a bigger commitment than one panel is
+# worth. Single mode keeps the callback on the app's own hostname, which is why
+# the HTTPRoute grows an unauthenticated `/outpost.goauthentik.io/` rule.
+#
+# **The panel keeps its own password.** GATEWAY_ADMIN_TRUST_PROXY_AUTH stays
+# off, so this is a second independent lock rather than a replacement. The
+# gateway's `_authenticated()` returns True unconditionally when that flag is
+# set and never inspects a header, so trusting the proxy would leave the panel
+# with no auth of its own and make every path that reaches the Service without
+# traversing this one HTTPRoute an open control panel for a live Instagram
+# account. What authentik adds here is per-user identity and an audit trail.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprint-reelsmith
+  namespace: identity
+  annotations:
+    # Ahead of the chart-inflated worker Deployment (wave 0), which mounts this.
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  reelsmith.yaml: |
+    version: 1
+    metadata:
+      name: reelsmith-forward-auth
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        id: group-reelsmith-admins
+        state: present
+        identifiers:
+          name: reelsmith-admins
+        attrs:
+          is_superuser: false
+          # Declared here for the same reason as argocd-admins: a rebuilt
+          # cluster grants access without anyone touching the UI. Reconciliation
+          # resets this list, so add members here rather than in authentik.
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
+
+      - model: authentik_providers_proxy.proxyprovider
+        id: provider-reelsmith
+        state: present
+        identifiers:
+          name: reelsmith
+        attrs:
+          name: reelsmith
+          # The browser-facing origin. authentik builds the redirect back to
+          # the callback from this, so it has to be the external URL and not
+          # the in-cluster Service.
+          external_host: https://reelsmith.local.bigd.no
+          mode: forward_single
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          # The panel is used from a browser by one operator. No token access
+          # path is wanted, so the defaults for basic auth stay off.
+          intercept_header_auth: true
+
+      - model: authentik_core.application
+        id: app-reelsmith
+        state: present
+        identifiers:
+          slug: reelsmith
+        attrs:
+          name: reelsmith
+          slug: reelsmith
+          provider: !KeyOf provider-reelsmith
+          meta_description: The reelsmith control panel, publishing and queue
+          # Shown on the authentik dashboard so the panel is reachable without
+          # remembering the hostname.
+          meta_launch_url: https://reelsmith.local.bigd.no/admin/
+          policy_engine_mode: any
+
+      # Without a binding, an application is reachable by every authenticated
+      # user. This restricts it to the group above.
+      - model: authentik_policies.policybinding
+        id: binding-reelsmith
+        state: present
+        identifiers:
+          target: !KeyOf app-reelsmith
+          group: !KeyOf group-reelsmith-admins
+          order: 0
+
+      # The embedded outpost is what Traefik actually calls. A provider that is
+      # not attached to an outpost exists but answers nothing, and the symptom
+      # is a 404 from /outpost.goauthentik.io/auth/traefik rather than an error
+      # anywhere that mentions the provider.
+      #
+      # `providers` is replaced wholesale on reconcile, so every provider the
+      # embedded outpost serves has to be listed here. Adding a second app
+      # later means adding it to this list, not writing a second binding.
+      - model: authentik_outposts.outpost
+        id: embedded-outpost
+        state: present
+        identifiers:
+          managed: goauthentik.io/outposts/embedded
+        attrs:
+          name: authentik Embedded Outpost
+          providers:
+            - !KeyOf provider-reelsmith

--- a/k8s/talos/infra/authentik/referencegrant-reelsmith.yaml
+++ b/k8s/talos/infra/authentik/referencegrant-reelsmith.yaml
@@ -1,0 +1,28 @@
+# Lets the reelsmith admin route send authentik's callback back to authentik.
+#
+# Gateway API refuses a cross-namespace backendRef unless the *target*
+# namespace says yes, which is the whole point of the rule: otherwise anyone
+# who can write an HTTPRoute in any namespace could route traffic at a Service
+# in this one.
+#
+# Narrow on purpose. Only HTTPRoutes in `reelsmith`, and only to the
+# authentik-server Service, which is what serves the embedded outpost that
+# Traefik's forward-auth middleware calls. Without this the route is accepted
+# with a ResolvedRefs=False condition and the sign-in callback 500s, which
+# reads like an authentik fault rather than a permissions one.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: reelsmith-to-authentik
+  namespace: identity
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: reelsmith
+  to:
+    - group: ""
+      kind: Service
+      name: authentik-server

--- a/k8s/talos/infra/authentik/values.yaml
+++ b/k8s/talos/infra/authentik/values.yaml
@@ -18,6 +18,7 @@ blueprints:
     - authentik-blueprint-argocd
     - authentik-blueprint-kargo
     - authentik-blueprint-grafana
+    - authentik-blueprint-reelsmith
 
 server:
   env:


### PR DESCRIPTION
Closes the reelsmith item in `BACKLOG.md`.

## Why

The panel publishes Reels to a live Instagram account, rewrites captions and
holds the outbound-DM kill switch. It already had two locks: served only on
`reelsmith.local.bigd.no` through the private gateway, and checking
`GATEWAY_ADMIN_TOKEN` itself. What it lacked was a real identity in front of it,
so the shared token could not tell one person from another.

## What

Six pieces:

- **Proxy provider, not oauth2.** The panel speaks no OIDC, unlike argocd,
  grafana and kargo, so authentik has to authenticate at Traefik before the
  request reaches the pod. `forward_single` rather than `forward_domain`,
  because domain mode needs a cookie domain shared by every protected app and an
  authentik host inside it, which is a bigger commitment than one panel is worth.
- **An unauthenticated `/outpost.goauthentik.io/` rule** on the admin route,
  pointed at `authentik-server`. Single mode keeps the callback on the app's own
  hostname, so it has to be reachable while the user is still unauthenticated.
  Putting the auth filter on that rule deadlocks the sign-in against the sign-in
  it is trying to complete; pointing it at the gateway 404s instead.
- **A ReferenceGrant in `identity`**, because that backend is cross-namespace.
  Without it the route is accepted with `ResolvedRefs=False` and the callback
  fails in a way that reads like an authentik fault rather than a permissions one.
- **The provider attached to the embedded outpost.** A provider with no outpost
  exists but answers nothing, and the symptom is a 404 from
  `/outpost.goauthentik.io/auth/traefik` rather than anything naming the provider.
- **A `reelsmith-admins` group** with a policy binding, since an application
  with no binding is reachable by every authenticated user.
- **A forwardAuth Middleware** in the `reelsmith` namespace, because Traefik
  resolves an `ExtensionRef` filter in the route's own namespace.

## The one deliberate non-change

`GATEWAY_ADMIN_TRUST_PROXY_AUTH` stays off, so **this is a second lock and not a
replacement**. The gateway's `_authenticated()` returns `True` unconditionally
when that flag is set and never inspects a header, by design, because a header
is attacker-settable on a service this exposed. Enabling it would leave the
panel with no authentication of its own, and any path reaching the Service
without traversing this one HTTPRoute would be an open control panel for a live
Instagram account.

The cost is signing in twice. That was a deliberate choice over the alternative.

## Verification

- `kustomize build` clean for both `k8s/talos/apps/reelsmith` and
  `k8s/talos/infra/authentik` (the latter with `--enable-helm`).
- The blueprint parses, with all five entries in order: group, proxyprovider,
  application, policybinding, outpost.
- `ReferenceGrant` uses `v1beta1`, matching the two already in the repo, and the
  cluster serves both `v1` and `v1beta1`. `Middleware` is `v1alpha1`, matching
  the CRD.

Not verifiable before merge: the sign-in itself, and that
`default-provider-authorization-implicit-consent` resolves. Both need the
blueprint imported. Worth watching the authentik worker log on first sync.