### PR TITLE
fix(logeverylift): chown the NFS mount root before Postgres starts

### DIFF
--- a/docs/postgres-18-migration.md
+++ b/docs/postgres-18-migration.md
@@ -25,6 +25,40 @@ data — the 18 image detects the 16 cluster at the old path and refuses to
 start, exiting 1 with an explanation. It is a loud failure, not a quiet one,
 but it is still an outage, so the mount path moves as part of this change.
 
+## The NFS ownership trap
+
+Hit for real during the 2026-08-09 run. Moving the mount to the parent
+directory means Postgres has to *create* `18/docker` inside the volume, and on
+a freshly provisioned `syno-nfs-csi` volume it cannot:
+
+```
+mkdir: can't create directory '/var/lib/postgresql/18/': Permission denied
+```
+
+The mount root is readable as `drwxrwxrwx` by root but `d---------` by uid 70 —
+the Synology export grants root everything and postgres nothing. The entrypoint
+`gosu`s to postgres before creating any directory, so it is uid 70 that fails.
+`mkdir -p` on an already existing path does not error, so if you see this
+message the directory genuinely is not there yet.
+
+This never happened on 16 because the volume was mounted directly at `$PGDATA`,
+and that PVC's root had ended up owned by 70.
+
+`postgres.yaml` now carries a `fix-nfs-ownership` initContainer that chowns the
+mount root to `70:70` before Postgres starts, so a recreated PVC recovers on its
+own. If you are debugging this by hand, one root pod with the claim mounted is
+enough:
+
+```bash
+chown 70:70 /var/lib/postgresql && chmod 700 /var/lib/postgresql
+```
+
+`fsGroup: 70` looks like the tidier fix — `fsGroupPolicy` on the driver is
+`File`, so kubelet would apply it — but it recursively adds group write, and
+Postgres refuses to start unless `$PGDATA` is exactly `0700` or `0750`. The
+entrypoint chmods it back on every start, so it would probably work; the
+initContainer does not depend on "probably".
+
 ## What the database looks like
 
 Checked against the live cluster on 2026-08-09:

--- a/k8s/talos/apps/logeverylift/postgres.yaml
+++ b/k8s/talos/apps/logeverylift/postgres.yaml
@@ -46,6 +46,30 @@ spec:
       labels:
         app: postgres
     spec:
+      # The Synology NFS export hands a freshly provisioned volume to root only:
+      # uid 70 reads the mount root as d--------- even though root sees 0777, so
+      # the entrypoint (which gosu's to postgres before creating anything) cannot
+      # mkdir $PGDATA and the container crash-loops on
+      #   mkdir: can't create directory '/var/lib/postgresql/18/': Permission denied
+      #
+      # This never bit on 16 because the volume was mounted directly at $PGDATA,
+      # and that PVC's root had ended up owned by 70. Mounting the parent, which
+      # 18 requires, exposes it.
+      #
+      # One non-recursive chown of the mount root is enough: on a fresh PVC it is
+      # the only entry, and everything below it is created by postgres itself.
+      # Uses the same image as the main container so there is no second tag to
+      # pull or track.
+      initContainers:
+        - name: fix-nfs-ownership
+          image: postgres:18-alpine
+          command:
+            - sh
+            - -c
+            - chown 70:70 /var/lib/postgresql && chmod 700 /var/lib/postgresql
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql
       containers:
         - name: postgres
           image: postgres:18-alpine


### PR DESCRIPTION
Follow-up from the Postgres 16 to 18 migration (#601), which is complete and verified — all 27 tables restored with identical row counts.

## Why

Moving the mount to `/var/lib/postgresql` means Postgres has to create `18/docker` inside the volume, and on a freshly provisioned `syno-nfs-csi` volume it cannot:

```
mkdir: cant create directory /var/lib/postgresql/18/: Permission denied
```

The mount root reads as `drwxrwxrwx` to root but `d---------` to uid 70 — the Synology export grants root everything and postgres nothing. The entrypoint `gosu`s to postgres before creating any directory, so uid 70 is what fails.

This never bit on 16 because the volume was mounted directly at `$PGDATA` and that PVC`s root had ended up owned by 70. Mounting the parent, which 18 requires, exposes it.

## What

An initContainer chowns the mount root to `70:70` before Postgres starts, so a recreated PVC recovers without hands. Non-recursive on purpose: on a fresh PVC the root is the only entry. Reuses `postgres:18-alpine`, so no second image to pull or track.

`fsGroup: 70` was the other candidate — `fsGroupPolicy` on the driver is `File`, so kubelet would apply it — but it recursively adds group write, and Postgres refuses to start unless `$PGDATA` is exactly `0700` or `0750`.

## Verification

The live volume was already chowned by hand to get the migration through, so this makes the current state declarative. `kubectl diff` shows only the initContainer being added. The runbook documents the trap.