### PR TITLE
Tune Falco for verksted at the image level

### DIFF
--- a/k8s/talos/infra/falco/values.yaml
+++ b/k8s/talos/infra/falco/values.yaml
@@ -41,59 +41,13 @@ serviceMonitor:
 # (best practice: overriding these hooks is upgrade-safe; the rules consume them).
 customRules:
   tuning.yaml: |-
+    # ---- Cluster infrastructure --------------------------------------------
+
     # Cilium CNI plugin execs from /opt/cni/bin on every node — not a workload.
-    #
-    # Second clause: verksted keeps its agent CLIs current itself, npm-installing
-    # them into the global prefix at runtime rather than baking a version into the
-    # image, so /usr/local/lib/node_modules lives in the container's writable
-    # upper layer. Every exec of claude (or the ripgrep it re-execs itself as, via
-    # argv[0]) therefore carries EXE_WRITABLE|EXE_UPPER_LAYER and trips this rule
-    # — hundreds of Critical events an hour, which is the whole Discord feed.
-    # Pinned to the prefix the updater writes: a binary dropped anywhere else in
-    # this image still alerts, and so does one in any other image. Nothing is lost
-    # by exempting the path, because a dropped binary under /data (where the agent
-    # sessions actually work) sits on the NFS PVC, not the upper layer, and so
-    # never matched this rule to begin with.
     - macro: known_drop_and_execute_activities
-      condition: >
-        (proc.name=cilium-cni and proc.exepath startswith /opt/cni/bin/)
-        or (container.image.repository=ghcr.io/mortennordbye/verksted
-            and proc.exepath startswith /usr/local/lib/node_modules/)
+      condition: (proc.name=cilium-cni and proc.exepath startswith /opt/cni/bin/)
       override:
         condition: replace
-
-    # Unpacking an image layer writes the log files the layer ships with, so
-    # containerd truncates /var/log/dpkg.log every time it pulls a Debian-based
-    # image. Upstream already knows this and exempts it — but only at the host
-    # containerd's snapshot root. verksted's dind sidecar runs its own containerd
-    # under /var/lib/docker/containerd/daemon, so the identical write lands on a
-    # path upstream's macro doesn't cover and every image pull an agent session
-    # does fires this rule. Pinned to that daemon root in the dind image: the
-    # same process writing a log anywhere outside the snapshot tree still alerts.
-    - macro: allowed_clear_log_files
-      condition: >
-        (proc.name=containerd
-         and container.image.repository=docker.io/library/docker
-         and k8s.ns.name=verksted
-         and fd.name startswith /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/)
-      override:
-        condition: replace
-
-    # Agent sessions clone the repo under test into a mkdtemp directory,
-    # /tmp/vk-repos-<random>, and run its suite there. Test suites that harden
-    # against symlink escape create the fixture they defend against — a link to
-    # /etc or /root — and trip this rule from inside the dind daemon, where Falco
-    # has no container metadata to scope on (k8s.ns.name and the image come
-    # through as <NA>), so the linkpath is the only handle available.
-    #
-    # Exempting where the symlink is *created*, not what it points at: a link to
-    # a sensitive file anywhere outside a session's scratch checkout still
-    # alerts, and nothing privileged resolves paths under those directories.
-    - rule: Create Symlink Over Sensitive Files
-      condition: >
-        and not evt.arg.linkpath startswith /tmp/vk-repos-
-      override:
-        condition: append
 
     # kubelet (exec/port-forward streams) and Authentik wire stdio to sockets
     # legitimately; scoped to those binaries so a real shell still alerts.
@@ -102,24 +56,94 @@ customRules:
       override:
         condition: replace
 
+    # ---- verksted: trusted at the image level, not per path ----------------
+    #
+    # verksted is an agent sandbox: sessions install their own tooling at
+    # runtime and run arbitrary code as root. Two rules assume the opposite —
+    # an immutable image and a fixed set of programs — so both fire
+    # continuously, and every attempt to tune them by path only lasts until a
+    # session picks a new path. The npm prefix was exempted first; Playwright
+    # then put WebKit in /opt/ms-playwright and produced ~200 Critical events an
+    # hour, which was the entire Discord feed.
+    #
+    # So the exemption is declared where upstream intends it: these two lists
+    # are the adopter hooks the rules document for images that legitimately
+    # behave this way. Scoped to the image, so the same behaviour anywhere else
+    # still alerts.
+    #
+    # What this gives up: for the verksted container, "ran a binary that was not
+    # in the image" and "read /etc/shadow" stop being signals. Neither had
+    # discriminating power there to begin with — the pod ships a privileged dind
+    # sidecar and hands agents a root shell as its purpose, so an attacker
+    # inside it is indistinguishable from a session doing its job. The rules
+    # that watch the boundary that does matter — container escape, kernel module
+    # injection, release_agent, debugfs — stay armed for this image like any
+    # other.
+    - list: known_drop_and_execute_containers
+      items:
+        - ghcr.io/mortennordbye/verksted
+      override:
+        items: append
+
+    # systemd-sysusers reads /etc/shadow whenever a session apt-installs a
+    # package.
+    - list: read_sensitive_file_images
+      items:
+        - ghcr.io/mortennordbye/verksted
+      override:
+        items: append
+
+    # ---- verksted: the dind sidecar ----------------------------------------
+    #
+    # Falco sees the sidecar as the upstream docker image, so every exemption
+    # below has to pin the namespace too or it would exempt that image
+    # cluster-wide.
+    - macro: verksted_dind
+      condition: (container.image.repository=docker.io/library/docker and k8s.ns.name=verksted)
+
+    # Unpacking an image layer writes the log files the layer ships with, so
+    # containerd truncates /var/log/dpkg.log every time it pulls a Debian-based
+    # image. Upstream already knows this and exempts it — but only at the host
+    # containerd's snapshot root. The dind sidecar runs its own containerd under
+    # /var/lib/docker/containerd/daemon, so the identical write lands on a path
+    # upstream's macro doesn't cover and every image pull an agent session does
+    # fires this rule. Pinned to that daemon root: the same process writing a
+    # log anywhere outside the snapshot tree still alerts.
+    - macro: allowed_clear_log_files
+      condition: >
+        (proc.name=containerd and verksted_dind
+         and fd.name startswith /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/)
+      override:
+        condition: replace
+
     # cilium-agent opens AF_PACKET sockets as part of normal datapath setup, and
-    # so does the dockerd in verksted's dind sidecar every time it wires up the
-    # network for a container an agent session starts — about once a minute,
-    # which is noise loud enough to bury a real notice.
+    # so does the dind dockerd every time it wires up the network for a
+    # container an agent session starts — about once a minute.
     #
     # Appended to the rule rather than filled into its template hook, unlike the
     # tunings above: upstream declares user_known_packet_socket_binaries as a
     # *list* consumed by `proc.name in (...)`, so filling it can only ever say
     # "this binary name, anywhere". Exempting dockerd cluster-wide is a wider
-    # hole than either daemon needs. This keeps each exemption pinned to the
-    # image it belongs to, so the same binary in any other container still
-    # alerts. (The entry here was previously written as a macro override, which
-    # silently did nothing at all: it declared a second thing under the list's
-    # name, and no rule ever referred to it.)
+    # hole than either daemon needs.
     - rule: Packet socket created in container
       condition: >
         and not (proc.name=cilium-agent and container.image.repository=quay.io/cilium/cilium)
-        and not (proc.name=dockerd and container.image.repository=docker.io/library/docker
-                 and k8s.ns.name=verksted)
+        and not (proc.name=dockerd and verksted_dind)
+      override:
+        condition: append
+
+    # Agent sessions clone the repo under test into a mkdtemp directory,
+    # /tmp/vk-repos-<random>, and run its suite there. Test suites that harden
+    # against symlink escape create the fixture they defend against — a link to
+    # /etc or /root — and trip this rule from inside the dind daemon, where
+    # Falco has no container metadata to scope on (k8s.ns.name and the image
+    # come through as <NA>), so the linkpath is the only handle available.
+    #
+    # Exempting where the symlink is *created*, not what it points at: a link to
+    # a sensitive file anywhere outside a session's scratch checkout still
+    # alerts, and nothing privileged resolves paths under those directories.
+    - rule: Create Symlink Over Sensitive Files
+      condition: >
+        and not evt.arg.linkpath startswith /tmp/vk-repos-
       override:
         condition: append


### PR DESCRIPTION
## Why

A 24h sweep across all six nodes returned 435 Falco events, all of them from the verksted container. Every other node was silent.

| Rule | Events |
|---|---|
| Drop and execute new binary in container | 431 |
| Read sensitive file untrusted | 4 |

Of the 431, 415 were Playwright's WebKit under `/opt/ms-playwright` and 16 were apt/dpkg postinst helpers.

The existing exemption pinned `/usr/local/lib/node_modules`, which only held until a session installed a tool somewhere else. Playwright then put WebKit in `/opt/ms-playwright` and the rule went back to roughly 200 Critical events an hour. Pinning paths cannot work for a sandbox that installs its own tooling at runtime, so this stops doing that.

## What

Both noisy rules ship an adopter hook for images that legitimately behave this way, and the repo was not using either.

- `ghcr.io/mortennordbye/verksted` added to `known_drop_and_execute_containers` and `read_sensitive_file_images`. Covers all current noise regardless of where the next tool installs itself.
- Dropped the `/usr/local/lib/node_modules` clause, so `known_drop_and_execute_activities` is back to cilium only.
- Extracted a `verksted_dind` macro. That image and namespace predicate was written out twice.
- Regrouped the file into cluster infra, verksted image, and verksted dind sections.

For the verksted container this gives up two signals: "ran a binary not in the image" and "read /etc/shadow". Neither had discriminating power there, since the pod runs a privileged dind sidecar and hands agents a root shell as its purpose. Container escape detection (kernel module injection, release_agent, debugfs, /dev/shm exec) stays armed for this image like any other.

## Verification

- `falco --validate` against the running 0.44.1 engine with the base ruleset loaded: clean, no warnings.
- `falco -L` JSON dump confirms both lists resolve to the verksted image, `verksted_dind` expands, and the Packet socket rule compiles with its appended clause.
- `kustomize build --enable-helm` renders. The rendered ConfigMap content was re-validated against the engine, and its non-comment diff against the validated candidate is empty.
- `kubectl diff --field-manager=argocd-controller` touches only the `falco-rules` ConfigMap and the DaemonSet `checksum/rules` annotation, so Reloader restarts the DaemonSet on sync.

The dind sidecar runs as `docker.io/library/docker`, so it cannot join those global image lists without exempting that image cluster-wide. It still needs namespace-pinned clauses, as before.
