### PR TITLE
Give the reelsmith YouTube channel a slot

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -27,13 +27,27 @@ data:
   # A line that does not parse fails the pod's startup on purpose, rather than
   # quietly dropping that slot from the schedule.
   #
-  # These attach to the one registered account. Add GATEWAY_SLOTS_ACCOUNT with
-  # an IG user id if a second account is ever registered; until then the
-  # gateway resolves it, and logs rather than guessing if it becomes ambiguous.
+  # A line without account= attaches to the one registered Instagram account,
+  # which the gateway resolves and logs rather than guesses if that becomes
+  # ambiguous. A line with account= names its own destination, which is how one
+  # schedule covers both surfaces.
+  #
+  # YouTube runs at one a day against Instagram's three, deliberately. The risk
+  # there is not the API, it is the inauthentic content policy, renamed from
+  # "repetitious content" in July 2025 to cover mass produced AI video.
+  # Reviewers assess channel themes and overall patterns rather than single
+  # videos, and three a day of an identical layout is the shape they look for
+  # even when every video is original. Raising it is a one line edit once the
+  # channel has a history that is not all from the same week.
+  #
+  # Removing a line removes that slot, and an account whose lines all disappear
+  # loses its slots rather than keeping them, so deleting a destination here
+  # actually stops it publishing.
   GATEWAY_SLOTS: |
     08:10 Europe/Oslo jitter=15
     12:40 Europe/Oslo jitter=15
     19:20 Europe/Oslo jitter=15
+    21:05 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
 
   # Named zone, not an offset, so the slots stay at the same local hour across
   # a daylight saving change.


### PR DESCRIPTION
## Why

The gateway can now publish a queued video to a YouTube channel as well as to
the Instagram feed. Slots are per destination, so the channel needs one.

## What

One line on `GATEWAY_SLOTS`, naming its own account:

```
21:05 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
```

One a day, against Instagram's three. That gap is deliberate. The risk on
YouTube is not the API, it is the inauthentic content policy, renamed from
"repetitious content" in July 2025 specifically to cover mass produced AI
video. Reviewers assess channel themes and overall content patterns rather
than single videos, and three a day of an identical layout is the shape they
look for even when each video is original. Raising it is a one line edit once
the channel has a history that is not all from the same week.

## Verification

The block was parsed with the gateway's own `parse_slots`, which is the code
that runs at startup and fails the boot on a line it cannot read:

```
08:10 Europe/Oslo jitter=15 account=(instagram)
12:40 Europe/Oslo jitter=15 account=(instagram)
19:20 Europe/Oslo jitter=15 account=(instagram)
21:05 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
```

## Order

Needs the gateway image carrying schema v11, from mortennordbye/reelsmith#12.
Merging this first is harmless: until the channel is registered over
`/api/accounts/youtube` the slot resolves to no account and fires nothing.