### PR TITLE
chore(kargo): opt headroom into promotion auto-merge

### DIFF
--- a/.github/workflows/kargo-automerge.yaml
+++ b/.github/workflows/kargo-automerge.yaml
@@ -1,7 +1,10 @@
 # Merges Kargo's promotion PRs for the apps named in the KARGO_AUTOMERGE_APPS
-# repository variable. Those apps have no stage environment, so the PR is a
-# record rather than a review: the build was already vetted in the app's own
-# repo and the promotion still has to pass its smoke test afterwards.
+# repository variable. For those apps the PR is a record rather than a review:
+# the build was already vetted in the app's own repo and the promotion still has
+# to pass its smoke test afterwards. Most of them have no pre-prod environment at
+# all; headroom is the exception, where prod takes only Freight the demo canary
+# already verified (`sources.stages: [demo]`), so the canary is the gate the
+# merge click was standing in for.
 #
 # Kill switch, no deploy and no commit needed: Settings > Secrets and variables
 # > Actions > Variables > KARGO_AUTOMERGE_APPS. Drop an app from the list, or


### PR DESCRIPTION
## Why

`KARGO_AUTOMERGE_APPS` is now `logeverylift,verksted,reelsmith,headroom` (repository variable, already set — not tracked in the repo).

headroom's `demo` Stage already promoted unattended: it uses `promote-to-argocd`, which pushes straight to main and never opens a PR. Only `prod` used `promote-via-pr` and blocked on a merge, so that is the only thing this changes.

## What

Comment-only. The header claimed opted-in apps have no pre-prod environment, which headroom breaks. Prod takes only Freight the demo canary has verified (`sources.stages: [demo]`), so the canary plus prod's own smoke test are the gates the merge click was standing in for — worth saying, rather than leaving the comment describing a rule the list no longer follows.

The kill switch is unchanged: drop `headroom` from the variable and the next promotion PR waits for a human.

## Verification

`actionlint` passes. No workflow logic changed — the gate already keys off the `app/<name>` label, which headroom's promotion PRs already carry.