### PR TITLE
fix(logeverylift): smoke test the hostname the app actually serves

### DIFF
--- a/k8s/talos/infra/kargo-projects/logeverylift.yaml
+++ b/k8s/talos/infra/kargo-projects/logeverylift.yaml
@@ -112,9 +112,20 @@ spec:
         discoveryLimit: 20
 ---
 # prod verification: a one-shot Job that curls the app URL and fails on any
-# non-2xx. logeverylift is on the private gateway with an internal cert, so use
-# the internal hostname and -k. No KEDA (stays warm); the retries cover the
-# rolling pod from the deploy the promotion just triggered.
+# non-2xx. No KEDA (stays warm); the retries cover the rolling pod from the
+# deploy the promotion just triggered.
+#
+# The hostname is the public one, because #369 moved this app off the private
+# gateway onto traefik-gateway-public and the HTTPRoute now answers for
+# logeverylift.com alone. This check kept asking the old internal name, which
+# no route matches, so Traefik answered 404 and every verification since
+# 2026-07-18 has failed: three Freights promoted fine and each reported the
+# Stage unhealthy on a check that could not have passed. -k stays because it
+# costs nothing and this is a liveness check, not a TLS test.
+#
+# -L because / redirects to /login for anyone without a session, which is the
+# app working. Without it the check asserts nothing beyond "Traefik routed
+# somewhere", since -f treats a 307 as success.
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -141,9 +152,9 @@ spec:
                       - /bin/sh
                       - -c
                       - >
-                        curl -fsSk --retry 10 --retry-delay 6 --retry-all-errors
+                        curl -fsSkL --retry 10 --retry-delay 6 --retry-all-errors
                         -o /dev/null -w '%{http_code}\n'
-                        https://logeverylift.local.bigd.no/
+                        https://logeverylift.com/
 ---
 # prod: the only Stage. Receives Freight straight from the Warehouse
 # (sources.direct), auto-promoted per ProjectConfig through promote-via-pr, then
@@ -158,7 +169,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     # Cosmetic UI colour, kept identical across apps: prod = red.
     kargo.akuity.io/color: "#e11d48"
-    kargo.akuity.io/description: "Auto-promoted from the Warehouse via a homelab PR; smoke-tested on logeverylift.local.bigd.no after merge."
+    kargo.akuity.io/description: "Auto-promoted from the Warehouse via a homelab PR; smoke-tested on logeverylift.com after merge."
 spec:
   requestedFreight:
     - origin:


### PR DESCRIPTION
`logeverylift-cd/prod` has read Healthy=False since 2026-07-18, on a check that could not have passed.

The verification Job curls `https://logeverylift.local.bigd.no/`. #369 cut this app over to `traefik-gateway-public`, and its HTTPRoute now lists `logeverylift.com` as its only hostname — so nothing matches the old internal name and Traefik answers **404**, which `curl -f` treats as failure. Measured from inside the cluster just now:

```
https://logeverylift.local.bigd.no/  ->  404
https://logeverylift.com/            ->  307 -> 200  (/login?from=%2F)
```

Three Freights promoted, deployed and served traffic in that window while the Stage reported unhealthy, which is the expensive kind of false alarm: it trains you to ignore the one signal that says a deploy went wrong.

- URL is the public hostname now, matching the pattern the blog and reelsmith templates already use.
- `-L` added because `/` redirects to `/login` for a session-less client, which is the app working. Without it the check asserts almost nothing, since `-f` passes a 307.
- `-k` kept: it costs nothing and this is a liveness check, not a TLS test.
- The Stage's description annotation named the old host too.