### PR TITLE
Get the reelsmith Warehouse past the tags it cannot read

### DIFF
--- a/k8s/talos/infra/kargo-projects/reelsmith.yaml
+++ b/k8s/talos/infra/kargo-projects/reelsmith.yaml
@@ -108,7 +108,21 @@ spec:
         # selection.
         imageSelectionStrategy: SemVer
         strictSemvers: true
-        discoveryLimit: 20
+        # Ten rather than twenty, and the number is measured rather than picked.
+        #
+        # 0.0.1 through 0.0.12 point at manifests that no longer resolve. The
+        # build published a provenance attestation as an untagged child and the
+        # repo's own prune job deleted it. Discovery walks the newest N tags and
+        # fails the entire Warehouse on the first one it cannot read, so at
+        # twenty it reached 0.0.12 and stopped promoting anything at all. Six
+        # days and three merged PRs went nowhere while every build reported
+        # success.
+        #
+        # 0.0.13 upwards are intact, which is exactly ten tags. The window only
+        # ever slides further from the broken ones, so this does not need
+        # revisiting, and reelsmith now builds with provenance off so no new tag
+        # gains a child it can lose.
+        discoveryLimit: 10
 ---
 # prod verification: a one-shot Job that curls the gateway and fails on any
 # non-2xx. Unlike logeverylift this host is on the public gateway with a real


### PR DESCRIPTION
## Why

The reelsmith Warehouse has been in `DiscoveryFailure` since 2026-08-09:

```
error retrieving image with tag "0.0.11": MANIFEST_UNKNOWN
```

No freight has been created since, so nothing has been promoted. Three merged
PRs built images successfully and none of them reached the cluster. The build
is green, the CI is green, and the deploy silently does not happen.

The cause is in the reelsmith repo rather than here. `docker/build-push-action`
defaults to publishing a provenance attestation, which makes each push an index
manifest with an untagged child. The repo's prune job deletes untagged versions
and takes the child with it, leaving the tag pointing at nothing. That is fixed
separately by turning provenance off.

## What

`discoveryLimit` from 20 to 10. Discovery walks the newest N tags and fails the
whole Warehouse on the first one it cannot read, so it has to stop above the
damage.

Ten is measured, not chosen. Every semver tag was resolved against the registry
along with its children:

```
0.0.29 0.0.27 0.0.22 0.0.20 0.0.19 0.0.17 0.0.16 0.0.15 0.0.14 0.0.13   OK
0.0.12 and everything below                                            BROKEN
```

Exactly ten intact tags, so this clears the damage with nothing to spare today
and one more every build. The window only ever slides further from the broken
tags, so it does not need revisiting.

## Verification

Cannot be verified before merge: the Warehouse only retries on its own 1m
interval against the live registry. After merge the condition should leave
`DiscoveryFailure`, new freight should appear for 0.0.29, and a promotion PR
should follow.