### PR TITLE
fix(verksted): give dind the repos, and stop it flooding Falco

### DIFF
--- a/k8s/talos/apps/verksted/deployment.yaml
+++ b/k8s/talos/apps/verksted/deployment.yaml
@@ -110,6 +110,13 @@ spec:
             # prunes it daily. Kept off the NFS PVC (overlayfs needs local disk).
             - name: dind-storage
               mountPath: /var/lib/docker
+            # The same PVC the app has, at the same path. A bind mount is
+            # resolved by the daemon in its own filesystem, so without this a
+            # session running `docker compose up` in /data/repos/<project> gets
+            # an empty directory mounted over its source — and docker creates
+            # the missing path rather than failing, so nothing says why.
+            - name: data
+              mountPath: /data
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/k8s/talos/infra/falco/values.yaml
+++ b/k8s/talos/infra/falco/values.yaml
@@ -54,9 +54,24 @@ customRules:
       override:
         condition: replace
 
-    # cilium-agent opens AF_PACKET sockets as part of normal datapath setup;
-    # scoped to the cilium image so any other container still alerts.
-    - macro: user_known_packet_socket_binaries
-      condition: (proc.name=cilium-agent and container.image.repository=quay.io/cilium/cilium)
+    # cilium-agent opens AF_PACKET sockets as part of normal datapath setup, and
+    # so does the dockerd in verksted's dind sidecar every time it wires up the
+    # network for a container an agent session starts — about once a minute,
+    # which is noise loud enough to bury a real notice.
+    #
+    # Appended to the rule rather than filled into its template hook, unlike the
+    # tunings above: upstream declares user_known_packet_socket_binaries as a
+    # *list* consumed by `proc.name in (...)`, so filling it can only ever say
+    # "this binary name, anywhere". Exempting dockerd cluster-wide is a wider
+    # hole than either daemon needs. This keeps each exemption pinned to the
+    # image it belongs to, so the same binary in any other container still
+    # alerts. (The entry here was previously written as a macro override, which
+    # silently did nothing at all: it declared a second thing under the list's
+    # name, and no rule ever referred to it.)
+    - rule: Packet socket created in container
+      condition: >
+        and not (proc.name=cilium-agent and container.image.repository=quay.io/cilium/cilium)
+        and not (proc.name=dockerd and container.image.repository=docker.io/library/docker
+                 and k8s.ns.name=verksted)
       override:
-        condition: replace
+        condition: append


### PR DESCRIPTION
## Why

Two problems in one pod.

**Bind mounts land empty.** The dind sidecar mounted only its own layer store, so `/data` did not exist in the daemon's filesystem. Bind mounts are resolved by the daemon, and docker creates a missing source path rather than failing — so an agent session running `docker compose up` in `/data/repos/<project>` got an empty directory mounted over its source, with no error anywhere. Builds worked (the context streams over the socket), which made it read as intermittent rather than structural.

**Falco noise.** That daemon creates an AF_PACKET socket whenever it wires up the network for a container a session starts: roughly one Notice to Discord per minute.

## What

- `data` PVC mounted into the dind sidecar at `/data`, the same path the app sees it. The pod is already single-replica on a `Recreate` strategy, so both containers can hold the RWO claim.
- The `Packet socket created in container` exemption rewritten as a rule condition append covering both cilium-agent and dockerd.

## The Falco tuning was already broken

The entry for this rule has been in `values.yaml` for a while and has never done anything. Upstream declares `user_known_packet_socket_binaries` as a **list**, consumed by `not proc.name in (...)` — not as a macro. Overriding it as a macro declares a second thing under the list's name that no rule refers to, and Falco says so on validation:

```
LOAD_UNUSED_MACRO (Unused macro): Macro not referred to by any other rule/macro
```

Filling the list correctly would work, but a list can only say "this binary name, anywhere", and exempting `dockerd` cluster-wide is wider than this needs. Appending to the rule keeps each exemption pinned to the image it belongs to — which is what the original comment already said it wanted — and dockerd additionally to the one namespace that runs a daemon.

The other two tunings in that file are genuine macros upstream and are unaffected.

## Verification

Rendered the tuning block and validated it against the stock ruleset with falco 0.44.1, the appVersion behind chart 9.1.0:

```
/etc/falco/falco_rules.yaml: Ok
/t/tuning.yaml: Ok
```

The previous version of the same file reported the unused-macro warning above.

`kustomize build k8s/talos/apps/verksted` renders the sidecar with both mounts:

```
volumeMounts:
- mountPath: /var/lib/docker
  name: dind-storage
- mountPath: /data
  name: data
```

Pairs with mortennordbye/verksted#36, which fixes the same bind-mount problem in the dev compose stack and ships the in-pod documentation for it.