### PR TITLE
feat(headroom-demo): public read-only demo on headroom.nordbye.it

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,12 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Apps
 
+### `headroom-demo` image tag is bumped by hand
+- **What:** The public demo at `headroom.nordbye.it` runs the same `ghcr.io/mortennordbye/headroom` image as the private instance, but its tag is pinned in its own `kustomization.yaml` and is not promoted by anything. The demo therefore drifts behind the private instance until someone edits the tag.
+- **Why deferred:** The `headroom-cd` Kargo project is single-stage and hardcodes `appPath: k8s/talos/apps/headroom`. Giving the demo automatic promotion means adding a second Stage (plus its own smoke-test AnalysisTemplate against the public URL) and authorizing it in the ApplicationSet `templatePatch`, whose current convention only covers `<app>` and `<app>-stage`. That is a real change to the CD topology and was out of scope for standing the demo up.
+- **Unblock:** Either add a `demo` Stage to `headroom-cd` that promotes the same Freight into `k8s/talos/apps/headroom-demo` (and extend the `templatePatch` naming convention to cover `<app>-demo`), or accept manual bumps and just remember them when releasing.
+- **Where:** `k8s/talos/apps/headroom-demo/kustomization.yaml` (`images.newTag`), `k8s/talos/infra/kargo-projects/headroom.yaml`, `k8s/talos/infra/argocd/apps.yaml` (`templatePatch`).
+
 ### Remove the old `workout` app after logeverylift cutover
 - **What:** `logeverylift.com` was cut over from the old `workout` app to the renamed `logeverylift` app (PR #369, 2026-07-18). The `workout` namespace, Deployment, Postgres, and PVC are still present — both `workout-app` and `postgres` are scaled to 0 (ArgoCD ignores `/spec/replicas`; also declared in the manifests). The data is preserved on `postgres-pvc`; scale `postgres` back to 1 to re-access it. Nothing routes to it.
 - **Why deferred:** Kept as rollback until the owner has used `logeverylift.com` for a while and confirmed all data/history is intact. Deleting is one-way (prunes the namespace + PVC).

--- a/k8s/talos/apps/headroom-demo/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/headroom-demo/ciliumnetworkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: headroom-demo-policy
+  namespace: headroom-demo
+spec:
+  endpointSelector:
+    matchLabels:
+      app: headroom-demo
+  ingress:
+    # Only Traefik may reach the pod. No KEDA interceptor rule here (unlike the
+    # private headroom): this app never scales to zero, so traffic goes straight
+    # from the gateway to the service.
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": traefik
+            "k8s:app.kubernetes.io/instance": traefik-traefik
+      toPorts:
+        - ports:
+            - port: "3001"
+              protocol: TCP
+    # kubelet probes.
+    - fromEntities:
+        - host
+        - health

--- a/k8s/talos/apps/headroom-demo/compress-middleware.yaml
+++ b/k8s/talos/apps/headroom-demo/compress-middleware.yaml
@@ -1,0 +1,25 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: headroom-demo-compress
+  namespace: headroom-demo
+spec:
+  # The app ships a ~3.4 MB precached PWA shell (JS/CSS) and Express serves it
+  # uncompressed, so the edge owns compression. Same shape as portfolio-compress:
+  # brotli first (smallest for JS/HTML), limited to compressible text so fonts
+  # and images aren't re-compressed.
+  compress:
+    encodings:
+      - br
+      - zstd
+      - gzip
+    minResponseBodyBytes: 1024
+    includedContentTypes:
+      - text/html
+      - text/css
+      - text/plain
+      - text/javascript
+      - application/javascript
+      - application/json
+      - application/manifest+json
+      - image/svg+xml

--- a/k8s/talos/apps/headroom-demo/deployment.yaml
+++ b/k8s/talos/apps/headroom-demo/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headroom-demo
+  namespace: headroom-demo
+  labels:
+    app: headroom-demo
+spec:
+  # Always on. This is linked from the blog and LinkedIn, so a cold start would
+  # be the first thing a visitor sees — hence no KEDA scale-to-zero here, unlike
+  # the private headroom instance.
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: headroom-demo
+  template:
+    metadata:
+      labels:
+        app: headroom-demo
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      # The headroom image starts as root, fixes /data ownership, then drops to
+      # uid 1000 (node). Unlike the private instance (Synology NFS, where the
+      # chown doesn't stick and it falls back to root) /data here is a local
+      # emptyDir, so the chown succeeds and it genuinely runs non-root. Do NOT
+      # add runAsUser — starting the pod non-root removes the entrypoint's
+      # ability to chown at all.
+      securityContext:
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: headroom
+          # Pinned tag, owned by kustomization.yaml (`images.newTag`). This app is
+          # deliberately NOT in the Kargo pipeline — that promotes only
+          # k8s/talos/apps/headroom — so refreshing the demo is a manual tag bump.
+          # The tag MUST be a build that contains DEMO_MODE support; an older
+          # image would ignore DEMO_MODE and serve a writable, empty app publicly.
+          image: ghcr.io/mortennordbye/headroom:sha-32a1389
+          imagePullPolicy: IfNotPresent
+          env:
+            # Read-only public demo: the API refuses every write and the whole
+            # bank namespace, and the client fills itself with the fictional
+            # dataset it generates in the browser. See the headroom repo's
+            # README, "Public demo mode".
+            - name: DEMO_MODE
+              value: "1"
+            # Host-header allowlist (DNS-rebinding guard). The app 403s any host
+            # not listed, which is also why the probes below send an explicit
+            # Host header instead of hitting the pod IP.
+            - name: ALLOWED_HOSTS
+              value: "headroom.nordbye.it,localhost,127.0.0.1"
+          ports:
+            - name: http
+              containerPort: 3001
+          volumeMounts:
+            # SQLite still needs a writable dir to open its database, even though
+            # a demo never stores anything worth keeping. Ephemeral on purpose:
+            # every restart starts clean and there is no volume to leak.
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+              httpHeaders: [{ name: Host, value: headroom.nordbye.it }]
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+              httpHeaders: [{ name: Host, value: headroom.nordbye.it }]
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 3
+      volumes:
+        - name: data
+          emptyDir:
+            sizeLimit: 256Mi

--- a/k8s/talos/apps/headroom-demo/httproute.yaml
+++ b/k8s/talos/apps/headroom-demo/httproute.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headroom-demo
+  namespace: headroom-demo
+spec:
+  parentRefs:
+    # Public gateway: external-dns publishes the hostname below as a CNAME to the
+    # DDNS record, and the existing *.nordbye.it certificate already covers it —
+    # so no DNS or cert-manager change is needed for this app.
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-public
+      namespace: traefik
+  hostnames:
+    - headroom.nordbye.it
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: headroom-demo-compress
+      backendRefs:
+        # Straight to the service — no KEDA interceptor, because this app never
+        # scales to zero.
+        - group: ""
+          kind: Service
+          name: headroom-demo-service
+          port: 8080
+          weight: 1

--- a/k8s/talos/apps/headroom-demo/kustomization.yaml
+++ b/k8s/talos/apps/headroom-demo/kustomization.yaml
@@ -17,4 +17,4 @@ resources:
 # only to a build that actually contains DEMO_MODE support.
 images:
 - name: ghcr.io/mortennordbye/headroom
-  newTag: 0.0.297
+  newTag: 0.0.305

--- a/k8s/talos/apps/headroom-demo/kustomization.yaml
+++ b/k8s/talos/apps/headroom-demo/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "0"
+resources:
+- namespace.yaml
+- deployment.yaml
+- httproute.yaml
+- compress-middleware.yaml
+- service.yaml
+- ciliumnetworkpolicy.yaml
+# Public read-only demo of the headroom app, on the same image as the private
+# instance but with DEMO_MODE=1 (see deployment.yaml).
+#
+# Not managed by Kargo: the headroom-cd Warehouse/promotion only rewrites
+# k8s/talos/apps/headroom. Bump the tag here by hand to refresh the demo, and
+# only to a build that actually contains DEMO_MODE support.
+images:
+- name: ghcr.io/mortennordbye/headroom
+  newTag: 0.0.297

--- a/k8s/talos/apps/headroom-demo/namespace.yaml
+++ b/k8s/talos/apps/headroom-demo/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headroom-demo

--- a/k8s/talos/apps/headroom-demo/service.yaml
+++ b/k8s/talos/apps/headroom-demo/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headroom-demo-service
+  namespace: headroom-demo
+spec:
+  selector:
+    app: headroom-demo
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 3001


### PR DESCRIPTION
> **Draft — do not merge yet.** The pinned tag must first be bumped to a
> headroom build that contains `DEMO_MODE`. See "Before merging" below.

## Why

A public showcase instance of headroom to link from the blog and LinkedIn,
where people can click through a populated app without reaching real data or
changing anything for the next visitor.

## What

A new `headroom-demo` app. ArgoCD's ApplicationSet discovers `apps/*`, so the
directory is the registration — no change to `apps.yaml` needed.

Same `ghcr.io/mortennordbye/headroom` image as the private instance, with
`DEMO_MODE=1` (mortennordbye/headroom#100), which closes the API to writes,
refuses the whole `/api/bank/*` namespace, and makes the client fill itself
with a fictional dataset generated in the browser. Each visitor gets a private
sandbox that resets on reload; nothing is written server-side.

- **Routing:** public gateway on `headroom.nordbye.it`. The `*.nordbye.it`
  certificate already covers it and external-dns publishes the CNAME from the
  HTTPRoute, so no cert-manager or DNS change is needed. Brotli compress
  middleware, same shape as `portfolio-compress`, for the ~3.4 MB PWA shell.
- **Scaling:** always one replica, so a visitor arriving from a link never
  waits on a cold start. No ScaledObject and no KEDA interceptor hop — traffic
  goes straight from the gateway to the service.
- **Storage:** `/data` is an ephemeral `emptyDir`. SQLite still needs somewhere
  to open its database, but a demo has nothing worth keeping and no volume to
  leak. The emptyDir also lets the image's entrypoint chown succeed, so it
  genuinely drops to uid 1000 rather than falling back to root as it does on
  the Synology NFS PVC.
- **Network:** Cilium ingress from Traefik only, plus host/health for probes.
- **Probes:** `httpGet /healthz` with an explicit `Host` header, because the app
  enforces an `ALLOWED_HOSTS` allowlist and would 403 a probe aimed at the pod IP.

## Before merging

`kustomization.yaml` pins `newTag: 0.0.297`, which **predates `DEMO_MODE`**.
ArgoCD auto-syncs on merge, so merging as-is would stand up a public instance
that ignores the flag: an empty app that accepts writes from anyone. Separate
namespace and volume, so no real data is exposed, but it should not ship.

1. Merge mortennordbye/headroom#100
2. Let CI publish `0.0.<run>`
3. Bump `newTag` here to that build
4. Undraft and merge

## Verification

`kubectl kustomize k8s/talos/apps/headroom-demo` renders all seven resources
with the image override applied and `DEMO_MODE` set.

Demo behaviour itself was verified in the app repo: writes and bank routes
403, reads 200, and in a real browser zero console errors, zero writes, and
`/api/data` never requested.

The demo is deliberately outside the Kargo pipeline (`headroom-cd` hardcodes
`appPath: k8s/talos/apps/headroom`), so refreshing it is a manual tag bump.
Recorded in `BACKLOG.md` with what a proper `demo` Stage would need.