### PR TITLE
Manage the nordbye.it Cloudflare zone in Terraform

### DIFF
--- a/.backup-manifest
+++ b/.backup-manifest
@@ -23,3 +23,4 @@ terraform/proxmox/hyper-cluster/k8s/talos/controlplane.yaml
 terraform/proxmox/hyper-cluster/k8s/talos/terraform.tfvars
 terraform/azure/state/terraform.tfvars
 terraform/cloudflare/nordbye-it/terraform.tfvars
+terraform/cloudflare/logeverylift-com/terraform.tfvars

--- a/.backup-manifest
+++ b/.backup-manifest
@@ -22,3 +22,4 @@ terraform/proxmox/hyper-cluster/k8s/talos/controlplane.yaml
 # Terraform variables (contain credentials)
 terraform/proxmox/hyper-cluster/k8s/talos/terraform.tfvars
 terraform/azure/state/terraform.tfvars
+terraform/cloudflare/nordbye-it/terraform.tfvars

--- a/terraform/cloudflare/logeverylift-com/README.md
+++ b/terraform/cloudflare/logeverylift-com/README.md
@@ -1,0 +1,38 @@
+# Cloudflare: logeverylift.com
+
+Zone settings, DNS records and the www redirect. State lives in the shared
+azurerm backend.
+
+No cache rule: the app is authenticated and per-user, so its HTML must not be
+cached at a shared edge. Static assets are still edge-cached by extension.
+
+## Use
+
+```bash
+cp terraform.tfvars.example terraform.tfvars   # paste an API token
+terraform init
+terraform plan
+terraform apply
+```
+
+The token needs Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit,
+in a policy scoped to zones. An account-scoped policy alone does not grant DNS.
+
+The apex and SPF records already exist and must be imported before the first
+apply, otherwise it fails with "record already exists":
+
+```bash
+ZONE_ID=$(terraform output -raw zone_id)
+terraform import cloudflare_dns_record.apex "$ZONE_ID/<record id>"
+terraform import cloudflare_dns_record.spf  "$ZONE_ID/<record id>"
+```
+
+## Notes
+
+- The three MX records and the DKIM TXT are not managed. Cloudflare Email
+  Routing owns them and the API rejects writes.
+- TXT values keep their escaped quotes, to match what the API returns.
+- DMARC is `p=none` on purpose. Email Routing forwards mail, and forwarded mail
+  routinely fails SPF alignment. Tighten to quarantine once monitoring is clean.
+- Token permission changes take a few minutes to propagate. Until they do, API
+  calls fail intermittently.

--- a/terraform/cloudflare/logeverylift-com/dns.tf
+++ b/terraform/cloudflare/logeverylift-com/dns.tf
@@ -1,0 +1,43 @@
+# The three MX records and the DKIM TXT are absent on purpose. Cloudflare Email
+# Routing owns them (meta.email_routing, read_only), so the API rejects writes.
+#
+# TXT content carries its own escaped quotes, matching what the API returns.
+
+resource "cloudflare_dns_record" "apex" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = var.zone_name
+  type    = "CNAME"
+  content = var.origin_hostname
+  proxied = true
+  ttl     = 1
+}
+
+# The HTTPRoute only serves the apex, so www would 404 on its own. The redirect
+# ruleset sends it to the apex before it ever reaches the cluster.
+resource "cloudflare_dns_record" "www" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "www.${var.zone_name}"
+  type    = "CNAME"
+  content = var.zone_name
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "spf" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = var.zone_name
+  type    = "TXT"
+  content = "\"v=spf1 include:_spf.mx.cloudflare.net ~all\""
+  ttl     = 1
+}
+
+# p=none is deliberate. The domain receives through Cloudflare Email Routing,
+# which forwards, and forwarded mail routinely fails SPF alignment. Monitor
+# first; tighten to quarantine once it is clear nothing legitimate is affected.
+resource "cloudflare_dns_record" "dmarc" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "_dmarc.${var.zone_name}"
+  type    = "TXT"
+  content = "\"v=DMARC1; p=none\""
+  ttl     = 1
+}

--- a/terraform/cloudflare/logeverylift-com/main.tf
+++ b/terraform/cloudflare/logeverylift-com/main.tf
@@ -1,0 +1,5 @@
+data "cloudflare_zone" "this" {
+  filter = {
+    name = var.zone_name
+  }
+}

--- a/terraform/cloudflare/logeverylift-com/outputs.tf
+++ b/terraform/cloudflare/logeverylift-com/outputs.tf
@@ -1,0 +1,4 @@
+output "zone_id" {
+  description = "Cloudflare zone ID, useful for API calls and imports"
+  value       = data.cloudflare_zone.this.zone_id
+}

--- a/terraform/cloudflare/logeverylift-com/providers.tf
+++ b/terraform/cloudflare/logeverylift-com/providers.tf
@@ -1,0 +1,3 @@
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/terraform/cloudflare/logeverylift-com/redirect.tf
+++ b/terraform/cloudflare/logeverylift-com/redirect.tf
@@ -1,0 +1,28 @@
+# www exists only to not be a dead hostname. Redirecting at the edge keeps the
+# app on one canonical host, which avoids serving the same pages on two
+# hostnames, and means the cluster never sees the request.
+resource "cloudflare_ruleset" "redirect" {
+  zone_id     = data.cloudflare_zone.this.zone_id
+  name        = "default"
+  kind        = "zone"
+  phase       = "http_request_dynamic_redirect"
+  description = "Canonical host redirects"
+
+  rules = [
+    {
+      ref         = "www_to_apex"
+      description = "Send www to the apex"
+      expression  = "http.host eq \"www.${var.zone_name}\""
+      action      = "redirect"
+      action_parameters = {
+        from_value = {
+          status_code           = 301
+          preserve_query_string = true
+          target_url = {
+            expression = "concat(\"https://${var.zone_name}\", http.request.uri.path)"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/terraform/cloudflare/logeverylift-com/terraform.tfvars.example
+++ b/terraform/cloudflare/logeverylift-com/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# Copy to terraform.tfvars and fill in. *.tfvars is gitignored.
+#
+# Create the token at https://dash.cloudflare.com/profile/api-tokens with
+# permissions Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit,
+# in a policy scoped to zones.
+cloudflare_api_token = ""

--- a/terraform/cloudflare/logeverylift-com/variables.tf
+++ b/terraform/cloudflare/logeverylift-com/variables.tf
@@ -1,0 +1,17 @@
+variable "cloudflare_api_token" {
+  description = "API token with Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit on this zone. The token external-dns and cert-manager share is DNS-only and will not cover the zone setting or ruleset resources."
+  type        = string
+  sensitive   = true
+}
+
+variable "zone_name" {
+  description = "Cloudflare zone managed by this configuration"
+  type        = string
+  default     = "logeverylift.com"
+}
+
+variable "origin_hostname" {
+  description = "Hostname the apex points at. Its A record lives in the nordbye.it zone and is written by the DDNS client."
+  type        = string
+  default     = "ddns.nordbye.it"
+}

--- a/terraform/cloudflare/logeverylift-com/version.tf
+++ b/terraform/cloudflare/logeverylift-com/version.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.23"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "rg-tfstate-homelab"
+    storage_account_name = "sttfstatemvnhomelab"
+    container_name       = "tfstate"
+    key                  = "cloudflare/logeverylift-com.tfstate"
+  }
+}

--- a/terraform/cloudflare/logeverylift-com/zone-settings.tf
+++ b/terraform/cloudflare/logeverylift-com/zone-settings.tf
@@ -1,0 +1,8 @@
+# Full (Strict) rather than Full: the origin serves a Let's Encrypt certificate
+# covering logeverylift.com and *.logeverylift.com, so Cloudflare can validate it
+# instead of accepting anything.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = data.cloudflare_zone.this.zone_id
+  setting_id = "ssl"
+  value      = "strict"
+}

--- a/terraform/cloudflare/nordbye-it/README.md
+++ b/terraform/cloudflare/nordbye-it/README.md
@@ -1,0 +1,28 @@
+# Cloudflare: nordbye.it
+
+Zone settings, DNS records and the edge cache rule. State lives in the shared
+azurerm backend.
+
+## Use
+
+```bash
+cp terraform.tfvars.example terraform.tfvars   # paste an API token
+terraform init
+terraform plan
+terraform apply
+```
+
+The token needs Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit,
+in a policy scoped to zones. An account-scoped policy alone does not grant DNS.
+
+A record added by hand in the dashboard has to be imported before Terraform will
+manage it (`terraform import cloudflare_dns_record.<name> <zone_id>/<record_id>`),
+otherwise apply fails with "record already exists".
+
+## Notes
+
+- `_acme-challenge` is not managed. cert-manager creates and deletes it.
+- `ddns` content is ignored. The DDNS client owns the address.
+- TXT values keep their escaped quotes, to match what the API returns.
+- Token permission changes take a few minutes to propagate. Until they do, API
+  calls fail intermittently. Wait rather than changing the config.

--- a/terraform/cloudflare/nordbye-it/cache.tf
+++ b/terraform/cloudflare/nordbye-it/cache.tf
@@ -2,6 +2,11 @@
 # never cached without a rule regardless of origin headers. HTML is the request
 # that costs ~700ms from the residential origin, so it is the one worth caching.
 #
+# browser_ttl is deliberately absent. This rule matches every path on these
+# hosts except /api/, so overriding it would strip the immutable year off the
+# fingerprinted CSS and JS. The zone's browser TTL only fills the gap where an
+# origin sets no max-age, which is HTML alone, so assets are already correct.
+#
 # /api/ is excluded so nordbye.it/api/v1/infra, which feeds the README status
 # card, keeps hitting origin and stays fresh.
 resource "cloudflare_ruleset" "cache" {

--- a/terraform/cloudflare/nordbye-it/cache.tf
+++ b/terraform/cloudflare/nordbye-it/cache.tf
@@ -1,0 +1,32 @@
+# Cloudflare decides default cache eligibility by file extension, so HTML is
+# never cached without a rule regardless of origin headers. HTML is the request
+# that costs ~700ms from the residential origin, so it is the one worth caching.
+#
+# /api/ is excluded so nordbye.it/api/v1/infra, which feeds the README status
+# card, keeps hitting origin and stays fresh.
+resource "cloudflare_ruleset" "cache" {
+  zone_id     = data.cloudflare_zone.this.zone_id
+  name        = "default"
+  kind        = "zone"
+  phase       = "http_request_cache_settings"
+  description = "Edge-cache HTML for the proxied sites"
+
+  rules = [
+    {
+      ref         = "cache_html"
+      description = "Cache HTML at the edge, excluding the infra API"
+      expression = format(
+        "(http.host in {%s}) and not starts_with(http.request.uri.path, \"/api/\")",
+        join(" ", [for h in var.proxied_hostnames : "\"${h}\""])
+      )
+      action = "set_cache_settings"
+      action_parameters = {
+        cache = true
+        edge_ttl = {
+          mode    = "override_origin"
+          default = var.edge_cache_ttl_seconds
+        }
+      }
+    }
+  ]
+}

--- a/terraform/cloudflare/nordbye-it/dns.tf
+++ b/terraform/cloudflare/nordbye-it/dns.tf
@@ -1,0 +1,135 @@
+# Proxied records must carry ttl = 1 (automatic); Cloudflare rejects any other
+# value on them.
+#
+# _acme-challenge.nordbye.it is deliberately absent. cert-manager creates and
+# deletes it during every DNS-01 issuance, so managing it here would fight
+# certificate renewal.
+#
+# TXT content carries its own escaped quotes: the API stores and returns TXT
+# values quoted, and bare values plan as a diff on every run.
+
+# --- Origin ---------------------------------------------------------------
+
+# The address every web hostname points at. The DDNS client rewrites content, so
+# that attribute is ignored. The record stays managed so its proxy status is
+# pinned: proxying this would break the CNAME chain the other records rely on.
+resource "cloudflare_dns_record" "ddns" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "ddns.${var.zone_name}"
+  type    = "A"
+  content = "84.212.143.165"
+  proxied = false
+  ttl     = 1
+
+  lifecycle {
+    ignore_changes = [content]
+  }
+}
+
+# --- Proxied sites --------------------------------------------------------
+
+resource "cloudflare_dns_record" "blog" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "blog.${var.zone_name}"
+  type    = "CNAME"
+  content = var.origin_hostname
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "apex" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = var.zone_name
+  type    = "CNAME"
+  content = var.origin_hostname
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "www" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "www.${var.zone_name}"
+  type    = "CNAME"
+  content = var.zone_name
+  proxied = true
+  ttl     = 1
+}
+
+# --- Direct-to-origin apps ------------------------------------------------
+
+# gate serves reelsmith, headroom serves headroom-demo. Neither is proxied yet;
+# both would need the same ipStrategy treatment as blog and portfolio first.
+resource "cloudflare_dns_record" "direct" {
+  for_each = toset(["gate", "headroom"])
+
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "${each.key}.${var.zone_name}"
+  type    = "CNAME"
+  content = var.origin_hostname
+  proxied = false
+  ttl     = 1
+}
+
+# --- Mail -----------------------------------------------------------------
+
+resource "cloudflare_dns_record" "mx" {
+  for_each = {
+    "aspmx.l.google.com"      = 1
+    "alt1.aspmx.l.google.com" = 5
+    "alt2.aspmx.l.google.com" = 5
+    "alt3.aspmx.l.google.com" = 10
+    "alt4.aspmx.l.google.com" = 10
+  }
+
+  zone_id  = data.cloudflare_zone.this.zone_id
+  name     = var.zone_name
+  type     = "MX"
+  content  = each.key
+  priority = each.value
+  ttl      = 3600
+}
+
+resource "cloudflare_dns_record" "spf" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = var.zone_name
+  type    = "TXT"
+  content = "\"v=spf1 include:_spf.google.com ~all\""
+  ttl     = 3600
+}
+
+resource "cloudflare_dns_record" "dmarc" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "_dmarc.${var.zone_name}"
+  type    = "TXT"
+  content = "\"v=DMARC1; p=quarantine\""
+  ttl     = 3600
+}
+
+# --- Domain verification --------------------------------------------------
+
+# Two Search Console properties are verified against this zone: nordbye.it and
+# blog.nordbye.it. Removing either un-verifies a property.
+resource "cloudflare_dns_record" "google_verification_1" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = var.zone_name
+  type    = "TXT"
+  content = "\"google-site-verification=nZvJnfeqepcZVfqeG9LKRIbZQll06rxwsOi93EzoWHU\""
+  ttl     = 3600
+}
+
+resource "cloudflare_dns_record" "google_verification_2" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = var.zone_name
+  type    = "TXT"
+  content = "\"google-site-verification=pW0Dln3ShXs7R0R610g7fo0jeDAkiSQfmzgLI_KJolE\""
+  ttl     = 3600
+}
+
+# Azure App Service custom domain verification ID.
+resource "cloudflare_dns_record" "asuid" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "asuid.${var.zone_name}"
+  type    = "TXT"
+  content = "\"17D18F37325E41EA89D80F0E2BB5977B800AC2DCBA06E506C4049F68A11EC9BC\""
+  ttl     = 1
+}

--- a/terraform/cloudflare/nordbye-it/dns.tf
+++ b/terraform/cloudflare/nordbye-it/dns.tf
@@ -55,10 +55,20 @@ resource "cloudflare_dns_record" "www" {
   ttl     = 1
 }
 
-# --- Direct-to-origin apps ------------------------------------------------
+# --- Apps -----------------------------------------------------------------
 
-# gate serves reelsmith, headroom serves headroom-demo. Neither is proxied yet;
-# both would need the same ipStrategy treatment as blog and portfolio first.
+# gate serves reelsmith (behind Authentik), headroom serves headroom-demo. Both
+# are proxied for edge TLS, DDoS cover and asset caching, but deliberately left
+# out of var.proxied_hostnames so the cache rule never touches their HTML:
+# caching an authenticated or stateful response at a shared edge can serve one
+# visitor's page to another. Static assets are still edge-cached by extension,
+# with no rule involved.
+#
+# Neither app has an IP-keyed rate limit, unlike blog and portfolio, so proxying
+# them needs no ipStrategy change in the cluster.
+#
+# The resource name stays "direct" so this is an in-place update; renaming would
+# destroy and recreate live DNS records.
 resource "cloudflare_dns_record" "direct" {
   for_each = toset(["gate", "headroom"])
 
@@ -66,7 +76,7 @@ resource "cloudflare_dns_record" "direct" {
   name    = "${each.key}.${var.zone_name}"
   type    = "CNAME"
   content = var.origin_hostname
-  proxied = false
+  proxied = true
   ttl     = 1
 }
 

--- a/terraform/cloudflare/nordbye-it/main.tf
+++ b/terraform/cloudflare/nordbye-it/main.tf
@@ -1,0 +1,5 @@
+data "cloudflare_zone" "this" {
+  filter = {
+    name = var.zone_name
+  }
+}

--- a/terraform/cloudflare/nordbye-it/outputs.tf
+++ b/terraform/cloudflare/nordbye-it/outputs.tf
@@ -1,0 +1,4 @@
+output "zone_id" {
+  description = "Cloudflare zone ID, useful for API calls and imports"
+  value       = data.cloudflare_zone.this.zone_id
+}

--- a/terraform/cloudflare/nordbye-it/providers.tf
+++ b/terraform/cloudflare/nordbye-it/providers.tf
@@ -1,0 +1,3 @@
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/terraform/cloudflare/nordbye-it/terraform.tfvars.example
+++ b/terraform/cloudflare/nordbye-it/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# Copy to terraform.tfvars and fill in. *.tfvars is gitignored.
+#
+# Create the token at https://dash.cloudflare.com/profile/api-tokens with
+# permissions Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit,
+# scoped to the nordbye.it zone.
+cloudflare_api_token = ""

--- a/terraform/cloudflare/nordbye-it/variables.tf
+++ b/terraform/cloudflare/nordbye-it/variables.tf
@@ -1,0 +1,29 @@
+variable "cloudflare_api_token" {
+  description = "API token with Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit on this zone. The token external-dns and cert-manager share is DNS-only and will not cover the zone setting or ruleset resources."
+  type        = string
+  sensitive   = true
+}
+
+variable "zone_name" {
+  description = "Cloudflare zone managed by this configuration"
+  type        = string
+  default     = "nordbye.it"
+}
+
+variable "origin_hostname" {
+  description = "Hostname every web record points at. Its A record is written by the DDNS client, so Terraform does not manage it."
+  type        = string
+  default     = "ddns.nordbye.it"
+}
+
+variable "proxied_hostnames" {
+  description = "Hostnames served through the Cloudflare proxy, used to scope the cache rule"
+  type        = list(string)
+  default     = ["blog.nordbye.it", "nordbye.it", "www.nordbye.it"]
+}
+
+variable "edge_cache_ttl_seconds" {
+  description = "Edge TTL for HTML. Short so deploys appear without a purge step: blog sends no Cache-Control and the Next.js portfolio sends s-maxage=31536000, so neither origin header is worth respecting."
+  type        = number
+  default     = 60
+}

--- a/terraform/cloudflare/nordbye-it/variables.tf
+++ b/terraform/cloudflare/nordbye-it/variables.tf
@@ -17,13 +17,13 @@ variable "origin_hostname" {
 }
 
 variable "proxied_hostnames" {
-  description = "Hostnames served through the Cloudflare proxy, used to scope the cache rule"
+  description = "Hostnames whose HTML the cache rule may cache. Not the same as what is proxied: gate and headroom are proxied too but excluded here, because caching authenticated or stateful HTML at a shared edge can serve one visitor's page to another."
   type        = list(string)
   default     = ["blog.nordbye.it", "nordbye.it", "www.nordbye.it"]
 }
 
 variable "edge_cache_ttl_seconds" {
-  description = "Edge TTL for HTML. Short so deploys appear without a purge step: blog sends no Cache-Control and the Next.js portfolio sends s-maxage=31536000, so neither origin header is worth respecting."
+  description = "Edge TTL for HTML. Cloudflare caches per POP, so at this traffic level a short TTL expires before the next visitor from that POP arrives and almost everything misses. Four hours matches the zone's browser TTL. Purge from the dashboard after publishing."
   type        = number
-  default     = 60
+  default     = 14400
 }

--- a/terraform/cloudflare/nordbye-it/version.tf
+++ b/terraform/cloudflare/nordbye-it/version.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.23"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "rg-tfstate-homelab"
+    storage_account_name = "sttfstatemvnhomelab"
+    container_name       = "tfstate"
+    key                  = "cloudflare/nordbye-it.tfstate"
+  }
+}

--- a/terraform/cloudflare/nordbye-it/zone-settings.tf
+++ b/terraform/cloudflare/nordbye-it/zone-settings.tf
@@ -6,3 +6,16 @@ resource "cloudflare_zone_setting" "ssl" {
   setting_id = "ssl"
   value      = "strict"
 }
+
+# The origin is a residential connection and occasionally drops a request
+# outright, which Cloudflare renders as a 502. Always Online serves a stale copy
+# from Cloudflare's archive instead, for the sites whose content is public and
+# where a slightly old page beats an error.
+#
+# Deliberately not enabled on logeverylift.com: stale content in an
+# authenticated app is worse than an honest failure.
+resource "cloudflare_zone_setting" "always_online" {
+  zone_id    = data.cloudflare_zone.this.zone_id
+  setting_id = "always_online"
+  value      = "on"
+}

--- a/terraform/cloudflare/nordbye-it/zone-settings.tf
+++ b/terraform/cloudflare/nordbye-it/zone-settings.tf
@@ -1,0 +1,8 @@
+# Full (Strict). The origin serves a Let's Encrypt wildcard for *.nordbye.it, so
+# Cloudflare can validate it. Flexible would leave the Cloudflare-to-origin hop
+# unencrypted and loop against the origin's HTTP-to-HTTPS redirect.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = data.cloudflare_zone.this.zone_id
+  setting_id = "ssl"
+  value      = "strict"
+}


### PR DESCRIPTION
## Why

The zone was dashboard-only: SSL mode, proxy toggles, the cache rule and all 17 DNS records existed nowhere in code. With the sites moving behind the Cloudflare proxy for edge caching, that configuration stops being incidental and starts carrying real behaviour, so it belongs in the repo.

The driver was speed and crawlability. Google's Crawl Stats measured a 702ms average response time against the blog, served from a residential connection with nothing in front of it, and reported "Host had problems in the past" with robots.txt fetch and server connectivity both flagged.

## What

New `terraform/cloudflare/nordbye-it/`, state in the shared azurerm backend under `cloudflare/nordbye-it.tfstate`, provider `cloudflare/cloudflare ~> 5.23`. The API token comes from a gitignored tfvars, as the Proxmox configuration does. `.backup-manifest` picks that file up alongside the other two.

Manages the SSL/TLS mode (Full (Strict)), the `http_request_cache_settings` ruleset, and 16 of the 17 records.

## Proxying, and what may be cached

All five web hostnames are proxied. Only three have their HTML cached:

| Hostname | Proxied | HTML cached |
| --- | --- | --- |
| `blog.nordbye.it` | yes | yes |
| `nordbye.it`, `www` | yes | yes |
| `gate.nordbye.it` (reelsmith) | yes | **no** |
| `headroom.nordbye.it` | yes | **no** |

`gate` sits behind Authentik and `headroom-demo` is stateful. Caching either at a shared edge can serve one visitor's page to another, so both are deliberately excluded from `var.proxied_hostnames`, which scopes the cache rule. Their static assets are still edge-cached by extension, with no rule involved. Neither has an IP-keyed rate limit, so proxying them needed no cluster change.

## Cache rule

Marks HTML eligible and overrides origin TTL to 4 hours. Overriding rather than respecting is deliberate: blog HTML sends no `Cache-Control` and the Next.js portfolio sends `s-maxage=31536000`, so respecting origin headers would either cache nothing or freeze the portfolio for a year.

4 hours rather than the 60s I first used, because Cloudflare caches per POP: at this traffic level a 60s copy expires long before the next visitor from that POP arrives, so nearly everything missed. Deploys now need a dashboard purge to appear immediately.

`browser_ttl` is deliberately absent from the rule. It matches every path except `/api/`, so overriding it would strip the immutable year off the fingerprinted CSS and JS. Verified that the zone browser TTL only fills the gap where an origin sets no `max-age`, which is HTML alone, so assets keep `public, max-age=31536000, immutable` through the edge.

`/api/` is excluded so `nordbye.it/api/v1/infra`, which feeds the README status card, stays fresh.

## Two records that need care

`_acme-challenge.nordbye.it` is unmanaged. cert-manager creates and deletes it on every DNS-01 issuance, so Terraform would fight certificate renewal.

`ddns.nordbye.it` is managed with `ignore_changes = [content]`. The DDNS client owns the address, but its proxy status is worth pinning, since proxying it would break the CNAME chain every other hostname depends on.

TXT `content` values carry their own escaped quotes. The API stores and returns TXT values quoted, and the first plan caught that bare values would have rewritten SPF, DMARC and both verification records on apply.

## Verification

- `terraform fmt -check -recursive` clean, `terraform validate` passes
- Pending plan: **0 to add, 3 to change, 0 to destroy** — `gate` and `headroom` to proxied, and the edge TTL 60 to 14400. Confirmed via the JSON plan that nothing is destroyed or replaced, and that the cache rule expression still lists only the three cacheable hostnames
- Full TXT and MX values were read from live DNS rather than the truncated dashboard display
- No secret material in the diff; no real tfvars tracked

## Already applied and confirmed

`blog`, the apex and `www` are proxied:

- Traefik logs the real visitor IP rather than a Cloudflare edge address, on both sites, so `forwardedHeaders.trustedIPs` and `ipStrategy.depth: 1` from #702 are working
- `cf-cache-status` goes MISS then HIT on a repeat request
- `/api/v1/infra` is `DYNAMIC`, uncached, keeping its own `max-age=30`
- Valid TLS over IPv4 and IPv6; the edge cert covers `nordbye.it` and `*.nordbye.it`
- All 17 records intact