### PR TITLE
fix(falco): stop verksted agent CLI updates tripping drop-and-execute

### DIFF
--- a/k8s/talos/infra/falco/values.yaml
+++ b/k8s/talos/infra/falco/values.yaml
@@ -42,8 +42,23 @@ serviceMonitor:
 customRules:
   tuning.yaml: |-
     # Cilium CNI plugin execs from /opt/cni/bin on every node — not a workload.
+    #
+    # Second clause: verksted keeps its agent CLIs current itself, npm-installing
+    # them into the global prefix at runtime rather than baking a version into the
+    # image, so /usr/local/lib/node_modules lives in the container's writable
+    # upper layer. Every exec of claude (or the ripgrep it re-execs itself as, via
+    # argv[0]) therefore carries EXE_WRITABLE|EXE_UPPER_LAYER and trips this rule
+    # — hundreds of Critical events an hour, which is the whole Discord feed.
+    # Pinned to the prefix the updater writes: a binary dropped anywhere else in
+    # this image still alerts, and so does one in any other image. Nothing is lost
+    # by exempting the path, because a dropped binary under /data (where the agent
+    # sessions actually work) sits on the NFS PVC, not the upper layer, and so
+    # never matched this rule to begin with.
     - macro: known_drop_and_execute_activities
-      condition: (proc.name=cilium-cni and proc.exepath startswith /opt/cni/bin/)
+      condition: >
+        (proc.name=cilium-cni and proc.exepath startswith /opt/cni/bin/)
+        or (container.image.repository=ghcr.io/mortennordbye/verksted
+            and proc.exepath startswith /usr/local/lib/node_modules/)
       override:
         condition: replace
 


### PR DESCRIPTION
`Drop and execute new binary in container` fires at Critical on every `claude` exec in the verksted pod:

```
proc.exepath=/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe
exe_flags=EXE_WRITABLE|EXE_UPPER_LAYER  proc.exe=rg  container.name=verksted
```

verksted keeps its agent CLIs current itself, npm-installing them into the global prefix at runtime rather than baking a version into the image (it bumped claude-code 2.1.226 → 2.1.227 this morning). That puts `/usr/local/lib/node_modules` in the container's writable upper layer, so the binary is a "dropped" one as far as the rule is concerned — and it re-execs itself as `rg` for every file search, hence the volume.

The exemption goes into the rule's own `known_drop_and_execute_activities` template macro (upgrade-safe, same hook the cilium-cni entry already uses) and is pinned to that prefix in that image: a binary dropped anywhere else in verksted still alerts, and so does one at the same path in any other image. Nothing is given up for the agent sessions themselves either — binaries they build under `/data` live on the NFS PVC, not the upper layer, so they never matched this rule.

Verified: `values.yaml` and the embedded `tuning.yaml` both parse, and the macro renders as the intended two-clause condition. No kustomize/helm/kubectl in the sandbox, so the rendered chart was not diffed against the cluster.