### PR TITLE
Live cluster status card in the README

### DIFF
--- a/.github/workflows/status-card.yaml
+++ b/.github/workflows/status-card.yaml
@@ -19,8 +19,7 @@ on:
     - cron: "*/15 * * * *"
 
 permissions:
-  # write so the job can push to the status-data branch.
-  contents: write
+  contents: read
 
 concurrency:
   group: status-card
@@ -31,6 +30,9 @@ jobs:
     if: github.repository_owner == 'mortennordbye'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      # write only where it is needed: pushing the rendered card to status-data.
+      contents: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/status-card.yaml
+++ b/.github/workflows/status-card.yaml
@@ -1,0 +1,76 @@
+name: Status card
+
+# Draws the README's live cluster card. The status-publisher CronJob writes the
+# facts to a ConfigMap the portfolio serves at /api/v1/infra; this job reads that
+# public endpoint, renders both themes, and publishes them to the status-data
+# branch. The README embeds the SVGs from there over raw.githubusercontent, the
+# same hand-off the star history card uses.
+#
+# The cluster never needs a GitHub credential this way, and nothing extra is
+# exposed inbound. When the endpoint doesn't answer, the card says so instead of
+# redrawing the last good numbers.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every 15 minutes. GitHub proxies README images through camo, so the card
+    # lands a few minutes behind whatever this run saw; it stamps itself with
+    # the reading's own timestamp rather than pretending to be instant.
+    - cron: "*/15 * * * *"
+
+permissions:
+  # write so the job can push to the status-data branch.
+  contents: write
+
+concurrency:
+  group: status-card
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.repository_owner == 'mortennordbye'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fetch cluster status
+        env:
+          STATUS_URL: https://nordbye.it/api/v1/infra
+          PREVIOUS: https://raw.githubusercontent.com/${{ github.repository }}/status-data/status.json
+        run: |
+          mkdir -p dist
+          if curl -sf --max-time 20 --retry 2 --retry-delay 5 "$STATUS_URL" -o dist/status.json \
+            && jq -e '.generatedAt and .gitops' dist/status.json > /dev/null; then
+            jq '{generatedAt, applications: .gitops.applications, asleep: .apps.asleep}' dist/status.json
+            exit 0
+          fi
+
+          # No answer, or an answer the renderer can't use. Carry the last
+          # published reading forward marked as stale rather than failing the
+          # run: a card that admits the cluster is unreachable is the point.
+          echo "::warning::$STATUS_URL did not answer with a usable payload"
+          curl -sf --max-time 20 "$PREVIOUS" -o prev.json || echo '{}' > prev.json
+          jq '{
+            unreachable: true,
+            lastSeen: (.generatedAt // .lastSeen),
+            versions: .versions,
+            nodes: .nodes,
+            gitops: .gitops
+          }' prev.json > dist/status.json
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: portfolio/.nvmrc
+
+      - name: Render the card
+        run: node scripts/render-status-card.mjs
+
+      - name: Publish to status-data branch
+        uses: crazy-max/ghaction-github-pages@v5
+        with:
+          target_branch: status-data
+          build_dir: dist
+          keep_history: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -38,6 +38,13 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 
 ## Infrastructure page
 
+### Second consumer for the cluster status card
+
+- **What:** The status card added to the README is drawn from `/api/v1/infra`, which the `status-publisher` CronJob fills. Two things were deliberately left out. The publisher still lives in the `portfolio` namespace and is named for it even though it now collects cluster-wide facts, and the `/infrastructure` page still renders only the original four (nodes, versions, ArgoCD, cert) while the payload now also carries `gitops`, `apps`, `security`, `observability`, `resources` and `storage`.
+- **Why deferred:** Moving the publisher to its own namespace means standing up something to serve the JSON, since the portfolio pod is what serves it today, and that buys tidiness rather than capability while there is only one in-cluster consumer. Rewriting the `/infrastructure` page is its own design job, not part of shipping the card.
+- **Unblock:** When a second in-cluster consumer appears (the homepage widget is the likely one), extract the CronJob and its RBAC into `k8s/talos/infra/` with a small nginx and route of its own, then repoint the portfolio at the shared URL. The page adopting the new keys can happen independently and needs no move.
+- **Where:** `k8s/talos/apps/portfolio/status-publisher.yaml`, `portfolio/src/app/api/v1/infra/route.ts`, `portfolio/src/components/infrastructure/LiveStatus.tsx`, `scripts/render-status-card.mjs`, `.github/workflows/status-card.yaml`.
+
 ### Outside-in probing for the 30-day health strip
 - **What:** The `/infrastructure` page now renders a 30-day health strip from per-day sample counts the status publisher accumulates in `status.json` (`history` array). It is labelled "observed in-cluster" because that is all it is: days where the publisher never ran show as gaps, but the strip cannot see the site being unreachable from the internet while the cluster is fine, and self-reported health proves less than an external probe.
 - **Why deferred:** True availability needs an external prober (Uptime Kuma on another host, healthchecks.io, or a GitHub Actions schedule hitting the site) publishing daily results somewhere the static page can fetch.

--- a/README.md
+++ b/README.md
@@ -6,35 +6,51 @@
 
 ### Homelab Infrastructure
 
-[![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io) [![Talos](https://img.shields.io/badge/Talos-FF6C2C?logo=linux&logoColor=white)](https://www.talos.dev) [![ArgoCD](https://img.shields.io/badge/ArgoCD-GitOps-F05032?logo=argo&logoColor=white)](https://argoproj.github.io/cd/) [![Terraform](https://img.shields.io/badge/Terraform-IaC-844FBA?logo=terraform&logoColor=white)](https://www.terraform.io)
+[![Kubernetes](https://img.shields.io/badge/Kubernetes-378144?style=flat-square&logo=kubernetes&logoColor=white&labelColor=0f1410)](https://kubernetes.io) [![Talos](https://img.shields.io/badge/Talos-378144?style=flat-square&logo=linux&logoColor=white&labelColor=0f1410)](https://www.talos.dev) [![ArgoCD](https://img.shields.io/badge/ArgoCD-GitOps-378144?style=flat-square&logo=argo&logoColor=white&labelColor=0f1410)](https://argoproj.github.io/cd/) [![Terraform](https://img.shields.io/badge/Terraform-IaC-378144?style=flat-square&logo=terraform&logoColor=white&labelColor=0f1410)](https://www.terraform.io)
 
 [![Blog](https://github.com/mortennordbye/homelab/actions/workflows/build-blog.yaml/badge.svg)](https://github.com/mortennordbye/homelab/actions/workflows/build-blog.yaml) [![Portfolio](https://github.com/mortennordbye/homelab/actions/workflows/build-portfolio.yaml/badge.svg)](https://github.com/mortennordbye/homelab/actions/workflows/build-portfolio.yaml) [![Container Security](https://github.com/mortennordbye/homelab/actions/workflows/container-vulnerability-scan.yaml/badge.svg)](https://github.com/mortennordbye/homelab/actions/workflows/container-vulnerability-scan.yaml)
 
-[![License](https://img.shields.io/github/license/mortennordbye/homelab?style=flat-square)](LICENSE) [![Last Commit](https://img.shields.io/github/last-commit/mortennordbye/homelab?style=flat-square)](https://github.com/mortennordbye/homelab/commits/main) [![Issues](https://img.shields.io/github/issues/mortennordbye/homelab?style=flat-square)](https://github.com/mortennordbye/homelab/issues) [![Stars](https://img.shields.io/github/stars/mortennordbye/homelab?style=flat-square)](https://github.com/mortennordbye/homelab/stargazers)
+[![License](https://img.shields.io/github/license/mortennordbye/homelab?style=flat-square&labelColor=0f1410&color=378144)](LICENSE) [![Last Commit](https://img.shields.io/github/last-commit/mortennordbye/homelab?style=flat-square&labelColor=0f1410&color=378144)](https://github.com/mortennordbye/homelab/commits/main) [![Issues](https://img.shields.io/github/issues/mortennordbye/homelab?style=flat-square&labelColor=0f1410&color=378144)](https://github.com/mortennordbye/homelab/issues) [![Stars](https://img.shields.io/github/stars/mortennordbye/homelab?style=flat-square&labelColor=0f1410&color=378144)](https://github.com/mortennordbye/homelab/stargazers)
 
 My personal lab environment for experimenting with infrastructure and hosting self-hosted services. Professionally, I work with these technologies daily, but the homelab gives me freedom to explore ideas and patterns that don't always fit production constraints. This is where curiosity meets practicality, testing new tools, solving real problems at home, and yes, occasionally breaking things in the pursuit of learning.
 
 The repository is public by design. Transparency keeps me honest about following best practices, even when it's just for fun.
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mortennordbye/homelab/status-data/status-dark.svg" />
+  <img alt="Live cluster status: applications synced and healthy, nodes ready, pods running, critical alerts, CPU and memory in use, which apps are asleep, and 30-day availability" src="https://raw.githubusercontent.com/mortennordbye/homelab/status-data/status.svg" width="840" />
+</picture>
+
 </div>
+
+> Drawn every 15 minutes from [nordbye.it/api/v1/infra](https://nordbye.it/api/v1/infra), which a [CronJob](k8s/talos/apps/portfolio/status-publisher.yaml) fills from the Kubernetes API and Prometheus. When the cluster is unreachable the card says so.
+
+---
 
 ## Quick Links
 
-[![Portfolio](https://img.shields.io/badge/Portfolio-nordbye.it-844FBA?style=flat-square&logo=googlechrome&logoColor=white)](https://nordbye.it) [![Blog](https://img.shields.io/badge/Blog-blog.nordbye.it-FF4088?style=flat-square&logo=hugo&logoColor=white)](https://blog.nordbye.it) [![LinkedIn](https://img.shields.io/badge/LinkedIn-morten--victor--nordbye-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/morten-victor-nordbye/) [![GitHub](https://img.shields.io/badge/GitHub-mortennordbye-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/mortennordbye)
+[![Portfolio](https://img.shields.io/badge/Portfolio-nordbye.it-378144?style=flat-square&logo=googlechrome&logoColor=white&labelColor=0f1410)](https://nordbye.it) [![Blog](https://img.shields.io/badge/Blog-blog.nordbye.it-378144?style=flat-square&logo=hugo&logoColor=white&labelColor=0f1410)](https://blog.nordbye.it) [![LinkedIn](https://img.shields.io/badge/LinkedIn-morten--victor--nordbye-378144?style=flat-square&logo=linkedin&logoColor=white&labelColor=0f1410)](https://www.linkedin.com/in/morten-victor-nordbye/) [![GitHub](https://img.shields.io/badge/GitHub-mortennordbye-378144?style=flat-square&logo=github&logoColor=white&labelColor=0f1410)](https://github.com/mortennordbye)
 
 Feel free to send me a DM, open a pull request, or steal code from here. The goal is to learn and make connections.
 
 ---
 
-## Other Projects
+## How It Works
 
-A few other things I build and self-host outside this repo:
+Terraform builds the Talos VMs on Proxmox. Everything after that arrives through git.
 
-| Project | Description | Stack |
-| ------- | ----------- | ----- |
-| [**logeverylift**](https://github.com/mortennordbye/logeverylift) | Mobile-first workout tracking PWA | Next.js 16, PostgreSQL 18, Drizzle |
-| [**lawless-waf**](https://github.com/mortennordbye/lawless-waf) | Tune Azure WAF false positives without paying Log Analytics prices | Python, React, Terraform |
-| [**headroom**](https://github.com/mortennordbye/headroom) | Self-hosted personal finance tracker for budgets, assets, investments, and loan modeling | TypeScript, SQLite, Docker |
+```
+push to main
+   ├─ GitHub Actions builds portfolio and blog, pushes to GHCR
+   │     └─ Kargo promotes stage to prod as a pull request you merge
+   ├─ external app repos call bump-image.yml, which opens a PR pinning an immutable sha tag
+   └─ Argo CD reconciles k8s/talos/** onto the cluster
+         ├─ External Secrets fetches credentials at runtime, so none are committed
+         ├─ Traefik publishes routes through Gateway API, cert-manager and external-dns handle TLS and DNS
+         └─ KEDA lets idle apps drop to zero; the HTTP interceptor wakes them on the first request
+```
+
+Argo CD runs an app-of-apps. The two root Applications in `k8s/talos/infra/argocd/` own every other Application, so a new workload is a new directory.
 
 ---
 
@@ -97,16 +113,17 @@ homelab
 
 ## Kubernetes Tech Stack
 
-| Category      | Components                                                                                                                                                                             |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GitOps        | [ArgoCD](https://argoproj.github.io/cd/), [Kargo](https://kargo.io/) (stage → prod promotion, portfolio pilot)                                                                          |
-| Networking    | [Cilium](https://cilium.io/) (CNI + eBPF), [Traefik](https://traefik.io/) ([Gateway API](https://gateway-api.sigs.k8s.io/)), [external-dns](https://github.com/kubernetes-sigs/external-dns) (Cloudflare DNS automation)                                                            |
-| Security      | [Falco](https://falco.org/) (runtime security), [Authentik](https://goauthentik.io/) (SSO), [Cert-manager](https://cert-manager.io/), [External Secrets Operator](https://external-secrets.io/)                                                                                    |
-| Observability | [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/), [Loki](https://grafana.com/oss/loki/) (logs), [Tempo](https://grafana.com/oss/tempo/) (traces), [OpenTelemetry](https://opentelemetry.io/), [Metrics-server](https://github.com/kubernetes-sigs/metrics-server) |
-| Automation    | [Reloader](https://github.com/stakater/Reloader) (config/secret-triggered rollouts)                                                                                                   |
-| Storage       | [Proxmox CSI](https://github.com/sergelogvinov/proxmox-csi-plugin), [Synology](https://www.synology.com/) (NFS)                                                                        |
-| Databases     | [PostgreSQL 18](https://www.postgresql.org/) (in-cluster, NFS-backed, backing logeverylift)                                                                                            |
-| Platform      | [Proxmox VE](https://www.proxmox.com/) (6-node HA cluster), [Talos Linux](https://www.talos.dev/), [Terraform](https://www.terraform.io/)                                              |
+| Category | Components |
+| --- | --- |
+| GitOps | [Argo CD](https://argoproj.github.io/cd/) (app-of-apps), [Kargo](https://kargo.io/) (stage to prod promotion for blog, headroom, logeverylift, portfolio, reelsmith and verksted), [Argo Rollouts](https://argoproj.github.io/rollouts/) (installed, no workload uses it yet) |
+| Networking | [Cilium](https://cilium.io/) (CNI, eBPF, L2 announcements and LB IPAM), [Traefik](https://traefik.io/) via [Gateway API](https://gateway-api.sigs.k8s.io/), [external-dns](https://github.com/kubernetes-sigs/external-dns) (Cloudflare) |
+| Security | [Falco](https://falco.org/) (runtime, modern eBPF probe), [Authentik](https://goauthentik.io/) (SSO), [cert-manager](https://cert-manager.io/), [External Secrets Operator](https://external-secrets.io/) (Bitwarden Secrets Manager) |
+| Observability | [Prometheus and Alertmanager](https://prometheus.io/), [Grafana](https://grafana.com/), [Loki](https://grafana.com/oss/loki/) (logs), [Tempo](https://grafana.com/oss/tempo/) (traces), [OpenTelemetry Collector](https://opentelemetry.io/), [metrics-server](https://github.com/kubernetes-sigs/metrics-server) |
+| Scaling | [KEDA](https://keda.sh/) with the [HTTP add-on](https://github.com/kedacore/http-add-on): nine apps drop to zero replicas and the interceptor wakes them on the first request |
+| Automation | [Reloader](https://github.com/stakater/Reloader) (config and secret triggered rollouts) |
+| Storage | [Proxmox CSI](https://github.com/sergelogvinov/proxmox-csi-plugin) (block), [csi-driver-nfs](https://github.com/kubernetes-csi/csi-driver-nfs) (Synology NFS) |
+| Databases | [PostgreSQL 18](https://www.postgresql.org/) (in-cluster, NFS-backed, behind logeverylift) |
+| Platform | [Proxmox VE](https://www.proxmox.com/) on three Lenovo nodes, [Talos Linux](https://www.talos.dev/) (three control plane and three worker VMs), [Terraform](https://www.terraform.io/) |
 
 ---
 
@@ -129,11 +146,17 @@ Automated vulnerability scanning runs weekly and on every Dockerfile change usin
 | [**Build and Deploy Blog**](.github/workflows/build-blog.yaml)                          | Push to `main` (blog changes)                  | Builds Hugo blog, pushes to GHCR, updates k8s manifest |
 | [**Build and Deploy Portfolio**](.github/workflows/build-portfolio.yaml)                | Push to `main`                                 | Builds portfolio image and pushes to GHCR ([Kargo](https://kargo.io/) promotes stage → prod) |
 | [**Bump Image Tag**](.github/workflows/bump-image.yml)                                  | Called by external app repos (`workflow_call`) | Opens a PR pinning an app to a new immutable `sha-` image tag ([pattern](docs/gitops-external-app-deploys.md)) |
-| [**Container Vulnerability Scan**](.github/workflows/container-vulnerability-scan.yaml) | Weekly, Dockerfile changes, manual             | Scans blog & portfolio containers with Trivy           |
+| [**Container Vulnerability Scan**](.github/workflows/container-vulnerability-scan.yaml) | Sundays, Dockerfile changes, pull request, manual | Scans the blog and portfolio images with Trivy, CRITICAL and HIGH with a fix available |
 | [**Render Diagrams**](.github/workflows/render-diagram.yaml)                            | Push to `main` (`docs/diagrams/*.d2`), manual  | Renders D2 sources to SVG + PNG, commits the result    |
-| [**Reminders**](.github/workflows/reminders.yml)                                        | Monthly (1st, 8th, 15th)                       | Discord reminders for Kubernetes upkeep, backups, and server updates |
+| [**Reminders**](.github/workflows/reminders.yml)                                        | Monthly (1st, 8th, 15th), manual | Discord reminders for Kubernetes upkeep, backups, and server updates |
 | [**Dependency Review**](.github/workflows/dependency-review.yml)                        | PR                                             | Blocks pull requests that add known-vulnerable dependencies |
-| [**Scorecard**](.github/workflows/scorecard.yml)                                        | Push to `main`, weekly                         | OpenSSF supply chain score, published to the Security tab |
+| [**Scorecard**](.github/workflows/scorecard.yml)                                        | Push to `main`, Mondays 03:00 UTC | OpenSSF supply chain score, published to the Security tab |
+| [**Status Card**](.github/workflows/status-card.yaml)                                   | Every 15 minutes, manual | Reads the cluster's status endpoint and redraws the card at the top of this page |
+| [**Star History**](.github/workflows/star-history.yaml)                                 | Every 6 hours | Draws the star chart at the foot of this page from this repo's own stargazer data |
+| [**CI Blog**](.github/workflows/ci-blog.yaml) · [**CI Portfolio**](.github/workflows/ci-portfolio.yaml) | Pull request                   | Pull request gates; pushes to `main` are gated inside the build workflows |
+| [**Kargo Automerge**](.github/workflows/kargo-automerge.yaml)                           | Kargo promotion PR                             | Merges promotion PRs for the apps listed in `KARGO_AUTOMERGE_APPS`, where the canary is the real gate |
+| [**Lighthouse**](.github/workflows/lighthouse.yaml)                                     | Mondays 06:00 UTC, manual | Audits the live public sites, median of 3 runs, gating SEO, accessibility and best practices |
+| [**Render Logo**](.github/workflows/render-logo.yaml)                                   | Push to `main` (`docs/logo/source.jpg`)        | Re-crops the logo from its source and commits the result, so the image can't drift |
 
 ---
 
@@ -190,9 +213,21 @@ Automated vulnerability scanning runs weekly and on every Dockerfile change usin
 
 ---
 
+## Other Projects
+
+A few other things I build and self-host outside this repo:
+
+| Project | Description | Stack |
+| ------- | ----------- | ----- |
+| [**logeverylift**](https://github.com/mortennordbye/logeverylift) | Mobile-first workout tracking PWA | Next.js 16, PostgreSQL 18, Drizzle |
+| [**lawless-waf**](https://github.com/mortennordbye/lawless-waf) | Tune Azure WAF false positives without paying Log Analytics prices | Python, React, Terraform |
+| [**headroom**](https://github.com/mortennordbye/headroom) | Self-hosted personal finance tracker for budgets, assets, investments, and loan modeling | TypeScript, SQLite, Docker |
+
+---
+
 <div align="center">
 
-### ⭐ Star this repo if you find it useful ⭐
+### Star this repo if it is useful to you
 
 <a href="https://github.com/mortennordbye/homelab/stargazers">
   <picture>

--- a/k8s/talos/apps/portfolio/status-publisher.yaml
+++ b/k8s/talos/apps/portfolio/status-publisher.yaml
@@ -1,6 +1,13 @@
 # Publishes live cluster facts to the portfolio-status ConfigMap every five
-# minutes. The portfolio deployment mounts that ConfigMap and nginx serves it
-# as /status.json, which the /infrastructure page fetches client-side.
+# minutes. The portfolio deployment mounts that ConfigMap and the /api/v1/infra
+# route serves it, which the /infrastructure page fetches client-side. A
+# scheduled workflow also reads that public endpoint to draw the README's live
+# status card, so the payload carries cluster-wide facts, not just portfolio's.
+#
+# Object counts come from the API server, which is authoritative. Rates,
+# utilisation and anything over a time window come from Prometheus; when that
+# call fails the field lands as null and consumers drop it rather than the whole
+# run failing.
 #
 # The ConfigMap itself is created by the CronJob, not by Git — ArgoCD ignores
 # it because it carries no tracking label, so automated prune never touches it.
@@ -10,25 +17,35 @@ metadata:
   name: status-publisher
   namespace: portfolio
 ---
-# Cluster-scoped reads: nodes for readiness + versions, plus single named
-# objects (the ArgoCD Application and the site certificate) in other
-# namespaces. resourceNames limits get to exactly those objects.
+# Cluster-scoped reads. Everything here is read-only and none of it is a Secret;
+# the payload it produces is served publicly, so the job collects counts and
+# status fields only.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: portfolio-status-publisher
 rules:
   - apiGroups: [""]
-    resources: ["nodes"]
+    resources: ["nodes", "pods", "persistentvolumeclaims"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
     verbs: ["get", "list"]
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
-    resourceNames: ["portfolio"]
-    verbs: ["get"]
+    verbs: ["get", "list"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
-    resourceNames: ["nordbye-it"]
-    verbs: ["get"]
+    verbs: ["get", "list"]
+  - apiGroups: ["keda.sh"]
+    resources: ["scaledobjects"]
+    verbs: ["get", "list"]
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnetworkpolicies"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -58,10 +75,6 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["portfolio-status"]
     verbs: ["get", "patch", "update"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    resourceNames: ["portfolio"]
-    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -91,7 +104,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 180
       template:
         metadata:
           labels:
@@ -114,25 +127,98 @@ spec:
                 # kubectl writes discovery cache under $HOME
                 - name: HOME
                   value: /tmp
+                - name: PROM
+                  value: http://kube-prometheus-stack-prometheus.monitoring:9090
               command: ["/bin/sh", "-ec"]
               args:
                 - |
+                  # One instant query. Empty on any failure, so a Prometheus
+                  # outage nulls a field instead of failing the run.
+                  prom() {
+                    curl -sf --max-time 10 --get --data-urlencode "query=$1" \
+                      "$PROM/api/v1/query" 2>/dev/null \
+                      | jq -r '.data.result[0].value[1] // empty' 2>/dev/null || true
+                  }
+                  num() { if [ -n "$1" ]; then printf '%s' "$1"; else printf 'null'; fi; }
+
                   kubectl get nodes -o json > /tmp/nodes.json
                   READY=$(jq '[.items[] | select(any(.status.conditions[]; .type=="Ready" and .status=="True"))] | length' /tmp/nodes.json)
                   TOTAL=$(jq '.items | length' /tmp/nodes.json)
                   K8S=$(jq -r '.items[0].status.nodeInfo.kubeletVersion' /tmp/nodes.json)
                   TALOS=$(jq -r '.items[0].status.nodeInfo.osImage | capture("\\((?<v>v[0-9][0-9.]*)\\)").v // empty' /tmp/nodes.json)
 
-                  kubectl get application portfolio -n argocd -o json > /tmp/app.json
-                  SYNC=$(jq -r '.status.sync.status // "Unknown"' /tmp/app.json)
-                  HEALTH=$(jq -r '.status.health.status // "Unknown"' /tmp/app.json)
-                  SYNCED_AT=$(jq -r '.status.operationState.finishedAt // empty' /tmp/app.json)
+                  # Every Application, not just portfolio's: the card shows the
+                  # cluster-wide tally and portfolio's own status comes out of
+                  # the same read.
+                  kubectl get applications -n argocd -o json > /tmp/apps.json
+                  APP_TOTAL=$(jq '.items | length' /tmp/apps.json)
+                  APP_SYNCED=$(jq '[.items[] | select(.status.sync.status=="Synced")] | length' /tmp/apps.json)
+                  APP_HEALTHY=$(jq '[.items[] | select(.status.health.status=="Healthy")] | length' /tmp/apps.json)
+                  jq '[.items[] | select(.status.operationState.finishedAt)] | sort_by(.status.operationState.finishedAt) | last // {}' /tmp/apps.json > /tmp/last.json
+                  LAST_NAME=$(jq -r '.metadata.name // empty' /tmp/last.json)
+                  LAST_AT=$(jq -r '.status.operationState.finishedAt // empty' /tmp/last.json)
+
+                  jq '.items[] | select(.metadata.name=="portfolio") | .status' /tmp/apps.json > /tmp/app.json
+                  SYNC=$(jq -r '.sync.status // "Unknown"' /tmp/app.json)
+                  HEALTH=$(jq -r '.health.status // "Unknown"' /tmp/app.json)
+                  SYNCED_AT=$(jq -r '.operationState.finishedAt // empty' /tmp/app.json)
 
                   kubectl get deployment portfolio -n portfolio -o json > /tmp/deploy.json
                   BUILD=$(jq -r '.spec.template.spec.containers[0].image | split(":") | last' /tmp/deploy.json)
                   DEPLOYED_AT=$(jq -r '[.status.conditions[] | select(.type=="Progressing")][0].lastUpdateTime // empty' /tmp/deploy.json)
 
-                  NOT_AFTER=$(kubectl get certificate nordbye-it -n cert-manager -o jsonpath='{.status.notAfter}')
+                  # Sleepers are the deployments KEDA is allowed to take to zero.
+                  # Deriving them from the ScaledObjects keeps retired apps that
+                  # are merely parked at zero (workout) out of the count.
+                  kubectl get scaledobjects -A -o json > /tmp/so.json
+                  kubectl get deployments -A -o json > /tmp/deploys.json
+                  jq -n --slurpfile so /tmp/so.json --slurpfile dep /tmp/deploys.json '
+                    [$so[0].items[]
+                      | select((.spec.minReplicaCount // 1) == 0)
+                      | {ns: .metadata.namespace, target: .spec.scaleTargetRef.name}] as $sleepers
+                    | [$dep[0].items[]
+                      | {ns: .metadata.namespace, name: .metadata.name, replicas: (.spec.replicas // 0)}] as $deps
+                    | [$sleepers[] as $s
+                        | ($deps[] | select(.ns == $s.ns and .name == $s.target))
+                        | {name: .name, state: (if .replicas == 0 then "asleep" else "awake" end)}]
+                    | sort_by(.name)' > /tmp/tiles.json
+                  SO_TOTAL=$(jq '.items | length' /tmp/so.json)
+                  ASLEEP=$(jq '[.[] | select(.state=="asleep")] | length' /tmp/tiles.json)
+                  SLEEPERS=$(jq 'length' /tmp/tiles.json)
+
+                  kubectl get certificates -A -o json > /tmp/certs.json
+                  CERT_TOTAL=$(jq '.items | length' /tmp/certs.json)
+                  CERT_NEXT=$(jq -r '[.items[].status.notAfter // empty] | sort | first // empty' /tmp/certs.json)
+                  NOT_AFTER=$(jq -r '.items[] | select(.metadata.name=="nordbye-it") | .status.notAfter // empty' /tmp/certs.json)
+
+                  kubectl get pvc -A -o json > /tmp/pvc.json
+                  VOLUMES=$(jq '.items | length' /tmp/pvc.json)
+                  CLAIMED_GIB=$(jq '[.items[].status.capacity.storage // "0"
+                    | if endswith("Ti") then (rtrimstr("Ti") | tonumber * 1024)
+                      elif endswith("Gi") then (rtrimstr("Gi") | tonumber)
+                      elif endswith("Mi") then (rtrimstr("Mi") | tonumber / 1024)
+                      else 0 end] | add | round' /tmp/pvc.json)
+
+                  PODS=$(kubectl get pods -A --field-selector=status.phase=Running -o name | wc -l | tr -d ' ')
+                  SECRETS=$(kubectl get externalsecrets -A -o name | wc -l | tr -d ' ')
+                  POLICIES=$(kubectl get ciliumnetworkpolicies -A -o name | wc -l | tr -d ' ')
+
+                  CPU_USED=$(prom 'sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))')
+                  CPU_ALLOC=$(prom 'sum(kube_node_status_allocatable{resource="cpu"})')
+                  MEM_USED=$(prom 'sum(container_memory_working_set_bytes{container!=""})')
+                  MEM_ALLOC=$(prom 'sum(kube_node_status_allocatable{resource="memory"})')
+                  RESTARTS=$(prom 'sum(increase(kube_pod_container_status_restarts_total[24h]))')
+                  IMAGES=$(prom 'count(count by (image)(kube_pod_container_info))')
+                  UPTIME_DAYS=$(prom 'min(time() - node_boot_time_seconds) / 86400')
+                  DISK_PCT=$(prom 'avg(100 - (node_filesystem_avail_bytes{mountpoint="/var"} / node_filesystem_size_bytes{mountpoint="/var"} * 100))')
+                  SYSCALLS=$(prom 'sum(increase(falcosecurity_scap_n_evts_total[24h]))')
+                  LOGS_24H=$(prom 'sum(increase(loki_distributor_bytes_received_total[24h]))')
+                  ALERTS_CRIT=$(prom 'count(ALERTS{alertstate="firing",severity="critical"}) or vector(0)')
+                  ALERTS_WARN=$(prom 'count(ALERTS{alertstate="firing",severity="warning"}) or vector(0)')
+                  REQUESTS=$(prom 'sum(increase(traefik_service_requests_total[24h]))')
+                  ERRORS=$(prom 'sum(increase(traefik_service_requests_total{code=~"5.."}[24h])) or vector(0)')
+                  SYNCS_24H=$(prom 'sum(increase(argocd_app_sync_total[24h]))')
+                  SYNCS_30D=$(prom 'sum(increase(argocd_app_sync_total[30d]))')
 
                   # Previous payload carries the per-day uptime history; keep it.
                   kubectl get configmap portfolio-status -n portfolio \
@@ -157,14 +243,85 @@ spec:
                     --arg k8s "$K8S" \
                     --arg talos "$TALOS" \
                     --arg notAfter "$NOT_AFTER" \
-                    '{
+                    --argjson appTotal "$APP_TOTAL" \
+                    --argjson appSynced "$APP_SYNCED" \
+                    --argjson appHealthy "$APP_HEALTHY" \
+                    --arg lastName "$LAST_NAME" \
+                    --arg lastAt "$LAST_AT" \
+                    --argjson syncs24h "$(num "$SYNCS_24H")" \
+                    --argjson syncs30d "$(num "$SYNCS_30D")" \
+                    --slurpfile tiles /tmp/tiles.json \
+                    --argjson scaledObjects "$SO_TOTAL" \
+                    --argjson sleepers "$SLEEPERS" \
+                    --argjson asleep "$ASLEEP" \
+                    --argjson secrets "$SECRETS" \
+                    --argjson policies "$POLICIES" \
+                    --argjson certTotal "$CERT_TOTAL" \
+                    --arg certNext "$CERT_NEXT" \
+                    --argjson syscalls "$(num "$SYSCALLS")" \
+                    --argjson cpuUsed "$(num "$CPU_USED")" \
+                    --argjson cpuAlloc "$(num "$CPU_ALLOC")" \
+                    --argjson memUsed "$(num "$MEM_USED")" \
+                    --argjson memAlloc "$(num "$MEM_ALLOC")" \
+                    --argjson pods "$PODS" \
+                    --argjson restarts "$(num "$RESTARTS")" \
+                    --argjson images "$(num "$IMAGES")" \
+                    --argjson uptimeDays "$(num "$UPTIME_DAYS")" \
+                    --argjson diskPct "$(num "$DISK_PCT")" \
+                    --argjson logs24h "$(num "$LOGS_24H")" \
+                    --argjson alertsCrit "$(num "$ALERTS_CRIT")" \
+                    --argjson alertsWarn "$(num "$ALERTS_WARN")" \
+                    --argjson requests "$(num "$REQUESTS")" \
+                    --argjson errors "$(num "$ERRORS")" \
+                    --argjson volumes "$VOLUMES" \
+                    --argjson claimedGiB "$CLAIMED_GIB" \
+                    '
+                    def r(n): if . == null then null else (. * n | round) / n end;
+                    def i: if . == null then null else round end;
+                    {
                       generatedAt: $generatedAt,
                       build: $build,
                       deployedAt: $deployedAt,
                       argocd: {sync: $sync, health: $health, syncedAt: $syncedAt},
                       nodes: {ready: $ready, total: $total},
                       versions: {kubernetes: $k8s, talos: $talos},
-                      cert: {notAfter: $notAfter}
+                      cert: {notAfter: $notAfter},
+                      gitops: {
+                        applications: {total: $appTotal, synced: $appSynced, healthy: $appHealthy},
+                        syncs24h: ($syncs24h | i),
+                        syncs30d: ($syncs30d | i),
+                        lastSync: {name: $lastName, at: $lastAt}
+                      },
+                      apps: {
+                        scaledObjects: $scaledObjects,
+                        sleepers: $sleepers,
+                        asleep: $asleep,
+                        tiles: $tiles[0]
+                      },
+                      security: {
+                        secretsAtRuntime: $secrets,
+                        secretsInGit: 0,
+                        networkPolicies: $policies,
+                        policyMode: "audit",
+                        syscalls24h: ($syscalls | i),
+                        certs: {total: $certTotal, nextExpiry: $certNext}
+                      },
+                      resources: {
+                        cpu: {used: ($cpuUsed | r(100)), allocatable: ($cpuAlloc | r(100))},
+                        memory: {usedBytes: ($memUsed | i), allocatableBytes: ($memAlloc | i)},
+                        podsRunning: $pods,
+                        restarts24h: ($restarts | i),
+                        images: ($images | i),
+                        uptimeDays: ($uptimeDays | r(10)),
+                        diskUsedPct: ($diskPct | r(10))
+                      },
+                      observability: {
+                        logBytes24h: ($logs24h | i),
+                        alerts: {critical: ($alertsCrit | i), warning: ($alertsWarn | i)},
+                        requests24h: ($requests | i),
+                        errors5xx24h: ($errors | i)
+                      },
+                      storage: {volumes: $volumes, claimedGiB: $claimedGiB}
                     }' > /tmp/new.json
 
                   # Fold this run into today's uptime bucket, keep 30 days.

--- a/scripts/render-status-card.mjs
+++ b/scripts/render-status-card.mjs
@@ -1,0 +1,256 @@
+// Render the live cluster card for the README from the status payload that
+// .github/workflows/status-card.yaml fetches off nordbye.it/api/v1/infra.
+//
+// The cluster publishes facts and nothing else; the drawing happens here so no
+// GitHub credential ever has to live inside the cluster. Reads dist/status.json,
+// writes dist/status.svg (light) and dist/status-dark.svg; the workflow
+// publishes both to the status-data branch and the README picks a theme with
+// <picture>.
+//
+// A payload marked unreachable renders the "can't see the cluster" card rather
+// than redrawing yesterday's numbers, so the card never claims to know more
+// than it does.
+//
+// Run locally:  node scripts/render-status-card.mjs
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+// Brand palette, one hue at three steps (nordbye.it/brand). Shared with
+// scripts/render-star-history.mjs — keep the two in step.
+const DARK = {
+  bg: "#0f1410", line: "#2a382c", muted: "#a1ada3", faint: "#708373",
+  accent: "#51a45e", accent2: "#8ec798", accent3: "#61b86f",
+};
+const LIGHT = {
+  bg: "#f9fbf9", line: "#d1ddd3", muted: "#415344", faint: "#5f7963",
+  accent: "#378144", accent2: "#40a551", accent3: "#3d954c",
+};
+
+const W = 840;
+const H = 492;
+const FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
+const MONO = "ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace";
+
+const esc = (s) =>
+  String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+const tspan = (x, y, s, { size = 14, weight = 400, fill, font = FONT, anchor = "start" } = {}) =>
+  `<text x="${x}" y="${y}" font-family="${font}" font-size="${size}" font-weight="${weight}" fill="${fill}" text-anchor="${anchor}">${esc(s)}</text>`;
+
+const eyebrow = (x, y, s, t, anchor = "start") =>
+  tspan(x, y, String(s).toUpperCase(), { size: 11, weight: 600, fill: t.faint, font: MONO, anchor });
+
+const STYLE = `
+  .reveal{animation:rise .7s cubic-bezier(.2,.7,.3,1) both}
+  @keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}
+  .pulse{animation:pulse 2.2s ease-in-out infinite}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}
+  .grow{transform-origin:left center;animation:grow 1.4s cubic-bezier(.2,.7,.3,1) both}
+  @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+`;
+
+function card(t, inner, label, h = H) {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${h}" viewBox="0 0 ${W} ${h}" role="img" aria-label="${esc(label)}">
+  <defs>
+    <style>${STYLE}</style>
+    <clipPath id="topclip"><rect x="0" y="0" width="${W}" height="2"/></clipPath>
+  </defs>
+  <rect x="0.5" y="0.5" width="${W - 1}" height="${h - 1}" rx="14" fill="${t.bg}" stroke="${t.line}"/>
+  <g clip-path="url(#topclip)">
+    <rect x="0" y="0" width="${W}" height="2" fill="${t.accent}"/>
+  </g>
+  <g class="reveal">${inner}</g>
+</svg>`;
+}
+
+const DOWN_H = 200;
+
+const GB = 1000 ** 3;
+const GIB = 1024 ** 3;
+
+// Exact, with separators. Rounded-down counts read as marketing; the whole
+// number reads as a measurement, which is what it is.
+const fmt = (n) => (n == null ? "—" : Math.round(n).toLocaleString("en-US"));
+
+const gb = (bytes) => (bytes == null ? "—" : `${(bytes / GB).toFixed(2)} GB`);
+const gib = (bytes) => (bytes == null ? "—" : `${(bytes / GIB).toFixed(1)} GiB`);
+
+function ago(iso, now) {
+  if (!iso) return "—";
+  const mins = Math.max(0, Math.round((now - Date.parse(iso)) / 60000));
+  if (mins < 60) return `${mins}m ago`;
+  if (mins < 60 * 48) return `${Math.round(mins / 60)}h ago`;
+  return `${Math.round(mins / 1440)}d ago`;
+}
+
+const daysUntil = (iso, now) =>
+  iso ? Math.round((Date.parse(iso) - now) / 86400000) : null;
+
+// A horizontal meter with its own label, used for CPU and memory.
+function meter(t, x, y, w, label, used, total, detail) {
+  const pct = total ? Math.min(1, used / total) : 0;
+  const fill = Math.max(4, w * pct);
+  return `
+    ${eyebrow(x, y, label, t)}
+    ${tspan(x + w, y, `${(pct * 100).toFixed(1)}%`, { size: 12, weight: 700, fill: t.accent, font: MONO, anchor: "end" })}
+    <rect x="${x}" y="${y + 10}" width="${w}" height="8" rx="4" fill="${t.line}"/>
+    <rect class="grow" x="${x}" y="${y + 10}" width="${fill.toFixed(1)}" height="8" rx="4" fill="${t.accent}"/>
+    ${tspan(x, y + 36, detail, { size: 12, weight: 500, fill: t.muted, font: MONO })}`;
+}
+
+// One pill per app KEDA is allowed to take to zero. Filled means it's serving
+// right now, hollow means it's at zero and the next request wakes it. Wraps
+// onto a second row rather than running off the card as apps are added.
+function pills(t, x, y, tiles, maxW) {
+  const gap = 8;
+  const rowH = 30;
+  let cx = x;
+  let row = 0;
+  return tiles
+    .map(({ name, state }) => {
+      const w = 16 + name.length * 7.1;
+      if (cx > x && cx + w > x + maxW) {
+        row += 1;
+        cx = x;
+      }
+      const cy = y + row * rowH;
+      const asleep = state === "asleep";
+      const el = `
+        <rect x="${cx.toFixed(1)}" y="${cy}" width="${w.toFixed(1)}" height="24" rx="12"
+          fill="${asleep ? "none" : t.accent}" fill-opacity="${asleep ? 0 : 0.16}"
+          stroke="${asleep ? t.line : t.accent}" stroke-dasharray="${asleep ? "3 3" : "none"}"/>
+        ${tspan(cx + w / 2, cy + 16, name, { size: 11, weight: 600, fill: asleep ? t.faint : t.accent, font: MONO, anchor: "middle" })}`;
+      cx += w + gap;
+      return el;
+    })
+    .join("");
+}
+
+// 30 cells, one per day, built from the calendar rather than from the array so
+// a day the publisher never ran shows as a hole instead of vanishing.
+function strip(t, x, y, w, history, now) {
+  const byDay = new Map((history ?? []).map((h) => [h.d, h]));
+  const cellW = (w - 29 * 3) / 30;
+  let ok = 0;
+  let total = 0;
+  const cells = Array.from({ length: 30 }, (_, i) => {
+    const d = new Date(now - (29 - i) * 86400000).toISOString().slice(0, 10);
+    const e = byDay.get(d);
+    const cx = x + i * (cellW + 3);
+    if (!e || !e.total) {
+      return `<rect x="${cx.toFixed(1)}" y="${y}" width="${cellW.toFixed(1)}" height="18" rx="3" fill="none" stroke="${t.line}" stroke-dasharray="2 2"/>`;
+    }
+    ok += e.ok;
+    total += e.total;
+    const ratio = e.ok / e.total;
+    const fill = ratio >= 0.995 ? t.accent : ratio >= 0.95 ? t.accent2 : t.faint;
+    return `<rect x="${cx.toFixed(1)}" y="${y}" width="${cellW.toFixed(1)}" height="18" rx="3" fill="${fill}" fill-opacity="${ratio >= 0.995 ? 0.9 : 0.8}"/>`;
+  }).join("");
+  const pct = total ? ((ok / total) * 100).toFixed(2) : null;
+  return { cells, pct };
+}
+
+function render(t, s, now) {
+  const nodes = s.nodes ?? {};
+  const apps = s.gitops?.applications ?? {};
+  const res = s.resources ?? {};
+  const sec = s.security ?? {};
+  const obs = s.observability ?? {};
+  const allSynced = apps.total && apps.synced === apps.total && apps.healthy === apps.total;
+  const nodesOk = nodes.ready === nodes.total;
+  const stale = now - Date.parse(s.generatedAt) > 30 * 60000;
+
+  const headline = [
+    ["applications", apps.total ? `${apps.synced}/${apps.total}` : "—", allSynced ? "synced · healthy" : "synced", allSynced],
+    ["nodes ready", nodes.total ? `${nodes.ready}/${nodes.total}` : "—", `${res.uptimeDays ?? "—"}d since boot`, nodesOk],
+    ["pods running", fmt(res.podsRunning), `${res.images ?? "—"} distinct images`, true],
+    ["critical alerts", fmt(obs.alerts?.critical), `${fmt(res.restarts24h)} restarts in 24h`, (obs.alerts?.critical ?? 0) === 0],
+  ];
+
+  const tileW = (W - 80) / headline.length;
+  const tiles = headline
+    .map(([label, value, sub, good], i) => {
+      const x = 40 + i * tileW;
+      return `${tspan(x, 92, value, { size: 23, weight: 700, fill: good ? t.accent : t.muted, font: MONO })}
+        ${eyebrow(x, 114, label, t)}
+        ${tspan(x, 132, sub, { size: 11, weight: 500, fill: t.muted, font: MONO })}`;
+    })
+    .join("");
+
+  const cpu = res.cpu ?? {};
+  const mem = res.memory ?? {};
+  const meters = `
+    ${meter(t, 40, 168, 350, "cpu", cpu.used, cpu.allocatable, `${(cpu.used ?? 0).toFixed(2)} of ${(cpu.allocatable ?? 0).toFixed(2)} cores · prometheus`)}
+    ${meter(t, 450, 168, 350, "memory", mem.usedBytes, mem.allocatableBytes, `${gib(mem.usedBytes)} of ${gib(mem.allocatableBytes)} · prometheus`)}`;
+
+  const asleep = s.apps?.asleep ?? 0;
+  const sleepers = s.apps?.sleepers ?? 0;
+  const sleepRow = `
+    ${eyebrow(40, 252, `${asleep} of ${sleepers} asleep · the next request wakes them`, t)}
+    ${pills(t, 40, 262, s.apps?.tiles ?? [], W - 80)}`;
+
+  const certDays = daysUntil(sec.certs?.nextExpiry, now);
+  const facts = [
+    [`${sec.secretsAtRuntime ?? "—"} secrets at runtime`, `${sec.secretsInGit ?? 0} in git`],
+    [`${fmt(sec.syscalls24h)} syscalls`, "inspected by falco, last 24h"],
+    [`${gb(obs.logBytes24h)} of logs`, "shipped to loki, last 24h"],
+    [`${sec.networkPolicies ?? "—"} network policies`, sec.policyMode === "audit" ? "audit mode, not enforcing" : "enforcing"],
+    [`${s.storage?.claimedGiB ?? "—"} GiB claimed`, `across ${s.storage?.volumes ?? "—"} volumes`],
+    [certDays == null ? "cert —" : `cert renews in ${certDays}d`, `${s.gitops?.syncs30d ?? "—"} syncs in 30 days`],
+  ];
+  const colW = (W - 80) / 3;
+  const factRows = facts
+    .map(([head, sub], i) => {
+      const x = 40 + (i % 3) * colW;
+      const y = 362 + Math.floor(i / 3) * 34;
+      return `${tspan(x, y, head, { size: 13, weight: 700, fill: t.muted, font: MONO })}
+        ${tspan(x, y + 15, sub, { size: 11, weight: 500, fill: t.faint, font: MONO })}`;
+    })
+    .join("");
+
+  const { cells, pct } = strip(t, 40, 440, 480, s.history, now);
+  const last = s.gitops?.lastSync ?? {};
+
+  return `
+    <circle class="${stale ? "" : "pulse"}" cx="46" cy="36" r="5" fill="${stale ? t.faint : t.accent}"/>
+    ${eyebrow(60, 40, stale ? "cluster · stale" : "cluster · live", t)}
+    ${tspan(W - 40, 40, `${s.versions?.talos ?? "—"} talos · ${s.versions?.kubernetes ?? "—"} kubernetes`, { size: 12, weight: 600, fill: t.muted, font: MONO, anchor: "end" })}
+    ${tiles}
+    <line x1="40" y1="150" x2="${W - 40}" y2="150" stroke="${t.line}"/>
+    ${meters}
+    <line x1="40" y1="228" x2="${W - 40}" y2="228" stroke="${t.line}"/>
+    ${sleepRow}
+    <line x1="40" y1="336" x2="${W - 40}" y2="336" stroke="${t.line}"/>
+    ${factRows}
+    ${cells}
+    ${eyebrow(40, 432, `last 30 days${pct ? ` · ${pct}%` : ""}`, t)}
+    ${tspan(W - 40, 432, `last deploy · ${last.name ?? "—"} · ${ago(last.at, now)}`, { size: 11, weight: 600, fill: t.faint, font: MONO, anchor: "end" })}
+    ${eyebrow(40, 478, "source", t)}
+    ${tspan(94, 478, `kubernetes api and prometheus, read in cluster ${(s.generatedAt ?? "").replace("T", " ").replace("Z", "Z")} · nordbye.it/api/v1/infra`, { size: 11, weight: 500, fill: t.faint, font: MONO })}`;
+}
+
+// The cluster didn't answer. Say that, and say when it last did.
+function renderUnreachable(t, s, now) {
+  return `
+    <circle cx="46" cy="36" r="5" fill="${t.faint}"/>
+    ${eyebrow(60, 40, "cluster · unreachable", t)}
+    ${tspan(40, 104, "No answer from the cluster", { size: 30, weight: 700, fill: t.muted })}
+    ${tspan(40, 136, s.lastSeen ? `Last seen ${ago(s.lastSeen, now)}. The numbers below are from then.` : "No earlier reading to fall back on.", { size: 14, weight: 500, fill: t.faint })}
+    ${tspan(40, DOWN_H - 22, "source · nordbye.it/api/v1/infra", { size: 11, weight: 500, fill: t.faint, font: MONO })}
+    ${s.lastSeen ? tspan(40, 168, `${s.gitops?.applications?.synced ?? "—"}/${s.gitops?.applications?.total ?? "—"} applications synced · ${s.nodes?.ready ?? "—"}/${s.nodes?.total ?? "—"} nodes ready`, { size: 14, weight: 600, fill: t.faint, font: MONO }) : ""}`;
+}
+
+const src = JSON.parse(readFileSync("dist/status.json", "utf8"));
+const now = Date.now();
+const down = Boolean(src.unreachable);
+const label = down ? "Cluster unreachable" : "Live cluster status";
+
+for (const [name, t] of [["dist/status.svg", LIGHT], ["dist/status-dark.svg", DARK]]) {
+  writeFileSync(name, card(t, down ? renderUnreachable(t, src, now) : render(t, src, now), label, down ? DOWN_H : H));
+}
+
+console.log(
+  down
+    ? "✓ unreachable card → dist/status.svg, dist/status-dark.svg"
+    : `✓ ${src.gitops?.applications?.synced}/${src.gitops?.applications?.total} apps, ${src.apps?.asleep} asleep → dist/status.svg, dist/status-dark.svg`,
+);

--- a/scripts/render-status-card.mjs
+++ b/scripts/render-status-card.mjs
@@ -226,7 +226,7 @@ function render(t, s, now) {
     ${eyebrow(40, 432, `last 30 days${pct ? ` · ${pct}%` : ""}`, t)}
     ${tspan(W - 40, 432, `last deploy · ${last.name ?? "—"} · ${ago(last.at, now)}`, { size: 11, weight: 600, fill: t.faint, font: MONO, anchor: "end" })}
     ${eyebrow(40, 478, "source", t)}
-    ${tspan(94, 478, `kubernetes api and prometheus, read in cluster ${(s.generatedAt ?? "").replace("T", " ").replace("Z", "Z")} · nordbye.it/api/v1/infra`, { size: 11, weight: 500, fill: t.faint, font: MONO })}`;
+    ${tspan(94, 478, `kubernetes api and prometheus, read in cluster ${(s.generatedAt ?? "").replace("T", " ")} · nordbye.it/api/v1/infra`, { size: 11, weight: 500, fill: t.faint, font: MONO })}`;
 }
 
 // The cluster didn't answer. Say that, and say when it last did.


### PR DESCRIPTION
## Why

The README described the cluster but never showed it. This puts the cluster's own measurements on the front page and keeps them from drifting.

## What

`status-publisher` now collects cluster-wide facts rather than portfolio's four. Object counts come from the API server, rates and utilisation from Prometheus; a Prometheus failure nulls that field instead of failing the run. New keys are additive, so `/api/v1/infra` and the `/infrastructure` page are untouched. Sleepers are derived from ScaledObjects with `minReplicaCount: 0`, which keeps the retired `workout` out of the count.

`.github/workflows/status-card.yaml` reads the public endpoint every 15 minutes, renders a dual-theme SVG and publishes it to a `status-data` branch, the same hand-off `star-history.yaml` uses. The cluster holds no GitHub credential and nothing new is exposed inbound. If the endpoint doesn't answer, the card renders "No answer from the cluster, last seen Nh ago" rather than redrawing the last good numbers.

README restructured: badges unified on the brand palette, a How It Works section covering the GitOps path, the workflow table completed and its triggers corrected against the files, the tech stack checked against the live cluster, Other Projects moved below the homelab's own material, emoji heading dropped.

Two corrections the check turned up: Kargo now promotes six apps rather than being a portfolio pilot, and Proxmox is three nodes carrying six Talos VMs, not a six-node Proxmox cluster.

## Verification

- `kubectl diff --field-manager=argocd-controller` shows only the intended changes.
- The publisher script was extracted and run end to end against the live cluster and Prometheus; the payload is complete and the 30-day history merge is intact.
- The renderer was run in a Node container against that payload plus three fixtures (degraded and stale, unreachable with a previous reading, unreachable with none) and all four checked in both themes.
- `actionlint` passes on the new workflow.

## After merge

The card 404s until the first run creates `status-data`, so dispatch `Status Card` once. Follow-up work is in `BACKLOG.md`.