### PR TITLE
fix(falco): quiet two dind-shaped false positives from verksted

### DIFF
--- a/k8s/talos/infra/falco/values.yaml
+++ b/k8s/talos/infra/falco/values.yaml
@@ -62,6 +62,39 @@ customRules:
       override:
         condition: replace
 
+    # Unpacking an image layer writes the log files the layer ships with, so
+    # containerd truncates /var/log/dpkg.log every time it pulls a Debian-based
+    # image. Upstream already knows this and exempts it — but only at the host
+    # containerd's snapshot root. verksted's dind sidecar runs its own containerd
+    # under /var/lib/docker/containerd/daemon, so the identical write lands on a
+    # path upstream's macro doesn't cover and every image pull an agent session
+    # does fires this rule. Pinned to that daemon root in the dind image: the
+    # same process writing a log anywhere outside the snapshot tree still alerts.
+    - macro: allowed_clear_log_files
+      condition: >
+        (proc.name=containerd
+         and container.image.repository=docker.io/library/docker
+         and k8s.ns.name=verksted
+         and fd.name startswith /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/)
+      override:
+        condition: replace
+
+    # Agent sessions clone the repo under test into a mkdtemp directory,
+    # /tmp/vk-repos-<random>, and run its suite there. Test suites that harden
+    # against symlink escape create the fixture they defend against — a link to
+    # /etc or /root — and trip this rule from inside the dind daemon, where Falco
+    # has no container metadata to scope on (k8s.ns.name and the image come
+    # through as <NA>), so the linkpath is the only handle available.
+    #
+    # Exempting where the symlink is *created*, not what it points at: a link to
+    # a sensitive file anywhere outside a session's scratch checkout still
+    # alerts, and nothing privileged resolves paths under those directories.
+    - rule: Create Symlink Over Sensitive Files
+      condition: >
+        and not evt.arg.linkpath startswith /tmp/vk-repos-
+      override:
+        condition: append
+
     # kubelet (exec/port-forward streams) and Authentik wire stdio to sockets
     # legitimately; scoped to those binaries so a real shell still alerts.
     - macro: user_known_stand_streams_redirect_activities


### PR DESCRIPTION
Both alerts come from verksted's dind sidecar doing ordinary work on paths the upstream exemptions don't reach. Same shape as #625.

### `Clear Log Activities`

Unpacking an image layer writes the log files that layer ships with, so containerd truncates `/var/log/dpkg.log` on every pull of a Debian-based image. Upstream already treats this as benign — but its `containerd_activities` macro only covers the host containerd's snapshot root and the k3s equivalent. dind roots its own containerd under `/var/lib/docker/containerd/daemon`, so every image an agent session pulls lands outside the exemption.

Filled via the rule's own `allowed_clear_log_files` hook, pinned to that daemon root in the dind image — the same process writing a log anywhere outside the snapshot tree still alerts.

### `Create Symlink Over Sensitive Files`

A test suite that hardens against symlink escape has to create the fixture it defends against (a link to `/etc`), and agent sessions run those suites from a `mkdtemp` checkout at `/tmp/vk-repos-<random>`.

The suite runs in a container nested inside dind, which Falco cannot resolve through the CRI — the event carries `k8s.ns.name` and the image as `<NA>`, so there is no namespace to scope on and the linkpath is the only handle available. The exemption is on where the symlink is *created*, not what it points at: a link to a sensitive file anywhere outside a session's scratch checkout still fires, and nothing privileged resolves paths under those directories.

### Verification

`falco -V` against the 0.44.1 ruleset that chart 9.1.0 ships, with the tuning layered on `falco_rules.yaml` the way the DaemonSet loads it — both files `Ok`. That also confirms `allowed_clear_log_files` exists as a hook in this version, since an override on a missing macro is a load error.

### Not included

`DISCORD_MINIMUMPRIORITY` stays at `notice`. Raising it to `error` is the broader lever against this class of noise — verksted is an arbitrary-code sandbox with a nested daemon, so it will keep generating benign syscalls that look like the attacks these rules describe — but that is a separate decision from these two exemptions.