### PR TITLE
Hold the reelsmith YouTube slot back until the image can parse it

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -43,11 +43,17 @@ data:
   # Removing a line removes that slot, and an account whose lines all disappear
   # loses its slots rather than keeping them, so deleting a destination here
   # actually stops it publishing.
+  #
+  # The YouTube line is held back until the running image understands
+  # account=. An older parser does not, and parse_slots fails the boot on a
+  # line it cannot read rather than dropping it, so shipping the two in the
+  # wrong order crashlooped the pod. Put it back once the image carrying
+  # schema v11 is promoted:
+  #   21:05 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
   GATEWAY_SLOTS: |
     08:10 Europe/Oslo jitter=15
     12:40 Europe/Oslo jitter=15
     19:20 Europe/Oslo jitter=15
-    21:05 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
 
   # Named zone, not an offset, so the slots stay at the same local hour across
   # a daylight saving change.


### PR DESCRIPTION
## Why

The gateway is crashlooping. `#648` added a slot line using `account=`, which
the running image predates. `parse_slots` fails the boot on a line it cannot
read, which is the correct behaviour and the reason it exists: a schedule that
silently drops the slot with the typo is a schedule that quietly stops posting.
Here it means the two changes shipped in the wrong order.

```
SlotSpecError: '21:05 Europe/Oslo jitter=20 account=UC...': unknown setting 'account'
ERROR:    Application startup failed. Exiting.
```

`#648` claimed merging ahead of the image was harmless, on the reasoning that
the slot would resolve to no account and fire nothing. That is what happens
with a parser that understands the token. An older one never gets that far.

## What

The line comes out, and stays in a comment beside the block so it goes back
verbatim once the image carrying schema v11 is promoted.

## Verification

The remaining block is the three Instagram slots that were running before
`#648`, unchanged.