### PR TITLE
chore(blog): promote 0.0.103 to prod

### DIFF
--- a/k8s/talos/apps/blog/kustomization.yaml
+++ b/k8s/talos/apps/blog/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 # deployment.yaml.
 images:
 - name: ghcr.io/mortennordbye/homelab/blog
-  newTag: 0.0.101
+  newTag: 0.0.103


### PR DESCRIPTION
blog prod has been serving `0.0.101` for three days while stage runs `0.0.103` and passed its smoke test. This is the bump the Kargo promotion would have made.

Kargo did open it, as #647. Its `git-wait-for-pr` step took a `504` from api.github.com against an `errorThreshold` of 1, the Promotion errored terminally, and the deployer app closed its own PR — so nothing rejected this version, and no Promotion is left that could reopen it. #675 raised those thresholds so it stops happening; it cannot revive a Promotion that already failed.

Content is identical to what `kustomize-set-image` writes. The Stage record catches up on the next Freight: `git-commit` finds nothing to do, `git-push`/`open-pr`/`wait-pr` skip on `status('commit') == 'Skipped'`, and `argocd-update`/`argocd-wait` still run, so the Stage goes green without a second deploy.