### PR TITLE
ci: publish stargazer days for the profile star history card

### DIFF
--- a/.github/workflows/star-history.yaml
+++ b/.github/workflows/star-history.yaml
@@ -1,0 +1,72 @@
+name: Star history
+
+# Publishes this repo's stargazer timestamps, bucketed by day, for the star
+# history card in the profile README (mortennordbye/mortennordbye). That
+# generator cannot read them itself: its workflow token is an installation
+# token scoped to its own repo, and the stargazer listing answers
+# "Resource not accessible by integration" for any other repo. Read from here
+# it is just this repo's own data, which its own GITHUB_TOKEN may read.
+#
+# Same shape as the Lighthouse card's data hand-off: JSON on a data branch,
+# fetched over raw.githubusercontent by the generator.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every 6 hours at :40, ahead of the profile repo's refresh on the hour.
+    - cron: "40 */6 * * *"
+
+permissions:
+  # write so the job can push to the stars-data branch.
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Collect stargazer timestamps
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # shellcheck disable=SC2016  # $owner/$name/$endCursor are GraphQL variables, not shell
+          gh api graphql --paginate -F owner="${GITHUB_REPOSITORY%/*}" -F name="${GITHUB_REPOSITORY#*/}" -f query='
+            query($owner: String!, $name: String!, $endCursor: String) {
+              repository(owner: $owner, name: $name) {
+                stargazers(first: 100, after: $endCursor, orderBy: {field: STARRED_AT, direction: ASC}) {
+                  pageInfo { hasNextPage endCursor }
+                  edges { starredAt }
+                }
+              }
+            }' --jq '.data.repository.stargazers.edges[].starredAt' > starred.txt
+          wc -l < starred.txt
+
+      - name: Build stars JSON
+        run: |
+          # Empty means the query failed or paginated to nothing; publishing
+          # that would blank the card, so fail instead and keep the last file.
+          test -s starred.txt
+          mkdir -p dist
+          cut -c1-10 starred.txt | jq -R . | jq -s \
+            --arg repo "$GITHUB_REPOSITORY" \
+            '{repo: $repo,
+              generatedAt: (now | todate),
+              total: length,
+              days: (sort | group_by(.) | map({key: .[0], value: length}) | from_entries)}' \
+            > dist/stars.json
+          jq '{repo, generatedAt, total, days: (.days | length)}' dist/stars.json
+
+      - name: Publish to stars-data branch
+        uses: crazy-max/ghaction-github-pages@v5
+        with:
+          target_branch: stars-data
+          build_dir: dist
+          keep_history: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

star-history.com stopped rendering, so the star history chart for this repo is now drawn by the profile README generator in `mortennordbye/mortennordbye`. That generator cannot fetch the data itself: its workflow token is an installation token scoped to its own repo, and the stargazer listing answers `Resource not accessible by integration` for any other repo, over both REST and GraphQL. Verified in two runs there before falling back to this approach.

Read from here it is just this repo's own data, which this repo's `GITHUB_TOKEN` may read.

## What

A scheduled job collects the stargazer timestamps over GraphQL, buckets them by day, and publishes `stars.json` to the `stars-data` branch. The generator fetches it over raw.githubusercontent, exactly as it already does for `lighthouse.json` on the `lighthouse-data` branch.

Day buckets rather than raw timestamps keep the file near a kilobyte and are the resolution the chart draws at anyway. The build step fails on an empty collection rather than publishing a file that would blank the card.

Runs every 6 hours at :40, twenty minutes ahead of the profile repo's refresh on the hour.

## Verification

`actionlint` clean. The `gh api graphql --paginate` call and the `jq` bucketing were run locally against this repo: 288 stars across 50 days, first 2026-01-07, peak 81 on 2026-06-19, 1167-byte output. Those numbers match a separate raw `gh api` dump of the same data.