### PR TITLE
feat(verksted): give the pod cluster read for its agent sessions

### DIFF
--- a/k8s/talos/apps/verksted/deployment.yaml
+++ b/k8s/talos/apps/verksted/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app: verksted-app
     spec:
+      # Not the namespace default: the token projected into this pod is what
+      # kubectl in an agent session authenticates with, so the account it names
+      # is the whole access boundary. See rbac.yaml.
+      serviceAccountName: verksted
       containers:
         - name: verksted
           image: ghcr.io/mortennordbye/verksted:0.0.7

--- a/k8s/talos/apps/verksted/kustomization.yaml
+++ b/k8s/talos/apps/verksted/kustomization.yaml
@@ -4,6 +4,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-wave: "0"
 resources:
 - namespace.yaml
+- rbac.yaml
 - data-pvc.yaml
 - deployment.yaml
 - service.yaml

--- a/k8s/talos/apps/verksted/rbac.yaml
+++ b/k8s/talos/apps/verksted/rbac.yaml
@@ -1,0 +1,90 @@
+# Cluster read for the agent sessions in this pod, so an agent can answer "what
+# is broken" and "why is this Application OutOfSync" from kubectl instead of
+# being told the answer. Argo CD and Kargo are CRD-driven, so their objects are
+# reachable through the same apiserver credential — no second auth system, no
+# API token to mint and rotate.
+#
+# Read the blast radius before widening this: the token is mounted into a pod
+# whose job is running LLM-driven shells, and every session in every project
+# inherits it. Reads are cluster-wide; the single write verb is `create` on
+# Kargo Promotions.
+#
+# No sync-wave annotation here, unlike the siblings: this kustomization sets one
+# in commonAnnotations, which overwrites whatever a file asks for, so every
+# object in this directory lands in wave 0 regardless. Ordering inside a wave is
+# ArgoCD's own by-kind sort, and that already puts a ServiceAccount and its
+# bindings ahead of the Deployment that uses them.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: verksted
+  namespace: verksted
+---
+# The builtin `view` role covers the namespaced reads that matter (pods, logs,
+# events, workloads, services) and deliberately excludes Secrets, which is the
+# property that makes it safe to bind cluster-wide. Everything in the ClusterRole
+# below is what `view` does not reach: cluster-scoped objects, and the CRD groups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: verksted-agent-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: verksted
+    namespace: verksted
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verksted-agent
+rules:
+  # Cluster-scoped diagnosis: which node is unhappy, which PV did not bind,
+  # which CRD version an operator actually serves.
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch"]
+  # kubectl top, for the throttling and eviction questions this pod itself raised.
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
+  # Argo CD and Argo Rollouts: sync status, drift, and the AnalysisRuns that
+  # Kargo's verification step creates.
+  - apiGroups: ["argoproj.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # Kargo: Warehouses, Freight, Stages, Promotions.
+  - apiGroups: ["kargo.akuity.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  # The one write. Every project here auto-promotes through a homelab PR, so the
+  # deploy gate is still merging that PR — this only covers re-promoting older
+  # Freight, which has no PR to merge.
+  - apiGroups: ["kargo.akuity.io"]
+    resources: ["promotions"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: verksted-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: verksted-agent
+subjects:
+  - kind: ServiceAccount
+    name: verksted
+    namespace: verksted


### PR DESCRIPTION
The verksted pod already runs inside Genesis with a projected ServiceAccount token mounted. The account behind it — `verksted:default` — can do nothing but discovery, so an agent session diagnosing a deploy has to be told the answer instead of looking. [verksted#61](https://github.com/mortennordbye/verksted/pull/61) ships kubectl in the image for exactly this; this is the other half.

### What it grants

A dedicated `verksted` ServiceAccount rather than the namespace default, because the token in that pod is the whole access boundary and it should be named.

- **Reads:** the builtin `view` role, bound cluster-wide. It excludes Secrets, and that exclusion is the property that makes it safe to bind that widely.
- Plus what `view` does not reach: nodes, PVs, storage classes, CRDs, API services, `metrics.k8s.io` for `kubectl top`, and the `argoproj.io` and `kargo.akuity.io` groups. Argo CD and Kargo being CRD-driven is what keeps this to one credential instead of an API token per system.
- **One write:** `create` on Kargo Promotions. Every project here auto-promotes through a homelab PR, so merging that PR stays the deploy gate — this only covers re-promoting older Freight, which has no PR to merge.

Nothing else is writable. ArgoCD owns cluster state and reconciles it from this repo, so a change belongs in a manifest and a pull request.

Worth being deliberate about: this credential belongs to a pod whose job is running LLM-driven shells, and every session in every project inherits it.

### Notes

`rbac.yaml` carries no `sync-wave` annotation, unlike its siblings. This kustomization sets one in `commonAnnotations`, which overwrites whatever a file asks for — every object in the directory renders as wave 0 regardless, including `deployment.yaml`'s `"2"`. Left as found; flagging it because the annotations in there read as if they do something. Ordering within a wave is ArgoCD's by-kind sort, which already puts a ServiceAccount and its bindings ahead of the Deployment.

The Deployment gains `serviceAccountName`, so syncing this recreates the pod (strategy `Recreate`) and ends every live agent session with it.

### Verification

`kubectl kustomize k8s/talos/apps/verksted` renders clean, and every rendered object validates against the live apiserver's schema (1.35.7) via a client dry-run. `kubectl diff` is the one check not run: the credential it would need is the credential this PR creates.

After sync: `kubectl auth can-i --list` from the pod, and `kubectl auth can-i get secrets -A` should answer **no**.