### PR TITLE
fix(blog): move prod to the unprivileged nginx port

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,12 +4,6 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Apps
 
-### Flip blog prod to the unprivileged nginx port
-- **What:** `blog/Dockerfile` now serves from `nginxinc/nginx-unprivileged` on port 8080, and `blog-stage` was moved to match. Blog **prod** is deliberately still on port 80 everywhere: `deployment.yaml` (`containerPort`), `service.yaml` (`targetPort`), and both `toPorts` rules in `ciliumnetworkpolicy.yaml`.
-- **Why deferred:** Prod runs an older image (`newTag: 0.0.96`) that still listens on 80. Flipping the prod manifests before that image is promoted would point the Service and the network policy at a port nothing is listening on, taking the blog down until the promotion lands. Kargo's prod stage uses `promote-via-pr`, so prod does not move on its own — the two changes have to land together.
-- **Unblock:** When the Kargo prod promotion PR for the first image built after this change appears, add the port edits to that same PR before merging: `containerPort: 8080`, `targetPort: 8080`, and both CiliumNetworkPolicy `toPorts` entries to `"8080"`. Mirror the `securityContext`, `/tmp` emptyDir and `automountServiceAccountToken: false` from `blog-stage/deployment.yaml`. Verify with `kubectl diff -k k8s/talos/apps/blog --server-side --field-manager=argocd-controller` (the default field manager reports a spurious duplicate-port error).
-- **Where:** `k8s/talos/apps/blog/{deployment,service,ciliumnetworkpolicy}.yaml`, mirroring `k8s/talos/apps/blog-stage/`.
-
 ### Orphaned huntarr manifest
 - **What:** `k8s/talos/apps/arr-stack/huntarr.yaml` is commented out of the arr-stack `kustomization.yaml`, nothing is running in the cluster, and `ghcr.io/plexguide/huntarr` no longer resolves in any registry (the upstream repo is gone). Renovate is now explicitly disabled for that image, which was the source of a permanent "Package lookup failures" problem on the dependency dashboard.
 - **Why deferred:** Deleting someone's disabled app manifest is a judgement call, not a dependency fix. The Renovate disable removes the noise either way.

--- a/k8s/talos/apps/blog/ciliumnetworkpolicy.yaml
+++ b/k8s/talos/apps/blog/ciliumnetworkpolicy.yaml
@@ -14,7 +14,9 @@ spec:
             "k8s:app.kubernetes.io/instance": traefik-traefik
       toPorts:
         - ports:
-            - port: "80"
+            # Enforced at the pod, so this is the container port, not the
+            # Service port. Unprivileged nginx listens on 8080.
+            - port: "8080"
               protocol: TCP
     - fromEntities:
         - host

--- a/k8s/talos/apps/blog/deployment.yaml
+++ b/k8s/talos/apps/blog/deployment.yaml
@@ -27,13 +27,33 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: blog
                 topologyKey: topology.kubernetes.io/zone
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
+        # nginx-unprivileged runs as the built-in `nginx` user (uid 101).
+        runAsUser: 101
+        runAsGroup: 101
       containers:
         - name: blog
           image: ghcr.io/mortennordbye/homelab/blog:10930ac
           imagePullPolicy: Always
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m
@@ -49,3 +69,11 @@ spec:
             httpGet:
               path: /
               port: http
+          volumeMounts:
+            # Only writable path nginx-unprivileged needs: it puts client_body,
+            # proxy and fastcgi temp dirs under /tmp rather than /var/cache/nginx.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/talos/apps/blog/service.yaml
+++ b/k8s/talos/apps/blog/service.yaml
@@ -9,4 +9,6 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      # The container listens on 8080 (unprivileged nginx). Service port stays
+      # 80 so the HTTPRoute references nothing new.
+      targetPort: 8080


### PR DESCRIPTION
## Why

The blog image moved to `nginx-unprivileged` on port 8080 in #600. `blog-stage` was migrated with it; prod was deliberately left on 80 because the image it ran at the time still listened there, tracked by a BACKLOG entry saying to fold the port edits into the first prod promotion PR.

#676 promoted 0.0.103 to prod without them. Prod has since been trying to roll a pod that listens on 8080 behind a probe, Service and network policy all pointing at 80:

```
Liveness probe failed: Get "http://10.244.2.187:80/": connect: connection refused
Container blog failed liveness probe, will be restarted
```

The pod is killed ~28s in and sits in CrashLoopBackOff. The previous 0.0.101 replicas keep serving, so the blog is up, but the rollout is stuck and Kargo's `blog-cd/prod` Stage errors on `argocd-wait`.

## What

- `containerPort`, `targetPort` and the CiliumNetworkPolicy `toPorts` to 8080.
- Mirror the `securityContext`, `/tmp` emptyDir and `automountServiceAccountToken: false` from `blog-stage/deployment.yaml`.
- Drop the completed BACKLOG entry.

Prod's KEDA ScaledObject is a `cron` trigger rather than the HTTP add-on, so unlike stage it needs no interceptor ingress rule.

## Verification

`kubectl diff -k k8s/talos/apps/blog --server-side --field-manager=argocd-controller` reports only the three ports and the hardening fields. `kubectl kustomize k8s/talos/apps/blog` renders.

Not yet observed in the cluster — the rollout happens on merge.

## Caveat

Rolling this flips the Service to `targetPort: 8080` while the old 0.0.101 replicas still listen on 80 and stay Ready, so a share of requests fail for the length of the rollout. Unavoidable in either order once the image has moved.