### PR TITLE
Manage the local.bigd.no UniFi DNS records in Terraform

### DIFF
--- a/terraform/unifi/dns/README.md
+++ b/terraform/unifi/dns/README.md
@@ -1,0 +1,76 @@
+# UniFi: local.bigd.no
+
+The 27 user-defined records in the internal split-horizon zone served by the
+UniFi gateway's resolver, shown in the console under Settings > Policy Table >
+DNS Records. State lives in the shared azurerm backend.
+
+This is the counterpart to `terraform/cloudflare/bigd-no`. That zone is public
+and external-dns writes the app hostnames into it; this one is LAN-only and
+external-dns is barred from it by `excludeDomains: [local.bigd.no]` in
+`k8s/talos/infra/external-dns/values.yaml`. Nothing else writes the user-defined
+records, so Terraform can own all of them - but see the scope note below for the
+14 records the console shows that Terraform deliberately does not manage.
+
+## Use
+
+```bash
+cp terraform.tfvars.example terraform.tfvars   # paste an API key
+terraform init
+terraform plan
+terraform apply
+```
+
+The API key comes from the console at `/network/default/integrations` (left nav:
+Integrations) via **Create New API Key**. It is shown once. A key bypasses 2FA,
+so it does not need the local-only limited admin account the provider README
+suggests. Note this is a Network API key, not the per-admin UniFi OS key.
+
+## Import (done)
+
+The 27 records already existed in the controller and were adopted with a
+one-shot `imports.tf`, since removed. The apply reported `27 imported, 0 added,
+0 changed, 0 destroyed` and the controller was byte-identical afterwards.
+
+If the state is ever lost, rebuild that file rather than applying into a
+populated controller - `name` carries `RequiresReplace`, so an apply without
+import blocks recreates live records instead of adopting them:
+
+```bash
+curl -sk -H "X-API-KEY: $KEY" \
+  https://10.3.10.1/proxy/network/v2/api/site/default/static-dns
+```
+
+Each `_id` becomes `id` in an `import` block addressing
+`unifi_dns_record.vip["<name>"]` or `.alias["<name>"]`. Confirm the plan reports
+imports and no adds, changes or destroys before applying.
+
+## Scope: 27 records, not the 41 the console shows
+
+The console's DNS Records view counts 41 because "View Default Policies (14)" is
+on. Those 14 are generated from DHCP fixed-IP reservations - `nas`, `pbs`,
+`hyper1`-`hyper3`, `home`, `hue-bridge-pro`, `adguard`, `genesis-ctrl-01..03`,
+`genesis-worker-01..03`. They are absent from both the legacy `static-dns` API
+and the newer `dns/policies` API, which return the same 27 `USER_DEFINED`
+records, so there is nothing to import. Declaring one here would create a second,
+user-defined record shadowing the generated one. Rename or renumber those in the
+DHCP reservation instead.
+
+## Notes
+
+- `ttl` is unset everywhere on purpose. The console stores "Auto" as 0 and the
+  provider maps 0 to a null TTL, so setting a TTL would show as a change against
+  every existing record.
+- `site` and `enabled` are likewise unset. Both are Optional+Computed and settle
+  on the controller's own values.
+- Adding an app means adding a name to `local.aliases` in `records.tf`. That
+  list is hand-maintained and mirrors the HTTPRoutes attached to
+  `gateway-private`; nothing reconciles the two automatically.
+- The three `.10x` addresses are Cilium LB-IPAM VIPs, not hosts. If a VIP is
+  reassigned in `k8s/talos/infra/cilium`, `local.vips` has to follow.
+- The provider talks to the undocumented `v2/api/site/<site>/static-dns` endpoint
+  (`go-unifi/unifi/dns_record.generated.go`), which this firmware still serves.
+  Network 10.1 added an official `network/integration/v1/sites/<id>/dns/policies`
+  API - verified present here, returning the same 27 records - and no Terraform
+  provider implements it yet. A future release that drops the v2 route would
+  break this module, and the `filipowm/unifi` fork uses the same route, so
+  switching provider is not the fix if that happens.

--- a/terraform/unifi/dns/providers.tf
+++ b/terraform/unifi/dns/providers.tf
@@ -1,0 +1,7 @@
+provider "unifi" {
+  api_key = var.unifi_api_key
+  api_url = var.unifi_api_url
+
+  # The console serves its own self-signed certificate on the LAN address.
+  allow_insecure = true
+}

--- a/terraform/unifi/dns/records.tf
+++ b/terraform/unifi/dns/records.tf
@@ -1,0 +1,77 @@
+# Split-horizon DNS for local.bigd.no, served by the UniFi gateway's resolver.
+#
+# This zone is deliberately not in Cloudflare and not managed by external-dns -
+# k8s/talos/infra/external-dns/values.yaml lists local.bigd.no under
+# excludeDomains so an internal hostname can never leak into the public zone.
+# Adding an app therefore means adding an alias below, not annotating a route.
+#
+# Scope is the 27 user-defined records only. The console's DNS Records view also
+# lists 14 entries under "View Default Policies", one per DHCP fixed-IP
+# reservation (nas, pbs, hyper1-3, home, hue-bridge-pro, adguard,
+# genesis-ctrl-01..03, genesis-worker-01..03). Those are generated from the
+# reservation, carry metadata.origin other than USER_DEFINED, and are absent
+# from both the static-dns and the dns/policies API. Declaring them here would
+# not import them - it would create a second, user-defined record shadowing each
+# one. Change those in the DHCP reservation instead.
+
+locals {
+  private_gateway = "traefik-gateway-private.${var.domain}"
+
+  # Cilium LB-IPAM VIPs announced on L2, not hosts. If a VIP is reassigned in
+  # k8s/talos/infra/cilium, this map has to follow.
+  vips = {
+    "traefik-gateway-public"  = "10.3.10.101"
+    "traefik-gateway-private" = "10.3.10.102"
+    "plex"                    = "10.3.10.103"
+  }
+
+  # Everything reached through the private Traefik gateway. One entry per
+  # HTTPRoute attached to gateway-private, so this list tracks the apps in
+  # k8s/talos/apps/ rather than any addressing decision.
+  aliases = [
+    "argocd",
+    "auth",
+    "bazarr",
+    "blog-stage",
+    "flaresolverr",
+    "grafana",
+    "ha",
+    "headroom",
+    "hubble",
+    "kargo",
+    "lazylibrarian",
+    "logeverylift",
+    "open-webui",
+    "portfolio-stage",
+    "prometheus",
+    "prowlarr",
+    "qbittorrent",
+    "radarr",
+    "reelsmith",
+    "sonarr",
+    "tautulli",
+    "traefik",
+    "verksted",
+    "workout",
+  ]
+}
+
+# ttl is left unset on purpose. The controller stores "Auto" as 0, which the
+# provider maps to a null TTL, so setting anything here would show as a change
+# against every existing record. site and enabled are Optional+Computed and
+# likewise settle on the controller's own values.
+resource "unifi_dns_record" "vip" {
+  for_each = local.vips
+
+  name        = "${each.key}.${var.domain}"
+  record_type = "A"
+  value       = each.value
+}
+
+resource "unifi_dns_record" "alias" {
+  for_each = toset(local.aliases)
+
+  name        = "${each.key}.${var.domain}"
+  record_type = "CNAME"
+  value       = local.private_gateway
+}

--- a/terraform/unifi/dns/terraform.tfvars.example
+++ b/terraform/unifi/dns/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Copy to terraform.tfvars and fill in. *.tfvars is gitignored.
+#
+# Create the key in the UniFi console at /network/default/integrations (left nav:
+# Integrations) via "Create New API Key". It is shown once.
+unifi_api_key = ""

--- a/terraform/unifi/dns/variables.tf
+++ b/terraform/unifi/dns/variables.tf
@@ -1,0 +1,17 @@
+variable "unifi_api_key" {
+  description = "UniFi Network API key, created in the console at /network/default/integrations. Ignores username/password when set, and does not work with 2FA-protected accounts because it bypasses them entirely."
+  type        = string
+  sensitive   = true
+}
+
+variable "unifi_api_url" {
+  description = "Base URL of the UniFi console. No /api path - the SDK discovers it."
+  type        = string
+  default     = "https://10.3.10.1"
+}
+
+variable "domain" {
+  description = "Internal split-horizon domain these records live in. external-dns is barred from it by excludeDomains in k8s/talos/infra/external-dns/values.yaml."
+  type        = string
+  default     = "local.bigd.no"
+}

--- a/terraform/unifi/dns/version.tf
+++ b/terraform/unifi/dns/version.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    unifi = {
+      source  = "ubiquiti-community/unifi"
+      version = "~> 0.55"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "rg-tfstate-homelab"
+    storage_account_name = "sttfstatemvnhomelab"
+    container_name       = "tfstate"
+    key                  = "unifi/dns.tfstate"
+  }
+}


### PR DESCRIPTION
## Why

The internal split-horizon zone `local.bigd.no` was hand-maintained by clicking
around the UniFi console. It is the last DNS zone in the homelab with no
configuration behind it, and there was no record of what any entry was for.

Terraform can safely own it. external-dns is barred from the zone by
`excludeDomains: [local.bigd.no]` in `k8s/talos/infra/external-dns/values.yaml`,
so nothing else writes these records and there is no controller to fight with.

## What

Adds `terraform/unifi/dns`, following the layout of the existing
`terraform/cloudflare/*` configs: azurerm backend, API key in a gitignored
tfvars, a `terraform.tfvars.example`, and a README.

Provider is `ubiquiti-community/unifi` v0.55, authenticated with a Network API
key from `/network/default/integrations`.

Scope is the 27 user-defined records:

- 3 A records for the Cilium LB-IPAM VIPs (public and private Traefik gateways, Plex)
- 24 CNAMEs aimed at `traefik-gateway-private.local.bigd.no`

The console shows 41 records because "View Default Policies (14)" is on. Those
14 are generated from DHCP fixed-IP reservations (`nas`, `pbs`, `hyper1-3`,
`home`, `hue-bridge-pro`, `adguard`, the six `genesis-*` nodes) and are absent
from both the legacy `static-dns` API and the newer `dns/policies` API.
Declaring them here would not adopt them, it would create a second user-defined
record shadowing each generated one. They stay in the DHCP reservation.

`ttl`, `site` and `enabled` are deliberately unset. The console stores "Auto" as
0 and the provider maps 0 to a null TTL, so setting any of them would show as a
change against every existing record.

## Verification

The records already existed, so this was applied as an import via a one-shot
`imports.tf`, since removed.

- `terraform fmt -check` and `terraform validate` pass
- `terraform plan` before apply: `27 to import, 0 to add, 0 to change, 0 to destroy`
- `terraform apply`: `27 imported, 0 added, 0 changed, 0 destroyed`
- Records re-fetched from the controller after the apply and diffed against a
  pull taken beforehand: identical across ids, names, types, values, ttl and
  enabled. Nothing that resolves was touched.
- `terraform plan` after apply: `No changes. Your infrastructure matches the configuration.`

## Notes

`local.aliases` is hand-maintained and mirrors the HTTPRoutes on
`gateway-private`. Nothing reconciles the two, so adding an app means adding a
line. Removing a line now deletes the live record.

Two pre-existing gaps found while cross-checking, both left as they were:
`cleanuparr`, `huntarr`, `readarr` and `tdarr` have HTTPRoutes but no DNS
record, and `lazylibrarian` and `workout` have records with no matching
hostname in the repo.

The provider only speaks the undocumented `v2/api/site/<site>/static-dns`
endpoint. Network 10.1 added an official `dns/policies` API, confirmed present
on this firmware and returning the same 27 records, but no Terraform provider
implements it yet. The `filipowm/unifi` fork uses the same v2 route, so
switching provider is not the fix if Ubiquiti drops it.
