### PR TITLE
feat(verksted): mount the reelsmith private half

### DIFF
--- a/k8s/talos/apps/verksted/deployment.yaml
+++ b/k8s/talos/apps/verksted/deployment.yaml
@@ -83,6 +83,16 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            # The half of reelsmith that is not in git: the editorial profile,
+            # the voice reference recording, and the cooldown and star history
+            # stores. Kept off the PVC so the workbench can be rebuilt without
+            # taking the account's identity with it, and so the NAS backs it up
+            # — the voice recording exists nowhere else and is not
+            # reconstructible. subPath, like audiobookshelf, so the container
+            # sees only this folder rather than the whole media share.
+            - name: shared-data
+              mountPath: /mnt/reelsmith
+              subPath: media/reelsmith
         # Docker daemon for the agent sessions. Privileged is inherent to dind;
         # shares the pod netns so the app reaches it at localhost:2375.
         - name: dind
@@ -121,5 +131,10 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: verksted-data
+        - name: shared-data
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data
+            readOnly: false
         - name: dind-storage
           emptyDir: {}


### PR DESCRIPTION
## Why

The half of reelsmith that is not in git: the editorial profile, the voice reference recording, and the cooldown and star history stores. A session in that project cannot write copy without `PROFILE.md`, and cannot use the cloned voice at all without the recording. First step toward running that pipeline on the pod instead of the laptop.

## What

Mounts `nas.local.bigd.no:/volume1/shared-data` at `/mnt/reelsmith` with `subPath: media/reelsmith`, matching the audiobookshelf pattern so the container sees only that folder rather than the whole media share.

On the NAS rather than the PVC for two reasons: the workbench can be rebuilt without taking the account's identity with it, and the recording gets backed up. It is biometric, exists nowhere else, and is not reconstructible.

The Instagram token is deliberately absent. The gateway holds the token that publishes and already refreshes it on a daily loop, so the pipeline needs no copy of it on a media share.

## Verification

- `/volume1/shared-data/media/reelsmith` exists and is already seeded: `PROFILE.md`, `ref/morten.wav`, `ref/RECORD-THIS.txt`, `data/star_history.json`, `data/used_repos.json`. Sizes checked against the originals.
- `kubectl kustomize` renders cleanly with the mount and volume in place.