### PR TITLE
Publish reelsmith Shorts publicly

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -63,4 +63,14 @@ data:
   # GATEWAY_ADMIN_TOKEN and refuses to start with no authentication at all,
   # which matters here because this host is public: Meta fetches media from it,
   # so there is no network boundary in front of the panel.
+  # What a Short goes out as. The documented behaviour is that an unaudited
+  # API project has every upload locked to private whatever this says, and that
+  # is not true of this project: measured on 2026-08-16, three uploads asking
+  # for private, unlisted and public each kept what they asked for. The audit is
+  # still worth submitting for quota and standing; it gates neither.
+  #
+  # The gateway logs a warning if a returned status ever differs from this one,
+  # which is what the restriction would look like if it does start applying.
+  GATEWAY_YOUTUBE_PRIVACY_STATUS: "public"
+
   GATEWAY_ADMIN_ENABLED: "true"


### PR DESCRIPTION
## Why

The gateway has been uploading private since it went live, because the
documented behaviour is that an unaudited API project has every upload locked
to private regardless of what is requested.

That is not true of this project. Measured on 2026-08-16, three uploads asking
for `private`, `unlisted` and `public` each kept the value they asked for, with
no rejection reason and the values still holding after processing. The audit is
worth submitting for quota headroom and compliance standing, and it gates
nothing.

## What

`GATEWAY_YOUTUBE_PRIVACY_STATUS: "public"`.

## Verification

The whole ConfigMap was loaded through the gateway's own `GatewaySettings` and
`parse_slots`, which is the code that runs at startup:

```
privacy parses as: public
slots still parse : 4 slots
```

The gateway logs a warning whenever a returned privacy status differs from the
requested one, so if the restriction ever does start applying here it shows up
as a line naming both values rather than as a silent downgrade.