### PR TITLE
Put blog.nordbye.it and nordbye.it behind the Cloudflare proxy

### DIFF
--- a/k8s/talos/apps/blog/inflight-middleware.yaml
+++ b/k8s/talos/apps/blog/inflight-middleware.yaml
@@ -10,9 +10,7 @@ spec:
   #
   # sourceCriterion is explicit because inFlightReq defaults to keying on
   # requestHost, unlike rateLimit — left implicit it would cap the whole blog at
-  # 30 concurrent requests rather than 30 per client. depth: 1 reads the rightmost
-  # X-Forwarded-For entry, which behind Cloudflare is the real visitor; the
-  # connection's remote address is only an edge IP. Same reasoning as the rate
+  # 30 concurrent requests rather than 30 per client. depth: 1 as in the rate
   # limit middleware.
   inFlightReq:
     amount: 30

--- a/k8s/talos/apps/blog/inflight-middleware.yaml
+++ b/k8s/talos/apps/blog/inflight-middleware.yaml
@@ -10,9 +10,12 @@ spec:
   #
   # sourceCriterion is explicit because inFlightReq defaults to keying on
   # requestHost, unlike rateLimit — left implicit it would cap the whole blog at
-  # 30 concurrent requests rather than 30 per client. An empty ipStrategy makes
-  # Traefik key on the connection's remote address (the true client IP).
+  # 30 concurrent requests rather than 30 per client. depth: 1 reads the rightmost
+  # X-Forwarded-For entry, which behind Cloudflare is the real visitor; the
+  # connection's remote address is only an edge IP. Same reasoning as the rate
+  # limit middleware.
   inFlightReq:
     amount: 30
     sourceCriterion:
-      ipStrategy: {}
+      ipStrategy:
+        depth: 1

--- a/k8s/talos/apps/blog/ratelimit-middleware.yaml
+++ b/k8s/talos/apps/blog/ratelimit-middleware.yaml
@@ -8,9 +8,12 @@ spec:
   # serves static files with no limit_req zone, so request rate was uncapped all
   # the way to the pod.
   #
-  # sourceCriterion left unset on purpose — Traefik then keys on the connection's
-  # remote address, which is the true client IP (the router DNATs without SNAT).
-  # ipStrategy.depth would read a forgeable X-Forwarded-For instead.
+  # Behind Cloudflare the connection's remote address is an edge IP, so keying on
+  # it would bucket every visitor behind a POP into one limit. depth: 1 takes the
+  # rightmost X-Forwarded-For entry instead, which is the address Cloudflare
+  # observed the request coming from. It is not forgeable: Cloudflare appends its
+  # own observation after anything the client sent, and the websecure entrypoint
+  # only preserves the header for connections from Cloudflare's ranges.
   #
   # Lower than portfolio's because a Hugo page pulls far less: the busiest real
   # client in the access logs peaked at 13 req/s. Each of the three Traefik
@@ -19,3 +22,6 @@ spec:
     average: 25
     period: 1s
     burst: 100
+    sourceCriterion:
+      ipStrategy:
+        depth: 1

--- a/k8s/talos/apps/blog/ratelimit-middleware.yaml
+++ b/k8s/talos/apps/blog/ratelimit-middleware.yaml
@@ -4,16 +4,12 @@ metadata:
   name: blog-ratelimit
   namespace: blog
 spec:
-  # Same reasoning as the portfolio middleware: no CDN in front, and nginx here
-  # serves static files with no limit_req zone, so request rate was uncapped all
-  # the way to the pod.
+  # Same reasoning as the portfolio middleware: the origin stays directly
+  # reachable past Cloudflare, and nginx here serves static files with no
+  # limit_req zone, so request rate was uncapped all the way to the pod.
   #
-  # Behind Cloudflare the connection's remote address is an edge IP, so keying on
-  # it would bucket every visitor behind a POP into one limit. depth: 1 takes the
-  # rightmost X-Forwarded-For entry instead, which is the address Cloudflare
-  # observed the request coming from. It is not forgeable: Cloudflare appends its
-  # own observation after anything the client sent, and the websecure entrypoint
-  # only preserves the header for connections from Cloudflare's ranges.
+  # depth: 1 reads the rightmost X-Forwarded-For entry, the address Cloudflare
+  # observed. Keying on the remote address would bucket a whole POP together.
   #
   # Lower than portfolio's because a Hugo page pulls far less: the busiest real
   # client in the access logs peaked at 13 req/s. Each of the three Traefik

--- a/k8s/talos/apps/portfolio/inflight-middleware.yaml
+++ b/k8s/talos/apps/portfolio/inflight-middleware.yaml
@@ -10,10 +10,10 @@ spec:
   #
   # sourceCriterion is explicit here because inFlightReq defaults to keying on
   # requestHost, unlike rateLimit — left implicit it would cap the whole site at
-  # 60 concurrent requests rather than 60 per client. An empty ipStrategy (no
-  # depth, no excludedIPs) makes Traefik use the connection's remote address,
-  # which is the true client IP and, unlike X-Forwarded-For, cannot be forged.
+  # 60 concurrent requests rather than 60 per client. depth: 1 as in the rate
+  # limit middleware.
   inFlightReq:
     amount: 60
     sourceCriterion:
-      ipStrategy: {}
+      ipStrategy:
+        depth: 1

--- a/k8s/talos/apps/portfolio/ratelimit-middleware.yaml
+++ b/k8s/talos/apps/portfolio/ratelimit-middleware.yaml
@@ -4,15 +4,14 @@ metadata:
   name: portfolio-ratelimit
   namespace: portfolio
 spec:
-  # Nothing sat in front of this origin: no CDN (the apex A record points
-  # straight at the house), and neither Next.js nor the gateway capped request
+  # Cloudflare fronts the proxied path, but the origin stays directly reachable
+  # via ddns.nordbye.it, and neither Next.js nor the gateway capped request
   # rate. A single client could pull /fun's ~6.5 MB of models and textures, or
   # the 262 KB uncompressed homepage, as fast as the uplink allowed.
   #
-  # Token bucket keyed on the client IP. sourceCriterion is deliberately left
-  # unset so Traefik keys on the connection's remote address — the router DNATs
-  # without SNAT, so that is the real client. Setting ipStrategy.depth instead
-  # would read X-Forwarded-For, which any caller can forge here.
+  # Token bucket keyed on the client IP. depth: 1 reads the rightmost
+  # X-Forwarded-For entry, the address Cloudflare observed. Keying on the remote
+  # address would bucket a whole POP together.
   #
   # average/burst are ~4x the busiest real client seen in the access logs
   # (33 req/s on a cold /fun load), so a browser fetching chunks, models and
@@ -23,3 +22,6 @@ spec:
     average: 50
     period: 1s
     burst: 200
+    sourceCriterion:
+      ipStrategy:
+        depth: 1

--- a/k8s/talos/infra/traefik/values.yaml
+++ b/k8s/talos/infra/traefik/values.yaml
@@ -56,6 +56,34 @@ ports:
     port: 8000
     exposedPort: 80
     protocol: TCP
+    # blog.nordbye.it is proxied through Cloudflare, so requests arrive from an
+    # edge address. Without trustedIPs the entrypoint strips X-Forwarded-For and
+    # the per-client limits downstream key on the edge IP, not the visitor.
+    # Ranges from cloudflare.com/ips-v4 and /ips-v6, fetched 2026-08-21.
+    forwardedHeaders:
+      trustedIPs: &cloudflareIPs
+        - 173.245.48.0/20
+        - 103.21.244.0/22
+        - 103.22.200.0/22
+        - 103.31.4.0/22
+        - 141.101.64.0/18
+        - 108.162.192.0/18
+        - 190.93.240.0/20
+        - 188.114.96.0/20
+        - 197.234.240.0/22
+        - 198.41.128.0/17
+        - 162.158.0.0/15
+        - 104.16.0.0/13
+        - 104.24.0.0/14
+        - 172.64.0.0/13
+        - 131.0.72.0/22
+        - 2400:cb00::/32
+        - 2606:4700::/32
+        - 2803:f800::/32
+        - 2405:b500::/32
+        - 2405:8100::/32
+        - 2a06:98c0::/29
+        - 2c0f:f248::/32
     expose:
       default: true
     http:
@@ -68,6 +96,9 @@ ports:
     port: 8443
     exposedPort: 443
     protocol: TCP
+    # Same ranges as web; this is where proxied traffic lands.
+    forwardedHeaders:
+      trustedIPs: *cloudflareIPs
     # HTTP/3 (QUIC) on the public HTTPS entrypoint. Traefik also listens UDP on
     # this port and advertises Alt-Svc: h3=":443" so browsers upgrade. Serving
     # over UDP/443 additionally needs the port on the public Service and the


### PR DESCRIPTION
## Why

Two goals, one change.

Speed: Google's Crawl Stats measures a 702ms average response time for `blog.nordbye.it`. Both sites are served from a residential connection with nothing in front of them. Edge caching moves the common case off that uplink.

Indexing: Search Console has 0 indexed pages for the blog against 16 known URLs, 12 crawled and declined and 4 never fetched. Crawl stats report "Host had problems in the past", with robots.txt fetch and server connectivity both flagged as having had a high fail rate. A failed robots.txt fetch stops crawling of the whole host, and a residential line makes that a recurring risk.

## What

`feat(traefik)` adds `forwardedHeaders.trustedIPs` to the `web` and `websecure` entrypoints, listing Cloudflare's published ranges through a YAML anchor. Without this the entrypoint strips the incoming `X-Forwarded-For`, so the real client IP would never reach the middlewares. This is entrypoint-level and therefore applies to every public hostname, but it is inert for any host whose traffic does not arrive from a Cloudflare address.

`fix(blog)` and `fix(portfolio)` move all four rate-limit and in-flight middlewares to `sourceCriterion.ipStrategy.depth: 1`. Each keyed on the connection's remote address, which was right for a directly exposed origin but behind Cloudflare would put a whole POP's visitors into one bucket.

The limits are kept rather than delegated to Cloudflare because proxying does not make the origin unreachable: `ddns.nordbye.it` stays DNS-only on the same address, so the origin can still be reached directly and these are the only limits on that path.

## Verification

- `helm template` renders the `trustedIPs` arg on both entrypoints with all 22 ranges, HTTP/3 settings intact
- `kustomize build` renders `depth: 1` on all four middlewares
- `kubectl diff --field-manager=argocd-controller` for both apps shows only the `ipStrategy` changes and nothing else
- Traefik access logs confirm external requests currently arrive with genuine public client IPs, so the services are not SNATing despite `externalTrafficPolicy: Cluster`
- Origin cert is `*.nordbye.it` + `nordbye.it` from Let's Encrypt, valid to 25 Sep 2026, chain verifies clean from outside

## Rollout order

Everything here is inert until the DNS records flip, so this merges safely on its own. The proxy must not be enabled first, or the rate limits apply per Cloudflare POP instead of per visitor.

1. Zone SSL/TLS mode set to Full (Strict). It was Flexible, which would put a proxied site into a redirect loop. Done outside this PR.
2. Merge, let ArgoCD reconcile. Traefik restarts to pick up the new static args; `maxSurge: 0` across 3 replicas means it runs at 2/3 briefly.
3. Add the Cloudflare cache rule (below).
4. Flip `blog.nordbye.it` to Proxied, confirm access logs still show visitor IPs, then flip `nordbye.it` and `www`.

## Cache rule

One rule per zone, covering both sites:

```
Match:  hostname in {blog.nordbye.it, nordbye.it, www.nordbye.it}
        AND NOT path starts_with "/api/"
Action: Eligible for cache
        Edge TTL = 60s (override origin)
```

The explicit TTL is deliberate. Blog HTML sends no `Cache-Control` at all, and portfolio HTML sends `s-maxage=31536000` (a Next.js default that assumes a purge-on-deploy CDN), so respecting origin headers would either cache nothing or freeze the portfolio for a year. 60s keeps deploys visible within a minute and needs no purge machinery.

`/api/` is excluded so `nordbye.it/api/v1/infra`, which feeds the README status card, keeps its own 30s freshness.

## Notes

Cloudflare ranges are pinned in the values file and need a manual refresh if Cloudflare publishes new ones. Once proxied, Cloudflare terminates HTTP/3 with the client, so the origin HTTP/3 config stops being what browsers negotiate for these hostnames.