### PR TITLE
feat(reelsmith): send the bare private hostname to the panel

### DIFF
--- a/k8s/talos/apps/reelsmith/httproute-admin.yaml
+++ b/k8s/talos/apps/reelsmith/httproute-admin.yaml
@@ -55,6 +55,36 @@ spec:
           port: 80
           weight: 1
 
+    # The bare hostname goes to the panel. The app mounts nothing on `/`, so
+    # opening reelsmith.local.bigd.no answered a JSON 404 and the panel had to
+    # be reached by typing the path.
+    #
+    # Here rather than in the app, because this file is the only place that is
+    # private by construction: it is parented to the private gateway and bound
+    # to this hostname, so the redirect cannot appear on gate.nordbye.it no
+    # matter what the app does later. A `/` route in FastAPI would have to test
+    # the Host header to stay local, which is a second thing to keep right.
+    #
+    # Exact beats PathPrefix in Gateway API's matching precedence, so this wins
+    # over the catch-all below regardless of rule order, and only for the bare
+    # path. No auth filter, because a redirect reaches no backend and discloses
+    # nothing the hostname did not already give away; /admin/ behind it is
+    # still authentik plus GATEWAY_ADMIN_TOKEN.
+    #
+    # 302 rather than 301: browsers cache a permanent redirect hard enough that
+    # undoing it means clearing state on every machine that saw it.
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /admin/
+            statusCode: 302
+
     # The whole app, not just /admin. Reaching /api or /media over the private
     # name is harmless and occasionally useful for debugging, and restricting
     # it here would only mean two lists to keep in step.


### PR DESCRIPTION
## Why

Opening `reelsmith.local.bigd.no` answered `{"detail":"Not Found"}`. The app
mounts nothing on `/`, so the control panel had to be reached by typing
`/admin/` every time.

## What

An `Exact: /` rule on the admin HTTPRoute with a `RequestRedirect` filter to
`/admin/`.

It lives here rather than in the FastAPI app because this file is the only place
that is private by construction: it is parented to `traefik-gateway-private` and
bound to `reelsmith.local.bigd.no`, so the redirect cannot appear on
`gate.nordbye.it` regardless of what the app grows later. A `/` route in the app
would have to test the Host header to stay local, which is a second thing to
keep right. The public route does not serve `/` at all today, but that is an
allowlist that could change.

`Exact` beats `PathPrefix` in Gateway API matching precedence, so the rule wins
over the existing catch-all regardless of order, and only for the bare path.

No auth filter on it: a redirect reaches no backend and discloses nothing the
hostname did not already give away, and `/admin/` behind it is still authentik
forward-auth plus `GATEWAY_ADMIN_TOKEN`. `302` rather than `301`, because a
permanent redirect is cached hard enough that undoing it means clearing state on
every machine that saw it.

## Verification

`kustomize build k8s/talos/apps/reelsmith` renders clean. Parsed the result and
confirmed three rules in the expected precedence, the redirect carrying no
backendRefs, and the hostname and parent gateway unchanged.