### PR TITLE
feat(logeverylift): move Postgres to 18-alpine [DO NOT MERGE ALONE - step 5 of the runbook]

### DIFF
--- a/k8s/talos/apps/logeverylift/postgres.yaml
+++ b/k8s/talos/apps/logeverylift/postgres.yaml
@@ -1,8 +1,26 @@
 ---
+# The Postgres 16 volume. Kept declared, and deliberately not mounted by
+# anything, so reverting this file is a complete rollback to 16 with the
+# original data intact. Remove it once 18 has been running happily for a
+# while — see docs/postgres-18-migration.md, step 8.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
+  namespace: logeverylift
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: syno-nfs-csi
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc-18
   namespace: logeverylift
 spec:
   accessModes:
@@ -30,7 +48,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:16-alpine
+          image: postgres:18-alpine
           ports:
             - containerPort: 5432
           env:
@@ -44,8 +62,14 @@ spec:
                   name: logeverylift-secret
                   key: POSTGRES_PASSWORD
           volumeMounts:
+            # Mounted at the parent, not at /var/lib/postgresql/data. Postgres 18
+            # keeps its cluster in a version-named subdirectory
+            # (/var/lib/postgresql/18/docker), so mounting the parent means the
+            # next major version lands beside this one instead of colliding with
+            # it. Mounting the old path instead makes the 18 image refuse to
+            # start, because it finds a 16 cluster where its own data should be.
             - name: postgres-data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", "postgres", "-d", "logeverylift_db"]
@@ -61,7 +85,7 @@ spec:
       volumes:
         - name: postgres-data
           persistentVolumeClaim:
-            claimName: postgres-pvc
+            claimName: postgres-pvc-18
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Do not merge this on its own.

This is **step 5 of `docs/postgres-18-migration.md`** and it expects the dump from step 2 to already exist. Merging it before that leaves the app pointed at an empty database until the restore runs.

The runbook ships in #600. Read it first.

## Why

Postgres 18 cannot read a Postgres 16 data directory, so the data has to be dumped out of 16 and loaded into a freshly initialised 18 cluster.

The Docker image also moved `PGDATA`, from `/var/lib/postgresql/data` on 16 to `/var/lib/postgresql/18/docker` on 18 — and `/var/lib/postgresql/data` is exactly where this Deployment mounts its PVC.

## What

- `postgres:16-alpine` to `postgres:18-alpine`
- new `postgres-pvc-18` for the fresh cluster
- mount moves from `/var/lib/postgresql/data` to the parent `/var/lib/postgresql`, so the next major version lands beside this one rather than colliding with it
- the 16 PVC stays declared and unmounted, so rollback is reverting this PR, not restoring a backup

## Verification

Checked against the real images rather than assumed:

- Keeping the old mount path is not an option. The 18 image finds the 16 cluster where its own data should be and exits 1. It does not lose data quietly, but it is still an outage.
- Mounting the parent works: the cluster initialises into `/var/lib/postgresql/18/docker` and survives a restart.
- Schema compatibility confirmed by dumping this database`s actual `pg_dumpall` output from the live 16.14 server and restoring it into a real 18.4 server. All 26 tables came across, with only the two expected "already exists" errors for the pre-created database and role.
- `kubectl diff -k k8s/talos/apps/logeverylift --server-side --field-manager=argocd-controller` shows only the image, the mount path, the claim name and the added PVC.

## Scope

`k8s/talos/apps/workout/postgres.yaml` is deliberately not included and is pinned below 17 in #600. Both its deployments have been scaled to 0 since the logeverylift cutover; the namespace exists only as a rollback snapshot, and upgrading it would rewrite the data into a format the stack it is a rollback for cannot read.