### PR TITLE
chore(renovate): fix security automerge and close group gaps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,13 @@
     "every weekend"
   ],
   "labels": ["dependencies"],
+  "automergeStrategy": "squash",
+  "vulnerabilityAlerts": {
+    "description": "Security fixes bypass group stability windows and the nightly schedule",
+    "automerge": true,
+    "minimumReleaseAge": "3 days",
+    "addLabels": ["security", "automerge"]
+  },
   "kubernetes": {
     "managerFilePatterns": ["/k8s/.*\\.ya?ml$/"]
   },
@@ -56,10 +63,13 @@
       "addLabels": ["helm", "networking"]
     },
     {
-      "description": "Helm Platform: argo-cd, reloader, keda, metrics-server, external-secrets, csi drivers",
+      "description": "Helm Platform: argo-cd, argo-rollouts, kargo, reloader, keda, metrics-server, external-secrets, csi drivers",
       "matchManagers": ["kustomize"],
       "matchPackageNames": [
         "argo-cd",
+        "argo-rollouts",
+        "kargo",
+        "ghcr.io/akuity/kargo-charts/kargo",
         "reloader",
         "keda",
         "keda-add-ons-http",
@@ -224,14 +234,6 @@
       "groupSlug": "terraform",
       "automerge": false,
       "addLabels": ["terraform"]
-    },
-    {
-      "description": "Security vulnerabilities: fast-track automerge",
-      "matchDepTypes": ["vulnerabilities"],
-      "automerge": true,
-      "automergeType": "pr",
-      "minimumReleaseAge": "3 days",
-      "addLabels": ["security", "automerge"]
     },
     {
       "description": "Major updates always require manual review",


### PR DESCRIPTION
Three fixes to `renovate.json`, plus two repo settings changed outside the repo.

### Security updates never automerged
The `Security vulnerabilities: fast-track automerge` packageRule used `matchDepTypes: ["vulnerabilities"]`. `matchDepTypes` matches dependency *types* (`dependencies`, `devDependencies`, …) — never `vulnerabilities` — so the rule has never fired. CVE bumps fell through to whatever group rule matched the package and inherited its 7- or 14-day `minimumReleaseAge`.

Replaced with a top-level `vulnerabilityAlerts` block, which is where Renovate actually handles security updates. Keeps the 3-day stability intent and additionally bypasses the nightly schedule.

### argo-rollouts and kargo matched no group
Both are helm charts in `k8s/talos/infra/*/kustomization.yaml` but appeared in no `matchPackageNames` list, so they got defaults: ungrouped, no stability window, no automerge. #413 is the visible symptom. `kargo` is listed under both its chart name and its OCI package name since it is pulled from `oci://ghcr.io/akuity/kargo-charts`.

### automergeStrategy
Squash is the only merge method this repo allows. Naming it explicitly avoids platform automerge picking an unavailable method.

---

Also changed in repo settings (not in this diff):
- **Dependabot automated security fixes: disabled.** It was on with no `.github/dependabot.yml`, so every advisory produced two PRs — #577 and #578 are the same pypdf bump from both bots. Renovate covers the same advisories.
- **Auto-merge: enabled.** `allow_auto_merge` was false while the config sets `platformAutomerge: true`, so Renovate fell back to merging itself and could only do so inside its 22:00–05:00 window.

Validated with `renovate-config-validator`.