### PR TITLE
docs: record that the cluster runs Postgres 18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,10 @@ Homelab infrastructure for a 6-node Proxmox cluster running a Talos Kubernetes c
 - **Security:** cert-manager, External Secrets Operator, Falco, Authentik.
 - **Observability:** kube-prometheus-stack, Grafana, Loki, OpenTelemetry collector.
 - **Storage:** Proxmox CSI for block, Synology NFS for shared volumes.
+- **Databases:** in-cluster Postgres 18 (`postgres:18-alpine`) backing logeverylift. Its PVC mounts at `/var/lib/postgresql`, not at `/var/lib/postgresql/data` — 18 keeps the cluster in a version-named subdirectory, and an initContainer chowns the NFS mount root so the non-root process can create it. See `docs/postgres-18-migration.md`.
 - **GitOps:** ArgoCD app-of-apps; root applications live in `k8s/talos/infra/argocd/{apps.yaml,infra.yaml}`.
-- **Apps shipped from this repo:** portfolio (stage + prod), blog, plex-media-stack, arr-stack, audiobookshelf, home-assistant, homepage, it-tools, omni-tools, gluetun-vpn, qbittorrent-vpn, headroom, workout.
+- **Apps shipped from this repo:** portfolio and blog (each stage + prod), headroom (+ headroom-demo), logeverylift, reelsmith, verksted, bigd, plex-media-stack, arr-stack, gluetun-vpn, audiobookshelf, mealie, home-assistant, homepage, it-tools, omni-tools, open-webui, ollama, workout. That is 22 ArgoCD `Application`s, one per directory under `k8s/talos/apps/`.
+- **Dormant:** `workout` is the pre-cutover version of logeverylift, scaled to 0 and kept only as a rollback. Its Postgres stays on 16 and is pinned in `renovate.json`. See `BACKLOG.md`.
 
 ### Directory layout
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A few other things I build and self-host outside this repo:
 
 | Project | Description | Stack |
 | ------- | ----------- | ----- |
-| [**logeverylift**](https://github.com/mortennordbye/logeverylift) | Mobile-first workout tracking PWA | Next.js 16, PostgreSQL, Drizzle |
+| [**logeverylift**](https://github.com/mortennordbye/logeverylift) | Mobile-first workout tracking PWA | Next.js 16, PostgreSQL 18, Drizzle |
 | [**lawless-waf**](https://github.com/mortennordbye/lawless-waf) | Tune Azure WAF false positives without paying Log Analytics prices | Python, React, Terraform |
 | [**headroom**](https://github.com/mortennordbye/headroom) | Self-hosted personal finance tracker for budgets, assets, investments, and loan modeling | TypeScript, SQLite, Docker |
 
@@ -105,6 +105,7 @@ homelab
 | Observability | [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/), [Loki](https://grafana.com/oss/loki/) (logs), [Tempo](https://grafana.com/oss/tempo/) (traces), [OpenTelemetry](https://opentelemetry.io/), [Metrics-server](https://github.com/kubernetes-sigs/metrics-server) |
 | Automation    | [Reloader](https://github.com/stakater/Reloader) (config/secret-triggered rollouts)                                                                                                   |
 | Storage       | [Proxmox CSI](https://github.com/sergelogvinov/proxmox-csi-plugin), [Synology](https://www.synology.com/) (NFS)                                                                        |
+| Databases     | [PostgreSQL 18](https://www.postgresql.org/) (in-cluster, NFS-backed, backing logeverylift)                                                                                            |
 | Platform      | [Proxmox VE](https://www.proxmox.com/) (6-node HA cluster), [Talos Linux](https://www.talos.dev/), [Terraform](https://www.terraform.io/)                                              |
 
 ---

--- a/docs/postgres-18-migration.md
+++ b/docs/postgres-18-migration.md
@@ -1,10 +1,31 @@
 # Postgres 16 to 18: logeverylift
 
-Runbook for moving `logeverylift`'s Postgres from `16-alpine` to `18-alpine`.
-Written 2026-08-09. Expect roughly 10 minutes of downtime for the app.
+> **Status: done.** Executed 2026-08-09. `logeverylift` runs
+> `postgres:18-alpine` (server 18.4) on `postgres-pvc-18`. All 27 tables
+> restored; row counts verified identical to the pre-migration baseline and to
+> the dump file itself, table by table. No data lost.
+>
+> Kept as the record of how it was done, what the trade-offs were, and as the
+> procedure to reuse for the next major or for the dormant `workout` database.
+
+Expect roughly 10 minutes of app downtime if you run this again.
 
 The manifest change lives in its own PR so it can be merged at step 5, not
 before. Merging it early takes the app down until the restore finishes.
+
+## Rollback still available
+
+Both are deliberately still in place and should stay until the app has been
+used for a while:
+
+- `postgres-pvc` — the untouched Postgres 16 volume, declared in
+  `postgres.yaml` but mounted by nothing. Rolling back is reverting the
+  manifest, not restoring a backup.
+- `~/logeverylift-pg16-20260809.sql` — the 341K `pg_dumpall` output, on the
+  operator's machine only. Copy it somewhere durable; `BACKLOG.md` records an
+  earlier dump that survives only in a session scratchpad.
+
+Step 8 below covers retiring the old PVC when you are ready.
 
 ## Why this is not just an image bump
 


### PR DESCRIPTION
The 16 to 18 migration is done, but nothing outside the runbook said so — and the runbook itself still read as pending work.

## What

**README**

- logeverylift`s stack now says PostgreSQL 18 rather than an unversioned "PostgreSQL".
- The Kubernetes tech stack table gains a Databases row. In-cluster Postgres was not represented there at all.

**CLAUDE.md**

- Adds a Databases line covering the version, the parent-directory mount that 18 requires, and the initContainer that chowns the NFS mount root — so the two non-obvious constraints are visible from the architecture summary rather than only after something breaks.
- Fixes the app list. It named `workout`, which has been the dormant pre-cutover copy of logeverylift since 2026-07-18, and omitted `logeverylift` entirely along with `reelsmith`, `verksted`, `bigd`, `mealie`, `open-webui` and `ollama`. It also listed `qbittorrent-vpn`, which is not an app directory. Replaced with the actual set, checked against both `k8s/talos/apps/` and the 22 live ArgoCD `Application`s, plus a note that `workout` is dormant and pinned to Postgres 16.

**Runbook**

- Marked done, with the verification result.
- Rollback assets moved to the top, so the untouched `postgres-pvc` and the `pg_dumpall` output are not retired by accident.

## Verification

Doc-only. App list checked against the live cluster, not assumed. Table alignment in the README verified — the added row matches the header width exactly. Existing markdownlint findings in README are pre-existing, in a hardware table this PR does not touch, and CI only lints `blog/content/**` anyway.