### PR TITLE
feat(kargo): auto-merge single-env promotions, fix polling and PR metadata

### DIFF
--- a/.github/workflows/kargo-automerge.yaml
+++ b/.github/workflows/kargo-automerge.yaml
@@ -1,0 +1,72 @@
+# Merges Kargo's promotion PRs for the apps named in the KARGO_AUTOMERGE_APPS
+# repository variable. Those apps have no stage environment, so the PR is a
+# record rather than a review: the build was already vetted in the app's own
+# repo and the promotion still has to pass its smoke test afterwards.
+#
+# Kill switch, no deploy and no commit needed: Settings > Secrets and variables
+# > Actions > Variables > KARGO_AUTOMERGE_APPS. Drop an app from the list, or
+# empty the variable entirely, and the next promotion PR waits for a human.
+# Kargo opens the PR either way and blocks on the merge, so nothing is lost.
+name: Kargo auto-merge
+
+on:
+  pull_request:
+    # Kargo attaches the labels just after opening the PR, so `opened` can
+    # arrive before `app/<name>` exists. The `labeled` events cover that.
+    types: [opened, labeled, reopened]
+
+permissions: {}
+
+# Serialised per PR so the three `labeled` events do not race each other into
+# the same merge.
+concurrency:
+  group: kargo-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    # Only branches Kargo generated, and only from this repo.
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'kargo/promotion/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check the app is opted in
+        id: gate
+        env:
+          APPS: ${{ vars.KARGO_AUTOMERGE_APPS }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          app=$(jq -r '.[] | select(startswith("app/")) | ltrimstr("app/")' <<<"$LABELS" | head -1)
+          if [ -z "$app" ]; then
+            echo "No app/* label yet; the labeled event will retry."
+            exit 0
+          fi
+          if ! tr ',' '\n' <<<"$APPS" | tr -d ' \t' | grep -qx "$app"; then
+            echo "$app is not in KARGO_AUTOMERGE_APPS ('$APPS'); leaving for manual merge."
+            exit 0
+          fi
+          echo "merge=true" >> "$GITHUB_OUTPUT"
+
+      - name: Squash merge
+        if: steps.gate.outputs.merge == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$(gh pr view "$PR" --json state --jq .state)" != OPEN ]; then
+            echo "PR $PR is no longer open; nothing to do."
+            exit 0
+          fi
+          # GitHub computes mergeability asynchronously and reports UNKNOWN
+          # until it finishes, which `gh pr merge` treats as a hard failure.
+          for _ in 1 2 3 4 5 6; do
+            state=$(gh pr view "$PR" --json mergeable --jq .mergeable)
+            [ "$state" = UNKNOWN ] || break
+            sleep 5
+          done
+          gh pr merge "$PR" --squash

--- a/docs/kargo.md
+++ b/docs/kargo.md
@@ -65,6 +65,8 @@ smoke-tested) in front, gating what Freight `prod` can receive.
 | Git write | GitHub App `mortennordbye-homelab-deployer` — needs **Contents AND Pull requests** read/write (PR flow); cred via ESO, per-Project |
 | Sync trigger | `argocd-update` + `argocd-wait` (needs `kargo.akuity.io/authorized-stage` on the Argo app) |
 | Smoke test | two-stage: `<app>-stage.local.bigd.no`; single-env: the app's URL (private gateway → `-k`) |
+| Discovery latency | ~1 min — Warehouses poll at `interval: 1m0s` and the controller floor is set to match |
+| PR labels | `kargo`, `app/<name>`, `env/<stage>`, attached by `git-open-pr` |
 | UI | `https://kargo.local.bigd.no` (admin account) |
 | Version | Kargo `1.10.9`, Argo Rollouts `2.41.0` (verification CRDs) |
 
@@ -78,11 +80,20 @@ smoke-tested) in front, gating what Freight `prod` can receive.
 | `k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml` | Shared PR-gated task `promote-via-pr` |
 | `k8s/talos/infra/kargo-projects/<app>.yaml` | One multi-doc file per app (Namespace, Project, ProjectConfig, ESO git cred, Warehouse, AnalysisTemplate, Stage(s)) |
 | `k8s/talos/infra/argocd/apps.yaml` | `authorized-stage` annotation via `goTemplate` + `templatePatch` (list-driven) |
+| `.github/workflows/kargo-automerge.yaml` | Squash-merges promotion PRs for apps listed in `KARGO_AUTOMERGE_APPS` |
 
 ## Operate
 
 - **Deploy to prod:** fully automatic up to the gate — merge the PR Kargo opens
   (`chore(<app>): promote 0.0.N to prod`). Nothing reaches prod without that merge.
+- **Auto-merge:** apps named in the `KARGO_AUTOMERGE_APPS` repository variable
+  skip that click. `.github/workflows/kargo-automerge.yaml` squash-merges their
+  promotion PR as soon as it opens, keyed on the `app/<name>` label. The list is
+  currently the three single-env apps: `logeverylift,verksted,reelsmith`.
+  Editing the variable under Settings > Secrets and variables > Actions is the
+  kill switch — per app or all of them, no commit and no deploy. Kargo still
+  opens the PR and blocks on it, so turning auto-merge off just puts a human
+  back in front of it.
 - **Trigger a build:** push under the app's path (monorepo) or to the app repo's
   `main` (external).
 - **Inspect:** `kubectl -n <app>-cd get warehouse,stage,freight,promotion`.
@@ -146,6 +157,19 @@ the `conversionStrategy`/`decodingStrategy`/`metadataPolicy` fields; only its
   `if: ${{ (task.outputs?.['commit']?.commit ?? '') != '' }}` so a no-op re-promote
   (Warehouse re-creating Freight for the already-live tag) skips cleanly and still
   ends green via `argocd-wait`.
+- **A Warehouse `interval` is a request, not a promise.** Kargo polls at the
+  greater of `spec.interval` and the controller's
+  `controller.reconcilers.warehouses.minReconciliationInterval`. The chart
+  defaults that floor to `5m0s`, so every Warehouse here sat at 5 minutes while
+  its manifest read `1m0s` and nothing anywhere reported the clamp. The floor is
+  now `1m0s` in `kargo/values.yaml`; lowering a Warehouse below it needs both
+  numbers changed. Making discovery instant instead needs a webhook receiver,
+  which needs the external webhooks server reachable from the internet — it is
+  currently only on the private gateway.
+- **Commit authorship is set on `git-clone`, not `git-commit`.** Unset, Kargo
+  authors as `Kargo <no-reply@kargo.io>` and GitHub turns that into a
+  `Co-authored-by:` trailer on the squash commit. `git-commit`'s own `author`
+  field does the same thing but is deprecated since v1.10 and goes away in v1.12.
 - **GitHub App scope:** the PR flow needs **Pull requests: read/write** in addition
   to Contents. Without it, `git-open-pr` fails.
 - **Stage namespace flips word order:** the `<app>-stage` overlay dir maps to
@@ -154,7 +178,7 @@ the `conversionStrategy`/`decodingStrategy`/`metadataPolicy` fields; only its
   git-push fails with GitHub `404` on the installation-access-token call.
 - ESO remoteRefs and the Warehouse must spell out defaulted fields
   (`conversionStrategy`/`decodingStrategy`/`metadataPolicy`; `strictSemvers`,
-  `interval: 5m0s`) or Argo CD reports perpetual `OutOfSync`.
+  `interval`, `discoveryLimit`) or Argo CD reports perpetual `OutOfSync`.
 - Per-app annotations in the `apps` ApplicationSet must use `templatePatch`; inline
   `{{if}}` in the parsed `template` is invalid YAML. Verify offline with
   `argocd appset generate --core -n argocd <file>` (swap the git generator for a

--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
@@ -27,6 +27,13 @@ spec:
     - uses: git-clone
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
+        # Without this Kargo authors commits as `Kargo <no-reply@kargo.io>`,
+        # which GitHub then carries into the squash commit as a
+        # `Co-authored-by:` trailer. Promotions are this repo's own automation,
+        # so they carry the repo owner's authorship like every other commit.
+        author:
+          name: Morten Victor Nordbye
+          email: morten@nordbye.it
         checkout:
           - branch: main
             path: ./repo
@@ -71,6 +78,14 @@ spec:
         sourceBranch: ${{ task.outputs?.['push']?.branch ?? '' }}
         targetBranch: main
         title: "chore(${{ vars.appName }}): promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
+        # `kargo` marks the PR as machine-opened, and the other two say which
+        # app and which environment without having to parse the title. The
+        # kargo-automerge workflow reads `app/<name>` to decide whether this
+        # app is opted into unattended merging.
+        labels:
+          - kargo
+          - app/${{ vars.appName }}
+          - env/${{ ctx.stage }}
     # Blocks the promotion until the PR is merged in GitHub.
     - uses: git-wait-for-pr
       as: wait-pr

--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask.yaml
@@ -24,6 +24,13 @@ spec:
     - uses: git-clone
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
+        # Without this Kargo authors commits as `Kargo <no-reply@kargo.io>`,
+        # which GitHub then carries into the squash commit as a
+        # `Co-authored-by:` trailer. Promotions are this repo's own automation,
+        # so they carry the repo owner's authorship like every other commit.
+        author:
+          name: Morten Victor Nordbye
+          email: morten@nordbye.it
         checkout:
           - branch: main
             path: ./repo

--- a/k8s/talos/infra/kargo/values.yaml
+++ b/k8s/talos/infra/kargo/values.yaml
@@ -44,6 +44,16 @@ api:
       enabled: false
 
 controller:
+  reconcilers:
+    warehouses:
+      # Kargo polls at the GREATER of this floor and each Warehouse's own
+      # `spec.interval`. The chart default is 5m0s, so every Warehouse here was
+      # being clamped to 5m despite asking for 1m. Lowering the floor makes the
+      # 1m0s they already declare the real discovery latency. Six Warehouses
+      # against GHCR once a minute is well inside the registry's rate limit.
+      # A webhook receiver would make this instant, but the external webhooks
+      # server is only exposed on the private gateway.
+      minReconciliationInterval: "1m0s"
   argocd:
     # We reconcile via Argo CD selfHeal (no argocd-update step in the pilot),
     # but leaving the integration on lets Kargo surface Argo app health/sync


### PR DESCRIPTION
## Why

Four separate annoyances in the Kargo pipeline.

1. `logeverylift`, `verksted` and `reelsmith` have no stage environment. Their prod PR is a record, not a review, and waiting on a click only adds latency to a build that was already vetted in the app's own repo.
2. Every Warehouse manifest says `interval: 1m0s`. None of them were polling at 1m.
3. Every promotion squash commit carries `Co-authored-by: Kargo <no-reply@kargo.io>`.
4. Promotion PRs have no labels, so the app and environment can only be read out of the title.

## What

**Auto-merge.** Kargo has no auto-merge promotion step, so this is a GitHub Actions workflow. It fires on the promotion PR, reads the `app/<name>` label, and squash-merges if that app is listed in the `KARGO_AUTOMERGE_APPS` repository variable (set to `logeverylift,verksted,reelsmith`).

Editing that variable is the kill switch: per app or all of them, no commit and no deploy, effective on the next PR. Kargo still opens the PR and still blocks on the merge when auto-merge is off, so turning it off puts a human back in front rather than breaking the pipeline.

The job is gated on the head branch being one Kargo generated and on the PR coming from this repo. It is serialised per PR, because Kargo attaches three labels and each one fires a `labeled` event.

**Polling.** Kargo polls at the greater of `spec.interval` and the controller's `minReconciliationInterval`. The chart defaults that floor to `5m0s`, so all six Warehouses sat at 5 minutes while their manifests read `1m0s`, and nothing anywhere reports the clamp. The floor is now `1m0s`. Six Warehouses hitting GHCR once a minute is well inside the rate limit.

Making discovery instant instead needs a webhook receiver, which needs the external webhooks server reachable from the internet. It is on the private gateway only, so that is written up as a gotcha rather than attempted here.

**Commit author.** `author` on `git-clone` in both ClusterPromotionTasks. Set there rather than on `git-commit` because `git-commit`'s own `author` field is deprecated as of v1.10 and removed in v1.12.

**Labels.** `git-open-pr` now attaches `kargo`, `app/<name>` and `env/<stage>`. The eight labels were created in the repo up front rather than relying on GitHub to create them on first use.

## Verification

- `kustomize build k8s/talos/infra/kargo-projects` and `kustomize build --enable-helm k8s/talos/infra/kargo` both render.
- `kubectl diff --server-side --field-manager=argocd-controller` on both. The only real changes are the `author` block on both tasks, the `labels` list on `git-open-pr`, and `MIN_WAREHOUSE_RECONCILIATION_INTERVAL` going `5m0s` to `1m0s`. The `annotations:` lines in that output are the tracking-id artifact of diffing without ArgoCD.
- The chart already stamps a `configmap/checksum` on the controller pod template, so ArgoCD rolls the controller on the ConfigMap change without a manual restart.
- `actionlint` clean on the new workflow.
- The label gate was run against eight cases: opted-in app, non-opted-in app, labels not yet attached, variable emptied, whitespace in the variable, substring near-miss, single-app list. That caught a real bug, `tr -d '[:space:]'` stripping the newlines and collapsing the app list into one token so nothing would ever have matched. Fixed and retested.
- The `git-clone` `author` schema and the `git-open-pr` `labels` schema were both checked against the v1.11.0 source rather than assumed, since the cluster runs v1.11.0 while the vendored chart directory is a stale 1.10.9 cache.

## Notes

An auto-merged promotion deploys before its smoke test runs, so a bad image reaches prod and then goes red. That is true of the manual flow too, just with a pause in front of it. `main` has no required status checks, so the merge does not wait on PR CI either.
