### PR TITLE
blog(headroom): move the post date to 20 August

### DIFF
--- a/blog/content/blog/headroom/index.md
+++ b/blog/content/blog/headroom/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Headroom: The Private Finance Overview School Never Gave You"
 description: "A self-hosted Norwegian finance tracker. Equity after tax, ten years of salary against CPI, what you cost your employer, the month, and a fifteen year forecast."
-date: 2026-08-04
+date: 2026-08-20
 draft: false
 tags: ["self-hosted", "docker", "personal-finance", "privacy", "cilium", "kubernetes", "intermediate"]
 ---


### PR DESCRIPTION
## Why

The Headroom post is being promoted on LinkedIn, so it should carry a current date rather than the original 4 August.

## What

`date` moves from 2026-08-04 to 2026-08-20 in the post frontmatter. Nothing else changes.

## Verification

- `hugo --minify --gc` in the pinned build image from `blog/Dockerfile`: post renders to `/blog/headroom/`, displays 2026-08-20, and sits first on the blog index.
- `markdownlint-cli2 "blog/content/**/*.md"`: 0 errors.