### PR TITLE
feat(headroom): promote demo then prod through Kargo, lock down demo egress

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,12 +4,6 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Apps
 
-### `headroom-demo` image tag is bumped by hand
-- **What:** The public demo at `headroom.nordbye.it` runs the same `ghcr.io/mortennordbye/headroom` image as the private instance, but its tag is pinned in its own `kustomization.yaml` and is not promoted by anything. The demo therefore drifts behind the private instance until someone edits the tag.
-- **Why deferred:** The `headroom-cd` Kargo project is single-stage and hardcodes `appPath: k8s/talos/apps/headroom`. Giving the demo automatic promotion means adding a second Stage (plus its own smoke-test AnalysisTemplate against the public URL) and authorizing it in the ApplicationSet `templatePatch`, whose current convention only covers `<app>` and `<app>-stage`. That is a real change to the CD topology and was out of scope for standing the demo up.
-- **Unblock:** Either add a `demo` Stage to `headroom-cd` that promotes the same Freight into `k8s/talos/apps/headroom-demo` (and extend the `templatePatch` naming convention to cover `<app>-demo`), or accept manual bumps and just remember them when releasing.
-- **Where:** `k8s/talos/apps/headroom-demo/kustomization.yaml` (`images.newTag`), `k8s/talos/infra/kargo-projects/headroom.yaml`, `k8s/talos/infra/argocd/apps.yaml` (`templatePatch`).
-
 ### Remove the old `workout` app after logeverylift cutover
 - **What:** `logeverylift.com` was cut over from the old `workout` app to the renamed `logeverylift` app (PR #369, 2026-07-18). The `workout` namespace, Deployment, Postgres, and PVC are still present — both `workout-app` and `postgres` are scaled to 0 (ArgoCD ignores `/spec/replicas`; also declared in the manifests). The data is preserved on `postgres-pvc`; scale `postgres` back to 1 to re-access it. Nothing routes to it.
 - **Why deferred:** Kept as rollback until the owner has used `logeverylift.com` for a while and confirmed all data/history is intact. Deleting is one-way (prunes the namespace + PVC).

--- a/k8s/talos/apps/headroom-demo/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/headroom-demo/ciliumnetworkpolicy.yaml
@@ -23,3 +23,26 @@ spec:
     - fromEntities:
         - host
         - health
+  # Egress is allowlisted rather than left open, because this pod is the one
+  # reachable from the internet. Adding rules here at all makes egress
+  # deny-by-default for this endpoint, which is the point: the app's only other
+  # outbound destination is api.enablebanking.com, and that is deliberately
+  # absent. The bank routes are already refused in demo mode, so this is the
+  # second, independent reason a demo can never reach a bank on the owner's
+  # credentials — a gate regression alone would not be enough.
+  egress:
+    # DNS to CoreDNS. Required for the toFQDNs rules below to resolve.
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports: [{ port: "53", protocol: ANY }]
+    # The public statistics the app proxies and caches: SSB (inflation, square
+    # metre prices, wage stats) and Norges Bank (policy rate). These are what
+    # make the demo's Forecast and Property pages show real figures.
+    - toFQDNs:
+        - matchName: "data.ssb.no"
+        - matchName: "data.norges-bank.no"
+      toPorts:
+        - ports: [{ port: "443", protocol: TCP }]

--- a/k8s/talos/apps/headroom-demo/deployment.yaml
+++ b/k8s/talos/apps/headroom-demo/deployment.yaml
@@ -33,11 +33,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: headroom
-          # Pinned tag, owned by kustomization.yaml (`images.newTag`). This app is
-          # deliberately NOT in the Kargo pipeline — that promotes only
-          # k8s/talos/apps/headroom — so refreshing the demo is a manual tag bump.
-          # The tag MUST be a build that contains DEMO_MODE support; an older
-          # image would ignore DEMO_MODE and serve a writable, empty app publicly.
+          # Pinned tag, owned by kustomization.yaml (`images.newTag`), which the
+          # Kargo `demo` Stage rewrites. This inline value is only the fallback
+          # for a raw `kubectl apply` without kustomize. An image built without
+          # DEMO_MODE support would ignore the env var below and serve a writable
+          # app publicly — the demo smoke test asserts against exactly that.
           image: ghcr.io/mortennordbye/headroom:sha-32a1389
           imagePullPolicy: IfNotPresent
           env:

--- a/k8s/talos/apps/headroom-demo/kustomization.yaml
+++ b/k8s/talos/apps/headroom-demo/kustomization.yaml
@@ -12,9 +12,9 @@ resources:
 # Public read-only demo of the headroom app, on the same image as the private
 # instance but with DEMO_MODE=1 (see deployment.yaml).
 #
-# Not managed by Kargo: the headroom-cd Warehouse/promotion only rewrites
-# k8s/talos/apps/headroom. Bump the tag here by hand to refresh the demo, and
-# only to a build that actually contains DEMO_MODE support.
+# newTag is owned by Kargo: the headroom-cd `demo` Stage rewrites it via the
+# kustomize-set-image promotion step and pushes straight to main, ahead of prod.
+# Don't hand-edit it.
 images:
 - name: ghcr.io/mortennordbye/headroom
   newTag: 0.0.305

--- a/k8s/talos/infra/argocd/apps.yaml
+++ b/k8s/talos/infra/argocd/apps.yaml
@@ -53,9 +53,10 @@ spec:
   # Authorize Kargo to sync the apps it promotes. templatePatch is a Go-templated
   # merge patch (a string), so structural conditionals are valid here in a way
   # they are not inside the parsed `template` above. Onboarding a new Kargo app is
-  # a one-word addition to the list below: its prod app "<app>" and stage app
-  # "<app>-stage" get authorized-stage <app>-cd:prod / <app>-cd:stage. Every
-  # non-Kargo app matches nothing and renders no patch.
+  # a one-word addition to the list below: its prod app "<app>", stage app
+  # "<app>-stage" and demo app "<app>-demo" get authorized-stage <app>-cd:prod /
+  # <app>-cd:stage / <app>-cd:demo. A suffix an app doesn't use matches no
+  # directory, so it renders nothing; every non-Kargo app matches nothing at all.
   templatePatch: |
     {{- $base := .path.basename }}
     {{- range $app := list "portfolio" "blog" "logeverylift" "headroom" "verksted" "reelsmith" }}
@@ -67,5 +68,9 @@ spec:
     metadata:
       annotations:
         kargo.akuity.io/authorized-stage: {{ $app }}-cd:stage
+    {{- else if eq $base (printf "%s-demo" $app) }}
+    metadata:
+      annotations:
+        kargo.akuity.io/authorized-stage: {{ $app }}-cd:demo
     {{- end }}
     {{- end }}

--- a/k8s/talos/infra/kargo-projects/headroom.yaml
+++ b/k8s/talos/infra/kargo-projects/headroom.yaml
@@ -1,8 +1,16 @@
-# Kargo project for the headroom app. Single-environment (no stage overlay), so
-# the whole pipeline is one auto-promotion: the headroom CI pushes a new image ->
-# Warehouse creates Freight -> Kargo auto-opens a homelab PR -> merging it deploys
-# prod -> the smoke test verifies. Mirrors logeverylift.yaml. The image source and
-# CI live in the separate mortennordbye/headroom repo.
+# Kargo project for the headroom app. Two stages off one image: the headroom CI
+# pushes a new image -> Warehouse creates Freight -> `demo` deploys it straight
+# to the public read-only demo and smoke-tests it -> only then does that Freight
+# become available to `prod`, which auto-opens a homelab PR whose merge deploys
+# the private instance. The image source and CI live in the separate
+# mortennordbye/headroom repo.
+#
+# The demo is the canary: it runs the same image with DEMO_MODE=1, holds no real
+# data, and is behind a public URL that can be probed directly — so a build that
+# fails to serve, or that has lost the read-only gate, is caught there before it
+# can reach the instance holding actual finances. Coverage is partial by nature
+# (the demo never exercises the write path, since it has none), which is why prod
+# keeps its own smoke test and its PR gate.
 
 # --- Project namespace ------------------------------------------------------
 # Named `headroom-cd` (not `headroom`) to avoid colliding with the app namespace.
@@ -22,8 +30,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 ---
-# Single Stage: a new Freight is auto-promoted to `prod` via promote-via-pr, which
-# opens a homelab PR and blocks on the merge. Merging the PR is the only gate.
+# Both stages auto-promote. `demo` pushes straight to main (it is a demo — no
+# review gate buys anything, and a fast public canary is the point). `prod`
+# auto-promotes only Freight that already passed `demo`, and does so via
+# promote-via-pr, so merging that PR stays the gate on the private instance.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: ProjectConfig
 metadata:
@@ -33,6 +43,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   promotionPolicies:
+    - stage: demo
+      autoPromotionEnabled: true
     - stage: prod
       autoPromotionEnabled: true
 ---
@@ -105,6 +117,62 @@ spec:
         strictSemvers: true
         discoveryLimit: 20
 ---
+# demo verification. More than a liveness curl: because this instance is exposed
+# to the internet, the smoke test asserts the properties that make that safe, so
+# a build which regresses them fails here and never becomes eligible for prod.
+#   1. the app shell serves at all
+#   2. the instance really is in demo mode (an image built without DEMO_MODE
+#      support would silently ignore the env var and serve a writable app)
+#   3. writes are actually refused
+#   4. the bank namespace is actually closed — those routes reach Enable Banking
+#      on the app's own credentials, so they must never answer here
+# Public URL with a real Let's Encrypt cert, so no -k (portfolio's prod smoke
+# test hits nordbye.it the same way). No cold start to wait out: the demo runs a
+# fixed replica.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: headroom-demo-smoke
+  namespace: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  metrics:
+    - name: headroom-demo-read-only
+      count: 1
+      provider:
+        job:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 180
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: smoke
+                    image: curlimages/curl:8.21.0
+                    command:
+                      - /bin/sh
+                      - -c
+                      - |
+                        set -eu
+                        BASE=https://headroom.nordbye.it
+                        echo "1/4 app shell serves"
+                        curl -fsS --retry 10 --retry-delay 6 --retry-all-errors \
+                          -o /dev/null "$BASE/"
+                        echo "2/4 instance reports demo mode"
+                        curl -fsS "$BASE/api/config" | grep -q '"demoMode":true'
+                        echo "3/4 writes are refused"
+                        code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+                          -H 'Content-Type: application/json' \
+                          -d '{"income":1,"assets":{},"fixedExpenses":[],"dailyTransactions":[]}' \
+                          "$BASE/api/data")
+                        [ "$code" = "403" ] || { echo "POST /api/data returned $code, expected 403"; exit 1; }
+                        echo "4/4 bank namespace is closed"
+                        code=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/bank/status")
+                        [ "$code" = "403" ] || { echo "GET /api/bank/status returned $code, expected 403"; exit 1; }
+                        echo "demo is serving and read-only"
+---
 # prod verification: a one-shot Job that curls the app URL and fails on any
 # non-2xx. headroom is on the private gateway with an internal cert, so use the
 # internal hostname and -k. headroom scales to zero (KEDA), so the request also
@@ -139,10 +207,52 @@ spec:
                         -o /dev/null -w '%{http_code}\n'
                         https://headroom.local.bigd.no/
 ---
-# prod: the only Stage. Receives Freight straight from the Warehouse
-# (sources.direct), auto-promoted per ProjectConfig through promote-via-pr, then
-# verified by the smoke test. promote-via-pr opens a homelab PR and waits for the
-# merge, so the PR review is the deploy gate.
+# demo: receives new Freight straight from the Warehouse (auto-promoted per
+# ProjectConfig) and pushes it to main directly via promote-to-argocd — no PR,
+# because a public demo with no data behind it has nothing a review would
+# protect, and a fast canary is the whole point. Only Freight that passes the
+# read-only smoke test above becomes available to prod.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: demo
+  namespace: headroom-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    # Cosmetic UI colour, kept identical across apps: the pre-prod stage = blue.
+    kargo.akuity.io/color: "#0284c7"
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse; verified read-only on headroom.nordbye.it."
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: headroom
+      sources:
+        direct: true
+  verification:
+    analysisTemplates:
+      - name: headroom-demo-smoke
+  promotionTemplate:
+    spec:
+      vars:
+        - name: appName
+          value: headroom
+        - name: appPath
+          value: k8s/talos/apps/headroom-demo
+        - name: imageRepo
+          value: ghcr.io/mortennordbye/headroom
+        - name: argocdApp
+          value: headroom-demo
+      steps:
+        - task:
+            name: promote-to-argocd
+            kind: ClusterPromotionTask
+---
+# prod: the private instance, holding real financial data. Receives only Freight
+# already verified in `demo` (sources.stages), auto-promoted per ProjectConfig
+# through promote-via-pr, then verified by its own smoke test. promote-via-pr
+# opens a homelab PR and waits for the merge, so the PR review stays the deploy
+# gate on top of the demo canary.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -152,14 +262,15 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     # Cosmetic UI colour, kept identical across apps: prod = red.
     kargo.akuity.io/color: "#e11d48"
-    kargo.akuity.io/description: "Auto-promoted from the Warehouse via a homelab PR; smoke-tested on headroom.local.bigd.no after merge."
+    kargo.akuity.io/description: "Demo-verified Freight, promoted via a homelab PR; smoke-tested on headroom.local.bigd.no after merge."
 spec:
   requestedFreight:
     - origin:
         kind: Warehouse
         name: headroom
       sources:
-        direct: true
+        stages:
+          - demo
   verification:
     analysisTemplates:
       - name: headroom-prod-smoke


### PR DESCRIPTION
## Why

The demo was pinned by hand and outside the pipeline, so it drifted behind prod
the moment prod moved. Both instances run the same image, so this makes it one
pipeline instead of two — and turns the demo into a canary for prod rather than
a thing to remember.

## Topology

```
Warehouse ──▶ demo ──▶ prod
              │         │
   promote-to-argocd   promote-via-pr
   (push to main)      (PR merge = gate)
```

- **`demo`** takes new Freight directly and pushes to main. No PR gate: a public
  demo with no data behind it has nothing a review would protect, and a fast
  canary is the point.
- **`prod`** now sources from `stages: [demo]` instead of `direct: true`, so only
  Freight that passed the demo reaches it. It keeps `promote-via-pr`, so merging
  that PR is still the gate on the instance holding real financial data.

## The demo smoke test is the leak guard

Because the demo is publicly probeable, its verification asserts the properties
that make exposing it safe, rather than just curling for a 200:

1. the app shell serves
2. `/api/config` reports `demoMode: true`
3. `POST /api/data` → `403`
4. `GET /api/bank/status` → `403`

An image built without `DEMO_MODE` support would silently ignore the env var and
serve a **writable public app**. That now fails verification and blocks the prod
promotion sitting behind it.

Coverage is partial by nature — the demo never exercises the write path, since it
has none — so prod keeps its own smoke test and its PR gate.

## Egress lockdown

The demo pod's egress is now allowlisted to CoreDNS plus `data.ssb.no` and
`data.norges-bank.no` (the public statistics that make Forecast and Property show
real figures). Naming any egress makes it deny-by-default for that endpoint,
which is the point: `api.enablebanking.com` is deliberately absent, so a demo
cannot reach a bank on the owner's credentials even if the route gate regressed.
Ingress already allowed only Traefik.

## Verification

**Smoke test run in the exact image Kargo uses** (`curlimages/curl:8.21.0`):

- against the live demo → all four assertions pass, exit 0
- against a **non-demo** `0.0.305` container → fails at assertion 2, exit 1

So the gate has teeth; it is not a test that always passes.

**Rendered topology** from the committed YAML:

| Stage | sources | task | appPath | verify |
|---|---|---|---|---|
| `demo` | `direct: true` | `promote-to-argocd` | `apps/headroom-demo` | `headroom-demo-smoke` |
| `prod` | `stages: [demo]` | `promote-via-pr` | `apps/headroom` | `headroom-prod-smoke` |

**`templatePatch` rendered** with a Go template evaluator — `headroom-demo` →
`headroom-cd:demo`; `headroom`, `portfolio`, `portfolio-stage`, `blog-stage`
unchanged; `mealie` and `it-tools` still render no patch.

**Leak audit of the rendered demo manifests:** no Secret/ExternalSecret/ServiceAccount,
env is only `DEMO_MODE` and `ALLOWED_HOSTS` (no `valueFrom`, no `envFrom`), volumes
are `emptyDir` only with zero PVC refs, `automountServiceAccountToken: false`.
Live probes of the demo return `null` data, empty history, and no auth material.

Both instances are at `0.0.305` right now, so this changes topology from a
consistent baseline. Resolves the backlog item added when the demo shipped.

`kubectl kustomize` renders `kargo-projects` and `apps/headroom-demo` cleanly; all
changed files parse. I could not server-side dry-run — no reachable context for
the Talos cluster from here.