### PR TITLE
Let a promotion survive one bad answer from GitHub

### DIFF
--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask-pr.yaml
@@ -1,12 +1,20 @@
+# Every step here that reaches GitHub or Argo CD carries a `retry.errorThreshold`
+# because Kargo's system-wide default is 1, which means "no retries": one 5xx
+# from an API this has no control over marks the whole Promotion failed, and a
+# failed Promotion is terminal, so the Stage sits at the old Freight until
+# somebody notices and promotes by hand. That is not theoretical; see the note
+# on wait-pr below.
+#
 # PR-based variant of promote-to-argocd. Same image-bump logic, but instead of
 # pushing the commit straight to main it pushes to a generated branch, opens a
 # homelab PR, and blocks until that PR is merged in GitHub before syncing Argo
 # CD. This keeps promotion "review-and-merge in GitHub" while Kargo still drives
 # image discovery, the pipeline view, and post-deploy verification.
 #
-# Currently used only by portfolio's prod Stage as a pilot. The direct-push
-# promote-to-argocd task (clusterpromotiontask.yaml) is unchanged and still used
-# by every stage Stage and by blog.
+# Every prod Stage promotes through this now; the pilot on portfolio ended. The
+# direct-push promote-to-argocd task (clusterpromotiontask.yaml) is what the
+# pre-prod Stages use, where a PR per image bump would be ceremony around a
+# deploy nobody reviews.
 #
 # PREREQUISITE: the git credential's GitHub App (mortennordbye-homelab-deployer)
 # needs Pull requests: read/write in addition to Contents: read/write. git-open-pr
@@ -25,6 +33,8 @@ spec:
     - name: argocdApp    # Argo CD Application to sync, e.g. portfolio
   steps:
     - uses: git-clone
+      retry:
+        errorThreshold: 3
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         # Without this Kargo authors commits as `Kargo <no-reply@kargo.io>`,
@@ -65,12 +75,16 @@ spec:
     # Output references are also kept null-safe as belt-and-suspenders.
     - uses: git-push
       as: push
+      retry:
+        errorThreshold: 3
       if: ${{ status('commit') != 'Skipped' }}
       config:
         path: ./repo
         generateTargetBranch: true
     - uses: git-open-pr
       as: open-pr
+      retry:
+        errorThreshold: 3
       if: ${{ status('commit') != 'Skipped' }}
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
@@ -89,16 +103,30 @@ spec:
     # Blocks the promotion until the PR is merged in GitHub.
     - uses: git-wait-for-pr
       as: wait-pr
+      # This one polls GitHub for as long as the PR is open, so over a review
+      # that takes a day it makes hundreds of API calls and only needs to be
+      # unlucky once. Left at the system-wide default of 1 it was: a 504 from
+      # api.github.com killed blog's promotion of 0.0.103 on 2026-08-15 and
+      # portfolio's of 0.0.103 on 2026-08-17, the second one *after* its PR had
+      # already merged, so the manifest was live and the Stage read Unknown for
+      # a day. Consecutive is the word that matters: five failures in a row is
+      # GitHub being down, which is worth failing on. One is weather.
+      retry:
+        errorThreshold: 5
       if: ${{ status('open-pr') != 'Skipped' }}
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         provider: github
         prNumber: ${{ task.outputs?.['open-pr']?.pr?.id ?? 0 }}
     - uses: argocd-update
+      retry:
+        errorThreshold: 3
       config:
         apps:
           - name: ${{ vars.argocdApp }}
     - uses: argocd-wait
+      retry:
+        errorThreshold: 3
       config:
         apps:
           - name: ${{ vars.argocdApp }}

--- a/k8s/talos/infra/kargo-projects/clusterpromotiontask.yaml
+++ b/k8s/talos/infra/kargo-projects/clusterpromotiontask.yaml
@@ -10,6 +10,13 @@
 # (both stage and prod apps track shared main HEAD; a fixed revision falls behind
 # on the next commit and reports the Stage perpetually Unhealthy). Real
 # verification is each Stage's own AnalysisTemplate smoke test.
+#
+# Every step that reaches GitHub or Argo CD carries a `retry.errorThreshold`,
+# because Kargo's system-wide default is 1 and 1 means no retries at all: one
+# 5xx from an API this has no control over marks the whole Promotion failed,
+# and a failed Promotion is terminal, so the Stage sits on the old Freight
+# until somebody notices. See the note on wait-pr in clusterpromotiontask-pr.yaml
+# for what that looked like when it happened.
 apiVersion: kargo.akuity.io/v1alpha1
 kind: ClusterPromotionTask
 metadata:
@@ -22,6 +29,8 @@ spec:
     - name: argocdApp    # Argo CD Application to sync, e.g. portfolio-stage
   steps:
     - uses: git-clone
+      retry:
+        errorThreshold: 3
       config:
         repoURL: https://github.com/mortennordbye/homelab.git
         # Without this Kargo authors commits as `Kargo <no-reply@kargo.io>`,
@@ -45,13 +54,19 @@ spec:
         path: ./repo
         message: "chore(${{ vars.appName }}): promote ${{ imageFrom(vars.imageRepo).Tag }} to ${{ ctx.stage }}"
     - uses: git-push
+      retry:
+        errorThreshold: 3
       config:
         path: ./repo
     - uses: argocd-update
+      retry:
+        errorThreshold: 3
       config:
         apps:
           - name: ${{ vars.argocdApp }}
     - uses: argocd-wait
+      retry:
+        errorThreshold: 3
       config:
         apps:
           - name: ${{ vars.argocdApp }}


### PR DESCRIPTION
Three prod Stages have been stuck on a transient GitHub error, two of them for days:

| Stage | State | Cause |
|---|---|---|
| blog-cd/prod | Errored 2d18h, prod on 0.0.101 while stage runs 0.0.103 | `git-wait-for-pr`: `GET .../pulls/647: 504` |
| portfolio-cd/prod | Errored 26h, though prod *is* on 0.0.103 | same, on PR 660 — **after** that PR had merged |
| headroom-cd/prod | Running 4d22h | waiting on PR #668, not opted into auto-merge (correct: it has a demo Stage) |

Kargo's system-wide `errorThreshold` default is 1, i.e. no retries. `git-wait-for-pr` polls GitHub for as long as the PR stays open, so over a day-long review it makes hundreds of calls and only has to be unlucky once — and a failed Promotion is terminal, so the Stage sits on its old Freight until someone promotes by hand.

- `git-wait-for-pr`: `errorThreshold: 5`
- `git-clone`, `git-push`, `git-open-pr`, `argocd-update`, `argocd-wait`: `errorThreshold: 3`
- Same on the direct-push `promote-to-argocd` task, which has the same exposure on push and on the Argo CD steps.
- The PR task's header still described itself as a portfolio-only pilot; every prod Stage uses it now, so the comment says that instead.

Consecutive failures are what the threshold counts, so five in a row still fails the promotion — that is GitHub being down, which is worth failing on.

Does not retroactively fix the two Errored promotions: those are terminal records. blog prod needs one manual promote of the current Freight to catch up from 0.0.101; portfolio prod is already on the right image and will go green on its next Freight.