### PR TITLE
chore(deps): fix dependency automation gaps, clear all security alerts, harden the blog base image

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,18 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Apps
 
+### Flip blog prod to the unprivileged nginx port
+- **What:** `blog/Dockerfile` now serves from `nginxinc/nginx-unprivileged` on port 8080, and `blog-stage` was moved to match. Blog **prod** is deliberately still on port 80 everywhere: `deployment.yaml` (`containerPort`), `service.yaml` (`targetPort`), and both `toPorts` rules in `ciliumnetworkpolicy.yaml`.
+- **Why deferred:** Prod runs an older image (`newTag: 0.0.96`) that still listens on 80. Flipping the prod manifests before that image is promoted would point the Service and the network policy at a port nothing is listening on, taking the blog down until the promotion lands. Kargo's prod stage uses `promote-via-pr`, so prod does not move on its own — the two changes have to land together.
+- **Unblock:** When the Kargo prod promotion PR for the first image built after this change appears, add the port edits to that same PR before merging: `containerPort: 8080`, `targetPort: 8080`, and both CiliumNetworkPolicy `toPorts` entries to `"8080"`. Mirror the `securityContext`, `/tmp` emptyDir and `automountServiceAccountToken: false` from `blog-stage/deployment.yaml`. Verify with `kubectl diff -k k8s/talos/apps/blog --server-side --field-manager=argocd-controller` (the default field manager reports a spurious duplicate-port error).
+- **Where:** `k8s/talos/apps/blog/{deployment,service,ciliumnetworkpolicy}.yaml`, mirroring `k8s/talos/apps/blog-stage/`.
+
+### Orphaned huntarr manifest
+- **What:** `k8s/talos/apps/arr-stack/huntarr.yaml` is commented out of the arr-stack `kustomization.yaml`, nothing is running in the cluster, and `ghcr.io/plexguide/huntarr` no longer resolves in any registry (the upstream repo is gone). Renovate is now explicitly disabled for that image, which was the source of a permanent "Package lookup failures" problem on the dependency dashboard.
+- **Why deferred:** Deleting someone's disabled app manifest is a judgement call, not a dependency fix. The Renovate disable removes the noise either way.
+- **Unblock:** Decide whether huntarr comes back. If yes, repoint the image at a maintained fork and drop the disable rule from `renovate.json`. If no, delete the manifest and the commented line, and drop the disable rule.
+- **Where:** `k8s/talos/apps/arr-stack/huntarr.yaml`, `k8s/talos/apps/arr-stack/kustomization.yaml` (line 15), `renovate.json` (huntarr disable rule).
+
 ### Remove the old `workout` app after logeverylift cutover
 - **What:** `logeverylift.com` was cut over from the old `workout` app to the renamed `logeverylift` app (PR #369, 2026-07-18). The `workout` namespace, Deployment, Postgres, and PVC are still present — both `workout-app` and `postgres` are scaled to 0 (ArgoCD ignores `/spec/replicas`; also declared in the manifests). The data is preserved on `postgres-pvc`; scale `postgres` back to 1 to re-access it. Nothing routes to it.
 - **Why deferred:** Kept as rollback until the owner has used `logeverylift.com` for a while and confirmed all data/history is intact. Deleting is one-way (prunes the namespace + PVC).

--- a/blog/Dockerfile
+++ b/blog/Dockerfile
@@ -20,10 +20,18 @@ COPY . .
 RUN hugo --minify --gc -d /target
 
 # --- Stage 2: Serve with Nginx ---
-FROM nginx:alpine
+# nginx-unprivileged rather than stock nginx: it runs as uid 101 with no
+# master process running as root, so the Deployment can assert runAsNonRoot
+# and drop every capability. Same image the bigd app already uses. Pinned to
+# a minor tag so Renovate tracks it — the previous `nginx:alpine` carried no
+# version at all, which meant no bot was watching the runtime base image.
+FROM nginxinc/nginx-unprivileged:1.31-alpine
 
-# Clean default Nginx files
+# The base image ships a default index.html and 50x.html. Clearing them keeps
+# the served root exactly what Hugo produced, and nothing else.
+USER root
 RUN rm -rf /usr/share/nginx/html/*
+USER 101
 
 # Copy custom Nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
@@ -31,5 +39,8 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copy build artifacts
 COPY --from=builder /target /usr/share/nginx/html
 
-EXPOSE 80
+# 8080, not 80: an unprivileged process cannot bind a port below 1024, and
+# granting NET_BIND_SERVICE back would defeat the point. The Service maps
+# its own port 80 to this, so nothing upstream of the Service changes.
+EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/blog/nginx.conf
+++ b/blog/nginx.conf
@@ -1,5 +1,6 @@
 server {
-    listen 80;
+    # 8080 because the image runs unprivileged (uid 101) and cannot bind <1024.
+    listen 8080;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;

--- a/docs/postgres-18-migration.md
+++ b/docs/postgres-18-migration.md
@@ -66,16 +66,13 @@ kubectl scale deploy/logeverylift-app -n logeverylift --replicas=0
 kubectl rollout status deploy/logeverylift-app -n logeverylift --timeout=60s
 ```
 
-ArgoCD has `selfHeal: true` on this app. It will try to scale the app back up,
-so do not leave a long gap between this step and step 5. If it fights you,
-suspend auto-sync for the duration:
+ArgoCD has `selfHeal: true`, but the Application also carries
+`ignoreDifferences` on `/spec/replicas` for Deployments, with
+`RespectIgnoreDifferences=true` in `syncOptions`. Scaling therefore sticks and
+does not need auto-sync suspended.
 
-```bash
-kubectl patch application logeverylift -n argocd --type=merge \
-  -p '{"spec":{"syncPolicy":{"automated":null}}}'
-```
-
-Remember to put it back at step 7.
+The same rule cuts the other way at step 5: a synced Deployment will *not* be
+scaled back up for you. Both scale-ups below are manual on purpose.
 
 ### 2. Take the dump
 
@@ -121,6 +118,15 @@ Merge the PR that switches `k8s/talos/apps/logeverylift/postgres.yaml` to
 ```bash
 kubectl -n argocd annotate application logeverylift \
   argocd.argoproj.io/refresh=hard --overwrite
+```
+
+Wait for the Application to report `Synced`, then scale Postgres back up —
+ArgoCD ignores `/spec/replicas`, so the sync alone leaves it at 0:
+
+```bash
+kubectl get application logeverylift -n argocd \
+  -o jsonpath='{.status.sync.status}{"\n"}'
+kubectl scale deploy/postgres -n logeverylift --replicas=1
 kubectl rollout status deploy/postgres -n logeverylift --timeout=180s
 ```
 
@@ -172,12 +178,11 @@ kubectl exec -n logeverylift "$POD18" -- psql -U postgres -d logeverylift_db \
   -tAc "select count(*) from workout_sets;"   # expect 1685
 ```
 
-Then bring the app back and re-enable auto-sync if you suspended it:
+Then bring the app back:
 
 ```bash
 kubectl scale deploy/logeverylift-app -n logeverylift --replicas=1
-kubectl patch application logeverylift -n argocd --type=merge \
-  -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+kubectl rollout status deploy/logeverylift-app -n logeverylift --timeout=120s
 ```
 
 Log in to logeverylift.com and confirm real workout history renders.

--- a/docs/postgres-18-migration.md
+++ b/docs/postgres-18-migration.md
@@ -1,0 +1,202 @@
+# Postgres 16 to 18: logeverylift
+
+Runbook for moving `logeverylift`'s Postgres from `16-alpine` to `18-alpine`.
+Written 2026-08-09. Expect roughly 10 minutes of downtime for the app.
+
+The manifest change lives in its own PR so it can be merged at step 5, not
+before. Merging it early takes the app down until the restore finishes.
+
+## Why this is not just an image bump
+
+Two things changed between 16 and 18, and both matter here.
+
+Postgres 18 cannot read a Postgres 16 data directory. The on-disk format is
+major-version specific, so the data has to be dumped out of 16 and loaded into
+a freshly initialised 18 cluster.
+
+The Docker image also moved its data directory. On 16, `PGDATA` is
+`/var/lib/postgresql/data`, which is exactly where this Deployment mounts its
+PVC. On 18 it is `/var/lib/postgresql/18/docker`, and the recommended layout is
+to mount a single volume at the parent `/var/lib/postgresql` so future major
+versions land in sibling directories and `pg_upgrade --link` stays possible.
+
+Leaving the mount path alone and only bumping the tag does not silently lose
+data — the 18 image detects the 16 cluster at the old path and refuses to
+start, exiting 1 with an explanation. It is a loud failure, not a quiet one,
+but it is still an outage, so the mount path moves as part of this change.
+
+## What the database looks like
+
+Checked against the live cluster on 2026-08-09:
+
+- 10 MB total, 26 tables in `public`
+- one login role, `postgres`
+- one extension, `plpgsql` 1.0
+- largest tables: `workout_sets` (1685 rows), `exercise_prs` (521),
+  `program_sets` (431)
+
+Small enough that `pg_dumpall` piped through `kubectl exec` is the right tool.
+There are no migration Jobs or a backup PVC here on purpose: for 10 MB they
+would be more moving parts than the thing they automate, and streaming the dump
+to your own machine gives an off-cluster copy, which a PVC-based Job would not.
+Keep that file — `BACKLOG.md` already records one previous dump that survives
+only in a session scratchpad.
+
+## Rollback position
+
+The existing `postgres-pvc` is left untouched and still declared in
+`postgres.yaml`. The 18 cluster initialises onto a new `postgres-pvc-18`. If
+anything goes wrong, revert the manifest PR: the pod comes back on 16 against
+the original PVC with the original data. Nothing in this procedure writes to
+the 16 volume.
+
+## Procedure
+
+Set the context once. The default kubeconfig points at work AKS, not this
+cluster:
+
+```bash
+export KUBECONFIG=~/Documents/github/Homelab/terraform/proxmox/hyper-cluster/k8s/talos/kubeconfig
+```
+
+### 1. Stop writes
+
+```bash
+kubectl scale deploy/logeverylift-app -n logeverylift --replicas=0
+kubectl rollout status deploy/logeverylift-app -n logeverylift --timeout=60s
+```
+
+ArgoCD has `selfHeal: true` on this app. It will try to scale the app back up,
+so do not leave a long gap between this step and step 5. If it fights you,
+suspend auto-sync for the duration:
+
+```bash
+kubectl patch application logeverylift -n argocd --type=merge \
+  -p '{"spec":{"syncPolicy":{"automated":null}}}'
+```
+
+Remember to put it back at step 7.
+
+### 2. Take the dump
+
+```bash
+POD=$(kubectl get pod -n logeverylift -l app=postgres -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n logeverylift "$POD" -- pg_dumpall -U postgres \
+  > ~/logeverylift-pg16-$(date +%Y%m%d).sql
+```
+
+Check it before going any further. A truncated dump that nobody looked at is
+the only way this procedure loses data:
+
+```bash
+DUMP=~/logeverylift-pg16-$(date +%Y%m%d).sql
+wc -l "$DUMP"                      # expect a few thousand lines
+grep -c "^CREATE TABLE" "$DUMP"    # expect 27
+tail -1 "$DUMP"                    # expect: PostgreSQL database dump complete
+```
+
+Put a copy somewhere durable now, not later.
+
+### 3. Record what the data should look like afterwards
+
+```bash
+kubectl exec -n logeverylift "$POD" -- psql -U postgres -d logeverylift_db \
+  -tAc "select relname, n_live_tup from pg_stat_user_tables order by relname;" \
+  | tee ~/logeverylift-rowcounts-before.txt
+```
+
+### 4. Scale Postgres down
+
+```bash
+kubectl scale deploy/postgres -n logeverylift --replicas=0
+kubectl rollout status deploy/postgres -n logeverylift --timeout=60s
+```
+
+### 5. Merge the manifest PR
+
+Merge the PR that switches `k8s/talos/apps/logeverylift/postgres.yaml` to
+`postgres:18-alpine`, adds `postgres-pvc-18`, and moves the mount to
+`/var/lib/postgresql`. Then let ArgoCD sync, or force it:
+
+```bash
+kubectl -n argocd annotate application logeverylift \
+  argocd.argoproj.io/refresh=hard --overwrite
+kubectl rollout status deploy/postgres -n logeverylift --timeout=180s
+```
+
+Wait for the new pod to be genuinely ready before restoring — the image starts
+a temporary server during initialisation and briefly rejects connections:
+
+```bash
+POD18=$(kubectl get pod -n logeverylift -l app=postgres -o jsonpath='{.items[0].metadata.name}')
+until kubectl exec -n logeverylift "$POD18" -- pg_isready -U postgres 2>/dev/null | grep -q accepting; do sleep 2; done
+kubectl exec -n logeverylift "$POD18" -- psql -U postgres -tAc "show data_directory;"
+# expect /var/lib/postgresql/18/docker
+```
+
+### 6. Restore
+
+```bash
+kubectl exec -i -n logeverylift "$POD18" -- psql -U postgres < "$DUMP"
+```
+
+Two errors are expected and harmless:
+
+```
+ERROR:  database "logeverylift_db" already exists
+ERROR:  role "postgres" already exists
+```
+
+Both objects are created by `POSTGRES_DB` and `POSTGRES_USER` before the dump
+runs. Any other error is not expected — stop and roll back.
+
+Verified ahead of time by restoring this database's actual schema into a real
+18.4 server: all 26 tables came across with only those two errors.
+
+### 7. Verify, then bring the app back
+
+```bash
+kubectl exec -n logeverylift "$POD18" -- psql -U postgres -d logeverylift_db \
+  -tAc "select relname, n_live_tup from pg_stat_user_tables order by relname;" \
+  > ~/logeverylift-rowcounts-after.txt
+diff ~/logeverylift-rowcounts-before.txt ~/logeverylift-rowcounts-after.txt
+```
+
+`n_live_tup` comes from the statistics collector and starts at 0 on a fresh
+restore until autovacuum runs, so a diff here is not proof of loss. If it looks
+empty, force the counts:
+
+```bash
+kubectl exec -n logeverylift "$POD18" -- psql -U postgres -d logeverylift_db -tAc "analyze;"
+kubectl exec -n logeverylift "$POD18" -- psql -U postgres -d logeverylift_db \
+  -tAc "select count(*) from workout_sets;"   # expect 1685
+```
+
+Then bring the app back and re-enable auto-sync if you suspended it:
+
+```bash
+kubectl scale deploy/logeverylift-app -n logeverylift --replicas=1
+kubectl patch application logeverylift -n argocd --type=merge \
+  -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+```
+
+Log in to logeverylift.com and confirm real workout history renders.
+
+### 8. Afterwards
+
+Leave `postgres-pvc` in place until you have used the app for a while. When you
+are satisfied, delete the PVC declaration from `postgres.yaml` and let ArgoCD
+prune it. Add a line to `BACKLOG.md` if you are not doing that immediately.
+
+## The other Postgres 16 in this repo
+
+`k8s/talos/apps/workout/postgres.yaml` is also on `16-alpine` and is
+deliberately **not** part of this migration. Both `workout-app` and its
+`postgres` are scaled to 0 and have been since the logeverylift cutover; the
+namespace exists only as a rollback snapshot, and `BACKLOG.md` already tracks
+deleting it.
+
+Upgrading it would mean scaling a dormant database up, rewriting its data into
+a format the thing it is a rollback *for* cannot read, and scaling it back
+down. That destroys the only reason it still exists. It stays on 16 until it is
+deleted, and `renovate.json` pins it so no bot proposes 18 in the meantime.

--- a/k8s/talos/apps/blog-stage/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/blog-stage/ciliumnetworkpolicy.yaml
@@ -14,7 +14,9 @@ spec:
             "k8s:app.kubernetes.io/instance": traefik-traefik
       toPorts:
         - ports:
-            - port: "80"
+            # Enforced at the pod, so this is the container port, not the
+            # Service port. Unprivileged nginx listens on 8080.
+            - port: "8080"
               protocol: TCP
     - fromEndpoints:
         - matchLabels:
@@ -23,7 +25,7 @@ spec:
             "k8s:app.kubernetes.io/part-of": keda-add-ons-http
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
               protocol: TCP
     - fromEntities:
         - host

--- a/k8s/talos/apps/blog-stage/deployment.yaml
+++ b/k8s/talos/apps/blog-stage/deployment.yaml
@@ -15,13 +15,34 @@ spec:
       labels:
         app.kubernetes.io/name: blog-stage
     spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
+        # nginx-unprivileged runs as the built-in `nginx` user (uid 101).
+        runAsUser: 101
+        runAsGroup: 101
       containers:
         - name: blog
           image: ghcr.io/mortennordbye/homelab/blog:a5feaed
           imagePullPolicy: Always
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m
@@ -37,3 +58,12 @@ spec:
             httpGet:
               path: /
               port: http
+          volumeMounts:
+            # Only writable path nginx-unprivileged needs: it puts client_body,
+            # proxy and fastcgi temp dirs under /tmp rather than /var/cache/nginx.
+            # Verified by running the image read-only with just this one mount.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/talos/apps/blog-stage/service.yaml
+++ b/k8s/talos/apps/blog-stage/service.yaml
@@ -9,4 +9,6 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      # The container listens on 8080 (unprivileged nginx). Service port stays
+      # 80 so the HTTPRoute and interceptor reference nothing new.
+      targetPort: 8080

--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -51,12 +51,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -75,21 +75,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -106,14 +106,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -123,14 +123,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -150,29 +150,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -192,18 +192,18 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -211,27 +211,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -250,33 +250,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -284,14 +284,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1795,16 +1795,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2515,9 +2515,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2536,9 +2536,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2560,9 +2560,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2580,11 +2580,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2691,9 +2691,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3085,9 +3085,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.353",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
-      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4271,9 +4271,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5098,9 +5098,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -6634,11 +6634,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -8948,9 +8951,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "dev": true,
       "funding": [
         {

--- a/renovate.json
+++ b/renovate.json
@@ -227,6 +227,16 @@
       "addLabels": ["npm", "portfolio", "major-update"]
     },
     {
+      "description": "TypeScript majors on their own branch. Grouped with the rest, a TypeScript bump the toolchain cannot handle yet blocks every other major in the group — PR #583 sat failing because @typescript-eslint crashes on TypeScript 7's API, holding up eslint 10 and motion 13, which are unrelated to it.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "TypeScript (major)",
+      "groupSlug": "npm-typescript-major",
+      "automerge": false,
+      "addLabels": ["npm", "major-update"]
+    },
+    {
       "description": "npm Blog major updates",
       "matchManagers": ["npm"],
       "matchFileNames": ["blog/**"],

--- a/renovate.json
+++ b/renovate.json
@@ -288,6 +288,14 @@
       "enabled": false
     },
     {
+      "description": "Pin: the workout namespace is a scaled-to-zero rollback snapshot from the logeverylift cutover, not a running database. Upgrading it to 18 would rewrite the data into a format the stack it is a rollback for cannot read. Stays on 16 until the app is deleted — see BACKLOG.md.",
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["k8s/talos/apps/workout/**"],
+      "matchPackageNames": ["postgres"],
+      "allowedVersions": "<17",
+      "addLabels": ["postgres", "pinned"]
+    },
+    {
       "description": "Disable: qbittorrent managed separately",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/linuxserver/qbittorrent"],

--- a/renovate.json
+++ b/renovate.json
@@ -13,10 +13,15 @@
   ],
   "labels": ["dependencies"],
   "automergeStrategy": "squash",
+  "osvVulnerabilityAlerts": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "unresolved",
   "vulnerabilityAlerts": {
-    "description": "Security fixes bypass group stability windows and the nightly schedule",
+    "description": "Security fixes bypass group stability windows and the nightly schedule. groupName null keeps each CVE on its own branch, so one stuck fix can't hold up the rest.",
+    "enabled": true,
     "automerge": true,
+    "schedule": ["at any time"],
     "minimumReleaseAge": "3 days",
+    "groupName": null,
     "addLabels": ["security", "automerge"]
   },
   "kubernetes": {
@@ -34,7 +39,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.ya?ml$/"],
+      "managerFilePatterns": ["/\\.ya?ml$/", "/\\.tfvars\\.example$/"],
       "matchStrings": [
         "(?<currentValue>[\\w+\\.\\-]*)['\",;]*\\s*#\\s?renovate: (?<datasource>\\S+)=(?<depName>\\S+)\\s?(registry=(?<registryUrl>\\S+))?\\s?(versioning=(?<versioning>\\S+))?"
       ]
@@ -97,13 +102,14 @@
       "addLabels": ["helm", "monitoring"]
     },
     {
-      "description": "Helm Security: authentik, falco — manual review",
+      "description": "Helm Security: authentik, falco — longer soak than the other groups, since a bad authentik locks us out of everything behind it",
       "matchManagers": ["kustomize"],
       "matchPackageNames": ["authentik", "falco", "falco-falcosidekick"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Helm Security",
       "groupSlug": "helm-security",
-      "automerge": false,
+      "automerge": true,
+      "minimumReleaseAge": "14 days",
       "addLabels": ["helm", "security"]
     },
     {
@@ -167,7 +173,8 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "npm Portfolio",
       "groupSlug": "npm-portfolio",
-      "automerge": false,
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
       "addLabels": ["npm", "portfolio"]
     },
     {
@@ -177,7 +184,8 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "npm Blog",
       "groupSlug": "npm-blog",
-      "automerge": false,
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
       "addLabels": ["npm", "blog"]
     },
     {
@@ -186,7 +194,8 @@
       "matchFileNames": ["ai/**"],
       "groupName": "Jarvis AI",
       "groupSlug": "jarvis-ai",
-      "automerge": false,
+      "automerge": true,
+      "minimumReleaseAge": "3 days",
       "addLabels": ["python", "ai"]
     },
     {
@@ -228,12 +237,30 @@
       "addLabels": ["npm", "blog", "major-update"]
     },
     {
-      "description": "Terraform: group all, manual review",
+      "description": "Terraform providers: group and automerge non-major. Nothing applies Terraform automatically, so a merged bump is a code change only — the plan still runs by hand.",
       "matchManagers": ["terraform"],
       "groupName": "Terraform",
       "groupSlug": "terraform",
-      "automerge": false,
+      "automerge": true,
+      "minimumReleaseAge": "7 days",
       "addLabels": ["terraform"]
+    },
+    {
+      "description": "Terraform helm_release charts duplicate the kustomize-managed infra charts. If these drift apart, a later terraform apply upgrades Cilium or ArgoCD out from under ArgoCD — bump both sides together, by hand.",
+      "matchManagers": ["terraform"],
+      "matchPackageNames": ["argo-cd", "cilium"],
+      "automerge": false,
+      "addLabels": ["terraform", "bootstrap"]
+    },
+    {
+      "description": "Talos and Kubernetes node versions. Tracked so they stop being invisible, never automerged — a fleet upgrade is a maintenance window with an etcd snapshot, not a merge.",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["siderolabs/talos", "kubernetes/kubernetes"],
+      "groupName": "Cluster (Talos / Kubernetes)",
+      "groupSlug": "cluster-talos-k8s",
+      "automerge": false,
+      "minimumReleaseAge": "30 days",
+      "addLabels": ["cluster", "major-update"]
     },
     {
       "description": "Major updates always require manual review",
@@ -242,9 +269,22 @@
       "addLabels": ["major-update"]
     },
     {
-      "description": "Disable: portfolio image is managed by CI",
+      "description": "Disable: Kargo owns these tags. The Warehouse writes newTag in kustomization.yaml via kustomize-set-image, and the inline tag in deployment.yaml is dead weight the overlay overrides. Renovate bumping either one just fights the promotion pipeline.",
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/mortennordbye/portfolio"],
+      "matchPackageNames": [
+        "ghcr.io/mortennordbye/homelab/portfolio",
+        "ghcr.io/mortennordbye/homelab/blog",
+        "ghcr.io/mortennordbye/headroom",
+        "ghcr.io/mortennordbye/verksted",
+        "ghcr.io/mortennordbye/reelsmith-gateway",
+        "ghcr.io/mortennordbye/logeverylift"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable: huntarr.yaml is commented out of the arr-stack kustomization and ghcr.io/plexguide/huntarr no longer resolves. Left in place rather than deleted; see BACKLOG.md.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/plexguide/huntarr"],
       "enabled": false
     },
     {

--- a/terraform/proxmox/hyper-cluster/k8s/talos/terraform.tfvars.example
+++ b/terraform/proxmox/hyper-cluster/k8s/talos/terraform.tfvars.example
@@ -11,8 +11,11 @@ cluster_vip          = "10.0.10.30"     # Virtual IP for cluster endpoint
 network_gateway      = "10.0.10.1"      # Network gateway IP
 
 # Version Configuration
-talos_version      = "v1.11.6" # Latest: v1.11.6 | Previous: v1.10.8
-kubernetes_version = "v1.34.2" # Latest: v1.34.2 | Previous: v1.33.6
+# Renovate tracks these two so a lagging fleet shows up on the dependency
+# dashboard instead of going unnoticed. It opens a PR; it never automerges one.
+# A fleet upgrade is a maintenance window with an etcd snapshot taken first.
+talos_version      = "v1.11.6" # renovate: github-releases=siderolabs/talos
+kubernetes_version = "v1.34.0" # renovate: github-releases=kubernetes/kubernetes
 
 # Upgrade Flags
 enable_talos_upgrade      = false


### PR DESCRIPTION
Full audit of how dependencies are managed in this repo, plus the fixes.

## Why

The dependency backlog was not what it looked like. Only two dependency PRs were open; the rest of the perceived pile-up was Renovate groups serving out their soak windows. What was actually wrong was the config itself, which had been failing silently in several places.

- The security fast-track rule used `"matchDepTypes": ["vulnerabilities"]`. That is not a valid depType, so the rule had never fired.
- The portfolio disable rule named `ghcr.io/mortennordbye/portfolio`, but the image is `ghcr.io/mortennordbye/homelab/portfolio`. It matched nothing.
- Renovate was bumping the `newTag` fields Kargo owns on blog, headroom, verksted, reelsmith, logeverylift and portfolio, so the two have been writing over each other.
- `ghcr.io/plexguide/huntarr` no longer resolves anywhere, leaving a permanent "Package lookup failures" problem on the dashboard.
- The custom regex manager had never matched a single file, so Talos and Kubernetes versions were tracked by nothing at all.
- `osvVulnerabilityAlerts` was off, so `requirements.txt` was never scanned for CVEs. GitHub Dependabot only covers the npm lockfile here.

## What

**Renovate.** All six gaps closed. Non-major automerge extended to npm, Python, Helm Security and Terraform, with soak windows scaled to blast radius: 3 days for npm and Python, 7 for Terraform and infra, 14 for authentik, falco and the app images. Majors stay manual. Terraform`s `argo-cd` and `cilium` `helm_release` versions are carved back out of automerge, because they duplicate the kustomize-managed charts and a later `terraform apply` on a drifted value would upgrade them out from under ArgoCD. TypeScript majors get their own branch so an incompatible compiler release stops blocking unrelated bumps.

**Security.** All 7 open Dependabot alerts cleared: js-yaml, brace-expansion and @babel/core. All transitive, so `package.json` is untouched and the change is entirely in the lockfile.

**Blog base image.** The runtime stage was `nginx:alpine` — unversioned, so no bot was watching it, and running its master process as root. Now `nginxinc/nginx-unprivileged:1.31-alpine`, pinned so Renovate tracks it, which lets the stage Deployment assert `runAsNonRoot`, `readOnlyRootFilesystem` and drop all capabilities. Unprivileged nginx cannot bind below 1024, so it listens on 8080; the Service keeps port 80, so nothing upstream changes. The CiliumNetworkPolicy `toPorts` rules do change, since they are enforced at the pod and would otherwise have dropped every request.

Only `blog-stage` moves. Prod runs an older image that still listens on 80 and Kargo gates it behind `promote-via-pr`, so the prod flip has to land with that promotion. Tracked in `BACKLOG.md`.

**Postgres.** `docs/postgres-18-migration.md` is the runbook for logeverylift. The manifest change is deliberately in a separate PR so it can be merged at step 5. `workout` is excluded and pinned below 17: both its deployments have been scaled to 0 since the logeverylift cutover, and upgrading it would rewrite the data into a format the stack it is a rollback for cannot read.

## Verification

- `renovate-config-validator` passes. A `--platform=local --dry-run=full` run completes with zero warnings, where it previously reported the huntarr lookup failure. The regex manager now extracts both cluster versions, the six Kargo-owned images produce zero updates, and the workout Postgres pin holds.
- Portfolio: `npm ci`, lint, typecheck and a production build all pass. `npm audit` reports 0 vulnerabilities.
- Blog runtime stage built and run with `--read-only --cap-drop ALL --user 101 --security-opt no-new-privileges`: serves `/`, static assets with the immutable `Cache-Control` header intact, and 404s correctly. Each mount combination was tested to establish that a single `/tmp` emptyDir is sufficient — `/var/cache/nginx` alone fails.
- `kubectl diff` against the live cluster shows only the intended changes. It must be run with `--field-manager=argocd-controller`; under the default manager the container ports list merges on `containerPort` and reports a spurious duplicate-name error.

## Not in this PR

The cluster stays on Talos v1.11.6 / Kubernetes v1.34.0 by choice. It is now tracked on the dependency dashboard rather than being invisible, but never automerged.

Blog prod port flip, and the orphaned huntarr manifest: both in `BACKLOG.md`.

PR #583 fails CI because `@typescript-eslint` crashes on TypeScript 7`s API. The TypeScript split here unblocks eslint 10 and motion 13 from it.