### PR TITLE
Let external-dns own zone apex records

### DIFF
--- a/k8s/talos/infra/external-dns/values.yaml
+++ b/k8s/talos/infra/external-dns/values.yaml
@@ -24,10 +24,19 @@ excludeDomains:
 # Start conservative: create/update records, never delete. Switch to "sync" once trusted.
 policy: upsert-only
 
-# Ownership tracking. txtPrefix templates the record type so the TXT never collides with a CNAME.
+# Ownership tracking. txtPrefix templates the record type so the TXT never
+# collides with a CNAME.
+#
+# The trailing dot matters. AffixNameMapper.ToTXTName splits the name on the
+# first dot and inserts the prefix into the first label, so a bare
+# "%{record_type}-" maps the zone apex bigd.no to cname-bigd.no, a sibling of
+# the zone rather than a record in it. The Cloudflare provider's changesByZone
+# then finds no matching zone and drops it at debug level, invisible at INFO,
+# so the apex could never be owned and annotation changes silently skipped it.
+# With the dot the apex maps to extdns-cname.bigd.no, inside the zone.
 registry: txt
 txtOwnerId: genesis
-txtPrefix: "%{record_type}-"
+txtPrefix: "extdns-%{record_type}."
 
 # v0.21 default is external-dns.kubernetes.io/; pinned so the gateway target annotation always matches.
 annotationPrefix: external-dns.kubernetes.io/


### PR DESCRIPTION
## Why

`external-dns` acts only on records carrying a matching ownership TXT, and it could never create one for a zone apex. Adding `cloudflare-proxied` to the bigd route reached `www.bigd.no` and silently skipped `bigd.no`.

`AffixNameMapper.ToTXTName` splits the name on the first dot and inserts the prefix into the first label. With `txtPrefix: "%{record_type}-"` the apex `bigd.no` maps to `cname-bigd.no`, which is a sibling of the zone, not a record in it. `changesByZone` in the Cloudflare provider then matches no zone and drops the change at `log.Debugf`, invisible at the configured INFO level. Subdomains were never affected: `www.bigd.no` maps to `cname-www.bigd.no`, inside the zone.

## What

`txtPrefix` becomes `extdns-%{record_type}.`. The trailing dot is the fix. The apex now maps to `extdns-cname.bigd.no`, which is inside the zone.

Verified against the mapper in both directions. `ToTXTName("bigd.no", "CNAME")` yields `extdns-cname.bigd.no`, a name `FindZone` accepts, and `dropAffixExtractType` parses it back to `bigd.no` plus `CNAME`.

`kustomize build --enable-helm` renders, and `kubectl diff --field-manager=argocd-controller` against the live Deployment shows one changed flag:

```
-        - --txt-prefix=%{record_type}-
+        - --txt-prefix=extdns-%{record_type}.
```

## After merge

Renaming the prefix does not migrate anything on its own. The six `bigd.no` app records will read as unowned under the new naming, and since they already match desired state external-dns computes no change and never writes the new TXTs. Two manual steps follow the sync:

1. Delete the six app CNAMEs so external-dns recreates them and writes ownership TXTs under the new name, apex included. Records return within its one-minute interval.
2. Delete the five orphaned `cname-*` TXTs, which `policy: upsert-only` will not remove.

`bigd.no` carries no critical service, and a short blip there is acceptable, which is what makes this the fix rather than working around the single record.
