### PR TITLE
Add a material layer to the palette and mute the brand green

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -106,17 +106,23 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Decide whether the stack gets its own block on `/`. If yes, build it from the same `public/icons/*.svg` and delete nothing. If no, delete those nineteen files (they are recoverable from git) and the hero loses no signal it still had.
 - **Where:** `portfolio/public/icons/*.svg`, `portfolio/src/components/sections/Hero.tsx`, deleted `portfolio/src/components/InlineGlobeDecor.ts`.
 
-### The hero is warm and the rest of the site is not
-- **What:** The hero renders a wooden room under a warm key light, while `tokens.css` stays hue-locked to 130 with a near-black ground, exactly as the `/brand` spec says. The seam is visible where the hero fades into the page: the room's table edge is brown and the section below it is green-black.
-- **Why deferred:** Warming the ground is a brand-spec change, not a hero change, and it would ripple into `/brand`, the print ramp and every solved contrast ratio on that page. The current fade covers the seam well enough that it is not a defect.
-- **Unblock:** Decide whether the ground follows the hero. If it does, re-solve the neutral ramp around a warm hue and update `content/brand.ts` and the `/brand` page with the new measured ratios. If it does not, leave it and treat the hero as the site's one photographic surface.
-- **Where:** `portfolio/src/styles/tokens.css`, `portfolio/src/content/brand.ts`, `portfolio/src/components/InlineGlobe.tsx`.
+### Warn and copper are the same hex
+- **What:** `--warn` and `--copper` are both `#c09955` in `tokens.css`, so a `Callout` with `tone="warn"` ("Watch") and any copper mark carry the same colour, separated only by their label. Now that copper is documented as the ink end of the wood/brass/copper material ramp, the overlap is spelled out in two places rather than hidden, but it is not fixed.
+- **Why deferred:** Moving warning off hue 38 does not actually separate them. At equal luminance a hue rotation is invisible to a colour-blind reader — measured, warn at hue 46 against copper is 1.00:1. A real fix means moving warning to a different lightness, which changes how every warning state reads and is a spec decision rather than a code change.
+- **Unblock:** Decide whether warning keeps amber. If it does, solve it at a distinctly different luminance from copper (roughly 4.5:1 or 9.5:1 rather than copper's 7.03:1) and re-check it against `--danger` `#d18e83`, which is also warm. If it does not, warning moves hue entirely and the material ramp keeps `#c09955` to itself.
+- **Where:** `portfolio/src/styles/tokens.css`, `portfolio/src/content/brand.ts` (the `warning` entry in `semantic`), `portfolio/src/components/primitives/Callout.tsx`.
 
-### Palette sweep: components still holding colour literals
-- **What:** After the dark ramp was locked to the `/brand` spec (2026-08-23), a few surfaces still paint from literals instead of tokens. `CommandPalette.tsx` uses `text-emerald-400`, `text-cyan-400`, `text-blue-400`, `text-rose-400/80` and `caret-emerald-400` (lines ~285-378), and roughly 120 `white/NN` and `black/NN` alpha utilities live across `components/fun/*`, `app/fun/FunRoomClient.tsx`, `components/work/ArchitectureDrawer.tsx`. Mapping them onto `--accent`, `--info`, `--danger` and an `rgba(var(--fg-rgb), …)` needs a new `--fg-rgb` token alongside the existing `--accent-rgb`.
-- **Why deferred:** The token layer was the blocker and is now correct; the sweep is mechanical but touches the fun room, which is hand-tuned 3D scenery where a blanket find-and-replace would flatten deliberate choices. Scene colours (wood, paper, screen glow) may legitimately stay literal.
-- **Unblock:** Decide which fun-room literals are UI chrome (must tokenise) versus illustration (may stay), add `--fg-rgb` to `tokens.css`, then convert file by file with a screenshot diff per surface.
-- **Where:** `portfolio/src/styles/tokens.css`, `portfolio/src/components/CommandPalette.tsx`, `portfolio/src/components/fun/`, `portfolio/src/components/work/ArchitectureDrawer.tsx`.
+### Data series 1 was left at the old saturation
+- **What:** The brand green moved from saturation 34 to 24 (2026-08-23). `dataSeries` series 1 is labelled "eucalyptus" and is meant to be the brand green, but it still ships `#4f9e6a` / `#2f7d4f` at the old saturation, so the chart green and the brand green no longer match.
+- **Why deferred:** The five categorical colours were validated for colour-vision deficiency as a set. Re-muting one of them without redoing that check would trade a visible mismatch for an invisible accessibility regression, which is the worse of the two.
+- **Unblock:** Re-run the CVD check across all five series with series 1 at `#5f9c68` / `#4a7952` (the held-luminance equivalents, already computed), and adjust whichever neighbours stop separating.
+- **Where:** `portfolio/src/content/brand.ts`.
+
+### Two material variants still have no callers
+- **What:** `Tag variant="warm"` and `Callout tone="result"` were repainted onto wood and brass, but nothing in the app renders either of them, so those two paths are unexercised. Every other consumer was converted in the full sweep (2026-08-23): `Button` secondary, `ServicesGrid`, the infrastructure packet dots, the command palette, the room HUD.
+- **Why deferred:** Inventing content to justify a variant is backwards. They are correct and waiting for a real use.
+- **Unblock:** First case study that needs a Result callout, or first tag that should read as material rather than brand. Check both against the ramp's two rules: brass takes `--fg` only, and `--fg-3` never sits on wood.
+- **Where:** `portfolio/src/components/primitives/{Tag,Callout}.tsx`.
 
 ### Captions on raised surfaces fall just under AA
 - **What:** `--fg-3` (`#708373`) is solved to 4.60:1 against the page ground `--bg` (`#0f1410`), but on `--surface` (`#191f1a`) it measures 4.14:1, under the 4.5:1 AA threshold for small text. Cards and panels use both.

--- a/portfolio/scripts/lib/templates.ts
+++ b/portfolio/scripts/lib/templates.ts
@@ -55,7 +55,7 @@ export function renderEntryPoint(variant: Variant, site: SiteForLatex): string {
 
 % Brand accent. The CV prints on white, so this is the light-ground value
 % from the palette (4.60:1 on paper), not the darker on-screen green.
-\\definecolor{eucalyptus}{HTML}{378144}
+\\definecolor{eucalyptus}{HTML}{4D7D54}
 \\colorlet{awesome}{eucalyptus}
 \\setbool{acvSectionColorHighlight}{true}
 \\renewcommand{\\acvHeaderSocialSep}{\\quad\\textbar\\quad}

--- a/portfolio/src/app/brand/brand.css
+++ b/portfolio/src/app/brand/brand.css
@@ -29,15 +29,19 @@
   --b-dline:    #2a382c;
   --b-dline-2:  #3e5542;
 
-  --b-brand:        #51a45e;
-  --b-brand-hover:  #65b372;
-  --b-brand-active: #478f53;
-  --b-brand-ink:    #378144;
-  --b-brand-solid:  #358142;
-  --b-subtle:       #ebf4ed;
-  --b-subtle-d:     #1e3322;
+  --b-brand:        #65a16e;
+  --b-brand-hover:  #7cae83;
+  --b-brand-active: #568d5e;
+  --b-brand-ink:    #4d7d54;
+  --b-brand-solid:  #4c7d54;
+  --b-subtle:       #ecf3ed;
+  --b-subtle-d:     #1f3322;
 
-  --b-success:  #51a45e;
+  --b-wood:     #4a3520;
+  --b-brass:    #7f5a2f;
+  --b-brass-hi: #8a6133;
+
+  --b-success:  #65a16e;
   --b-warning:  #c09955;
   --b-danger:   #d18e83;
   --b-info:     #5ca9c3;
@@ -67,11 +71,12 @@
 .bsys *::before,
 .bsys *::after { box-sizing: border-box; }
 
-/* The root layout wraps every route in the site header and footer, which are
-   still on the arctic-blue tokens and clash badly with a green spec sheet.
-   Suppressing them only when this page is mounted keeps the change contained
-   here rather than restructuring the app router for one unlisted route. The
-   command palette is deliberately left alone — it is still useful. */
+/* The root layout wraps every route in the site header and footer. This page
+   is a spec sheet with its own ramp and its own type, so the site chrome would
+   read as a second design on top of it. Suppressing them only when this page
+   is mounted keeps the change contained here rather than restructuring the app
+   router for one unlisted route. The command palette is deliberately left
+   alone — it is still useful. */
 body:has(.bsys) > header,
 body:has(.bsys) > footer { display: none; }
 body:has(.bsys) > main { flex: 1; }

--- a/portfolio/src/app/brand/page.tsx
+++ b/portfolio/src/app/brand/page.tsx
@@ -429,8 +429,8 @@ export default function BrandPage() {
           <div className="bsys__imggrid">
             <figure className="bsys__mock" style={{ background: imagery.grounds[0], margin: 0 }}>
               <svg viewBox="0 0 200 112" style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }} aria-hidden>
-                <circle cx="150" cy="34" r="26" fill="none" stroke="#51a45e" strokeWidth="2" />
-                <circle cx="150" cy="34" r="15" fill="none" stroke="#51a45e" strokeWidth="2" opacity="0.5" />
+                <circle cx="150" cy="34" r="26" fill="none" stroke="#65a16e" strokeWidth="2" />
+                <circle cx="150" cy="34" r="15" fill="none" stroke="#65a16e" strokeWidth="2" opacity="0.5" />
                 <path d="M14 90h70M14 80h44" stroke="#a1ada3" strokeWidth="2" opacity="0.6" />
               </svg>
               <figcaption>cover &middot; field ground, one accent</figcaption>
@@ -441,7 +441,7 @@ export default function BrandPage() {
                   [0, 1, 2, 3, 4, 5].map((c) => (
                     <rect
                       key={`${r}-${c}`} x={112 + c * 13} y={16 + r * 13} width="8" height="8"
-                      fill={r === 1 && c === 3 ? "#51a45e" : "#2a382c"}
+                      fill={r === 1 && c === 3 ? "#65a16e" : "#2a382c"}
                     />
                   )),
                 )}
@@ -450,7 +450,7 @@ export default function BrandPage() {
             </figure>
             <figure className="bsys__mock" style={{ background: imagery.grounds[2], margin: 0 }}>
               <svg viewBox="0 0 200 112" style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }} aria-hidden>
-                <path d="M100 22 148 50v34l-48 28-48-28V50z" fill="none" stroke="#51a45e" strokeWidth="2" />
+                <path d="M100 22 148 50v34l-48 28-48-28V50z" fill="none" stroke="#65a16e" strokeWidth="2" />
                 <path d="M100 22v34m0 0 48 28m-48-28-48 28" stroke="#a1ada3" strokeWidth="1.5" opacity="0.55" />
               </svg>
               <figcaption>diagram &middot; subtle ground, geometry</figcaption>

--- a/portfolio/src/app/globals.css
+++ b/portfolio/src/app/globals.css
@@ -10,10 +10,14 @@
   --color-fg: var(--fg);
   --color-fg-2: var(--fg-2);
   --color-fg-3: var(--fg-3);
+  --color-snow: rgb(var(--fg-rgb));
   --color-accent: var(--accent);
   --color-accent-2: var(--accent-2);
   --color-accent-3: var(--accent-3);
   --color-accent-ink: var(--accent-ink);
+  --color-wood: var(--wood);
+  --color-brass: var(--brass);
+  --color-brass-hi: var(--brass-hi);
   --color-copper: var(--copper);
   --color-warn: var(--warn);
   --color-interactive: var(--interactive);
@@ -398,9 +402,9 @@ body.fun-immersive > main {
     --fg: #1a201b;
     --fg-2: #415344;
     --fg-3: #5f7963;
-    --accent: #378144;
-    --accent-2: #40a551;
-    --accent-3: #3d954c;
+    --accent: #4d7d54;
+    --accent-2: #63a06c;
+    --accent-3: #599161;
     --accent-ink: #ffffff;
     --grain-opacity: 0;
     --grad-hero: none;

--- a/portfolio/src/app/infrastructure/page.tsx
+++ b/portfolio/src/app/infrastructure/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     "This site runs on a self-hosted Talos Kubernetes cluster, reconciled by ArgoCD. The request path, the deploy pipeline, and live cluster status.",
 };
 
-const dotTints = ["bg-accent", "bg-accent-3", "bg-accent-2", "bg-copper"];
+const dotTints = ["bg-accent", "bg-accent-3", "bg-accent-2", "bg-brass"];
 
 const statusJsonExample = `{
   "generatedAt": "2026-07-13T05:55:03Z",

--- a/portfolio/src/app/opengraph-image.tsx
+++ b/portfolio/src/app/opengraph-image.tsx
@@ -41,8 +41,8 @@ export default async function Image() {
               width: 12,
               height: 12,
               borderRadius: "50%",
-              background: "#51a45e",
-              boxShadow: "0 0 24px #51a45e",
+              background: "#65a16e",
+              boxShadow: "0 0 24px #65a16e",
             }}
           />
           available · oslo &amp; remote
@@ -65,7 +65,7 @@ export default async function Image() {
               style={{
                 marginLeft: 24,
                 background:
-                  "linear-gradient(110deg, #e9ebe9 30%, #61b86f 65%, #8ec798 95%)",
+                  "linear-gradient(110deg, #e9ebe9 30%, #81b288 65%, #9ec3a3 95%)",
                 backgroundClip: "text",
                 color: "transparent",
               }}
@@ -104,7 +104,7 @@ export default async function Image() {
               color: "#e9ebe9",
             }}
           >
-            <span style={{ color: "#51a45e" }}>●</span>
+            <span style={{ color: "#65a16e" }}>●</span>
             nordbye.it
           </div>
           <div style={{ color: "#708373" }}>

--- a/portfolio/src/components/CommandPalette.tsx
+++ b/portfolio/src/components/CommandPalette.tsx
@@ -230,7 +230,7 @@ export function CommandPalette({ work, services }: Props) {
           }}
         >
           <div
-            className="relative w-full max-w-3xl overflow-hidden rounded-xl border border-white/10 shadow-[0_40px_120px_-20px_rgba(0,0,0,0.8),0_0_0_1px_rgba(0,0,0,0.5)]"
+            className="relative w-full max-w-3xl overflow-hidden rounded-xl border border-snow/10 shadow-[0_40px_120px_-20px_rgba(0,0,0,0.8),0_0_0_1px_rgba(0,0,0,0.5)]"
             style={{
               background:
                 "linear-gradient(180deg, rgba(8,12,18,0.97) 0%, rgba(5,9,15,0.97) 100%)",
@@ -247,7 +247,7 @@ export function CommandPalette({ work, services }: Props) {
             />
 
             {/* Title bar — macOS-style traffic lights */}
-            <div className="relative flex items-center justify-between border-b border-white/10 bg-black/40 px-4 py-2.5">
+            <div className="relative flex items-center justify-between border-b border-snow/10 bg-black/40 px-4 py-2.5">
               <div className="flex items-center gap-2">
                 <button
                   type="button"
@@ -264,26 +264,26 @@ export function CommandPalette({ work, services }: Props) {
                   className="h-3 w-3 rounded-full bg-[#28c840] ring-1 ring-inset ring-black/20"
                 />
               </div>
-              <span className="font-mono text-[11px] text-white/50">
+              <span className="font-mono text-[11px] text-snow/50">
                 morten@talos-cp-01 — bash — 80×24
               </span>
               <button
                 type="button"
                 aria-label="Close"
                 onClick={close}
-                className="text-white/40 transition-colors hover:text-white"
+                className="text-snow/40 transition-colors hover:text-fg"
               >
                 <X size={14} />
               </button>
             </div>
 
             {/* Buffer (history + output) */}
-            <div className="max-h-64 overflow-y-auto bg-transparent px-5 pt-4 font-mono text-[13px] leading-relaxed text-white/80">
+            <div className="max-h-64 overflow-y-auto bg-transparent px-5 pt-4 font-mono text-[13px] leading-relaxed text-snow/80">
               {/* Welcome banner */}
-              <div className="text-white/40">
+              <div className="text-snow/40">
                 <div>
-                  <span className="text-emerald-400">●</span> connected to{" "}
-                  <span className="text-white/70">talos-cp-01.nordbye.local</span>
+                  <span className="text-accent">●</span> connected to{" "}
+                  <span className="text-snow/70">talos-cp-01.nordbye.local</span>
                 </div>
                 <div>
                   Last login: now on console — type{" "}
@@ -292,7 +292,7 @@ export function CommandPalette({ work, services }: Props) {
               </div>
 
               {output.length > 0 && (
-                <div className="mt-3 whitespace-pre text-white/75">
+                <div className="mt-3 whitespace-pre text-snow/75">
                   {output.map((line, i) => (
                     <div key={i}>{line}</div>
                   ))}
@@ -303,12 +303,12 @@ export function CommandPalette({ work, services }: Props) {
             {/* Prompt row */}
             <div className="relative flex items-center gap-2 px-5 py-3 font-mono text-[13px] leading-relaxed">
               <span className="select-none whitespace-nowrap">
-                <span className="text-emerald-400">morten</span>
-                <span className="text-white/40">@</span>
-                <span className="text-cyan-400">talos-cp-01</span>
-                <span className="text-white/40">:</span>
-                <span className="text-blue-400">{pathname}</span>
-                <span className="text-white/40">$</span>
+                <span className="text-accent">morten</span>
+                <span className="text-snow/40">@</span>
+                <span className="text-info">talos-cp-01</span>
+                <span className="text-snow/40">:</span>
+                <span className="text-copper">{pathname}</span>
+                <span className="text-snow/40">$</span>
               </span>
               <div className="relative flex-1">
                 <input
@@ -335,7 +335,7 @@ export function CommandPalette({ work, services }: Props) {
                     filtered[selected] ? `palette-opt-${filtered[selected].id}` : undefined
                   }
                   placeholder="try cd work, whoami, htop…"
-                  className="w-full caret-emerald-400 bg-transparent text-white placeholder:text-white/30 focus:outline-none"
+                  className="w-full caret-accent bg-transparent text-fg placeholder:text-fg-3 focus:outline-none"
                   autoComplete="off"
                   spellCheck={false}
                 />
@@ -346,10 +346,10 @@ export function CommandPalette({ work, services }: Props) {
             <ul
               id="palette-listbox"
               role="listbox"
-              className="max-h-72 overflow-y-auto border-t border-white/5 pb-2"
+              className="max-h-72 overflow-y-auto border-t border-snow/5 pb-2"
             >
               {filtered.length === 0 && (
-                <li className="px-5 py-3 font-mono text-[12px] text-rose-400/80">
+                <li className="px-5 py-3 font-mono text-[12px] text-danger">
                   zsh: command not found: {query}
                 </li>
               )}
@@ -366,8 +366,8 @@ export function CommandPalette({ work, services }: Props) {
                     className={cn(
                       "flex cursor-pointer items-center justify-between gap-4 px-5 py-1.5 font-mono text-[13px] transition-colors",
                       active
-                        ? "bg-white/[0.06] text-white"
-                        : "text-white/55 hover:text-white/80",
+                        ? "bg-snow/[0.06] text-fg"
+                        : "text-snow/55 hover:text-snow/80",
                     )}
                   >
                     <span className="flex items-center gap-2">
@@ -375,7 +375,7 @@ export function CommandPalette({ work, services }: Props) {
                         aria-hidden
                         className={cn(
                           "w-2 select-none",
-                          active ? "text-emerald-400" : "text-transparent",
+                          active ? "text-accent" : "text-transparent",
                         )}
                       >
                         ›
@@ -383,7 +383,7 @@ export function CommandPalette({ work, services }: Props) {
                       {cmd.label}
                     </span>
                     {cmd.hint && (
-                      <span className="truncate text-[11px] text-white/35">
+                      <span className="truncate text-[11px] text-snow/35">
                         {cmd.hint}
                       </span>
                     )}
@@ -393,11 +393,11 @@ export function CommandPalette({ work, services }: Props) {
             </ul>
 
             {/* Status bar */}
-            <div className="flex items-center justify-between border-t border-white/10 bg-black/30 px-5 py-2 font-mono text-[10px] uppercase tracking-[0.18em] text-white/40">
+            <div className="flex items-center justify-between border-t border-snow/10 bg-black/30 px-5 py-2 font-mono text-[10px] uppercase tracking-[0.18em] text-snow/40">
               <span>
-                <span className="text-white/70">↑↓</span> navigate ·{" "}
-                <span className="text-white/70">↵</span> run ·{" "}
-                <span className="text-white/70">esc</span> close
+                <span className="text-snow/70">↑↓</span> navigate ·{" "}
+                <span className="text-snow/70">↵</span> run ·{" "}
+                <span className="text-snow/70">esc</span> close
               </span>
               <span>
                 {filtered.length} / {commands.length}

--- a/portfolio/src/components/InlineGlobe.tsx
+++ b/portfolio/src/components/InlineGlobe.tsx
@@ -202,7 +202,7 @@ function StaticGlobe() {
         />
         <path d="M191 356h18v58h-18z" fill="url(#globe-brass)" />
         <ellipse cx="200" cy="420" rx="62" ry="13" fill="url(#globe-brass)" />
-        <circle cx="252" cy="72" r="7" fill="#8ec798" />
+        <circle cx="252" cy="72" r="7" fill="#9ec3a3" />
       </svg>
     </div>
   );

--- a/portfolio/src/components/InlineGlobeScene.tsx
+++ b/portfolio/src/components/InlineGlobeScene.tsx
@@ -206,8 +206,8 @@ function Globe({
   const pinHead = useMemo(
     () =>
       new THREE.MeshStandardMaterial({
-        color: "#8ec798",
-        emissive: new THREE.Color("#51a45e"),
+        color: "#9ec3a3",
+        emissive: new THREE.Color("#65a16e"),
         emissiveIntensity: 1.5,
         roughness: 0.35,
         metalness: 0,

--- a/portfolio/src/components/fun/BlogBoard.tsx
+++ b/portfolio/src/components/fun/BlogBoard.tsx
@@ -49,7 +49,7 @@ const cellPx = (i: number) => ({
  * mechanism: the tilt belongs to the slot, not the post.
  */
 const TILT = [-0.9, 0.7, -0.4, 0.8, -0.6, 0.5];
-const MAGNET = ["#51a45e", "#c09955", "#8ec798", "#478f53", "#a1ada3", "#61b86f"];
+const MAGNET = ["#65a16e", "#c09955", "#9ec3a3", "#568d5e", "#a1ada3", "#81b288"];
 
 const MONTHS = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",

--- a/portfolio/src/components/fun/CodeScreen.tsx
+++ b/portfolio/src/components/fun/CodeScreen.tsx
@@ -107,7 +107,7 @@ function ArgoView({ data }: { data: PanelProps }) {
         style={{
           background: "#202e23",
           padding: "6px 10px",
-          borderBottom: `1px solid ${ACCENT.blue}33`,
+          borderBottom: `1px solid ${ACCENT.brand}33`,
         }}
       >
         <span style={{ color: "#eaf3eb", letterSpacing: "0.1em" }}>
@@ -225,7 +225,7 @@ export function CodeScreen({
           style={{
             background:
               "linear-gradient(160deg, #0e160f 0%, #0b110c 55%, #080e09 100%)",
-            border: "1px solid #51a45e3d",
+            border: "1px solid #65a16e3d",
             color: COLOUR.plain,
             fontSize: "10px",
             lineHeight: "11.6px",
@@ -250,7 +250,7 @@ export function CodeScreen({
                   color: tab === id ? "#8fb6d8" : "#516154",
                   background: tab === id ? "#121b13" : "transparent",
                   borderRight: "1px solid #1b261d",
-                  borderTop: `2px solid ${tab === id ? "#51a45e" : "transparent"}`,
+                  borderTop: `2px solid ${tab === id ? "#65a16e" : "transparent"}`,
                 }}
               >
                 {label}

--- a/portfolio/src/components/fun/Devices.tsx
+++ b/portfolio/src/components/fun/Devices.tsx
@@ -30,7 +30,7 @@ const CHASSIS_GREY = { color: "#232629", roughness: 0.52, metalness: 0.42 };
 function Led({
   position,
   rotation = [0, 0, 0],
-  color = "#57d98b",
+  color = "#5ec96e",
   seed = 1,
   size = 0.005,
   steady = false,
@@ -88,9 +88,9 @@ export function ThinkCentre({
       </mesh>
       <mesh position={[0, 0.052, D / 2 + 0.003]}>
         <ringGeometry args={[0.0035, 0.0055, 20]} />
-        <meshBasicMaterial color="#8fd4ff" transparent opacity={0.85} />
+        <meshBasicMaterial color="#81bccf" transparent opacity={0.85} />
       </mesh>
-      <Led position={[0, 0.03, D / 2 + 0.003]} color="#57d98b" seed={2.1} size={0.0035} />
+      <Led position={[0, 0.03, D / 2 + 0.003]} color="#5ec96e" seed={2.1} size={0.0035} />
     </group>
   );
 }
@@ -126,7 +126,7 @@ export function SynologyNas({
         <Led
           key={y}
           position={[W / 2 - 0.016, y, D / 2 + 0.003]}
-          color={i === 0 ? "#8fd4ff" : "#57d98b"}
+          color={i === 0 ? "#81bccf" : "#5ec96e"}
           seed={0.9 + i * 0.8}
           size={0.0045}
         />
@@ -152,7 +152,7 @@ export function CloudGateway({
         <ringGeometry args={[0.008, 0.011, 24]} />
         <meshBasicMaterial color="#9aa3ad" transparent opacity={0.75} />
       </mesh>
-      <Led position={[0, -0.004, 0.0556]} color="#61b86f" seed={1.1} size={0.004} />
+      <Led position={[0, -0.004, 0.0556]} color="#81b288" seed={1.1} size={0.004} />
     </group>
   );
 }
@@ -178,7 +178,7 @@ export function UnifiFlexMini({
         <Led
           key={i}
           position={[-0.031 + i * 0.0155, 0.008, 0.0356]}
-          color="#61b86f"
+          color="#81b288"
           seed={1.2 + i * 0.7}
           size={0.003}
         />
@@ -208,7 +208,7 @@ export function UnifiSwitch8({
         <Led
           key={i}
           position={[-0.075 + i * 0.0215, 0.0095, 0.0526]}
-          color={i % 3 === 0 ? "#57d98b" : "#61b86f"}
+          color={i % 3 === 0 ? "#5ec96e" : "#81b288"}
           seed={0.8 + i * 0.55}
           size={0.003}
         />
@@ -239,7 +239,7 @@ export function IspRouter({
           key={y}
           position={[0.0272, y, 0.055]}
           rotation={[0, Math.PI / 2, 0]}
-          color={i === 0 ? "#57d98b" : "#9aa3ad"}
+          color={i === 0 ? "#5ec96e" : "#9aa3ad"}
           seed={0.7 + i * 0.9}
           size={0.0035}
         />
@@ -288,7 +288,7 @@ export function HubPuck({ position }: { position: [number, number, number] }) {
       <Led
         position={[0, 0.0125, 0]}
         rotation={[-Math.PI / 2, 0, 0]}
-        color="#61b86f"
+        color="#81b288"
         seed={1.5}
         size={0.006}
       />
@@ -310,7 +310,7 @@ export function UnifiAccessPoint({ position }: { position: [number, number, numb
       </mesh>
       <mesh position={[0, 0.0108, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <ringGeometry args={[0.0335, 0.0365, 32]} />
-        <meshBasicMaterial color="#61b86f" transparent opacity={0.35} side={THREE.DoubleSide} />
+        <meshBasicMaterial color="#81b288" transparent opacity={0.35} side={THREE.DoubleSide} />
       </mesh>
     </group>
   );

--- a/portfolio/src/components/fun/FunRoom.tsx
+++ b/portfolio/src/components/fun/FunRoom.tsx
@@ -216,11 +216,11 @@ function Notice({
 }) {
   return (
     <div className="fixed inset-0 z-[210] grid place-content-center bg-[#04070a] px-8">
-      <p className="eyebrow mb-5 text-[0.65rem] text-white/35">
+      <p className="eyebrow mb-5 text-[0.65rem] text-snow/35">
         nordbye.it · the room
       </p>
-      <h1 className="font-mono text-xl leading-snug text-white">{title}</h1>
-      <p className="mt-4 max-w-[42ch] text-[13px] leading-relaxed text-white/60">
+      <h1 className="font-mono text-xl leading-snug text-fg">{title}</h1>
+      <p className="mt-4 max-w-[42ch] text-[13px] leading-relaxed text-snow/60">
         {body}
       </p>
       <div className="mt-8 flex flex-wrap items-center gap-3">{children}</div>
@@ -229,7 +229,7 @@ function Notice({
 }
 
 const NOTICE_BUTTON =
-  "focus-ring border border-white/25 px-4 py-2.5 font-mono text-xs text-white transition-colors hover:border-white/60 hover:bg-white/5";
+  "focus-ring border border-snow/25 px-4 py-2.5 font-mono text-xs text-fg transition-colors hover:border-snow/60 hover:bg-snow/5";
 const NOTICE_LINK =
   "focus-ring font-mono text-xs text-accent underline-offset-4 hover:underline";
 
@@ -1218,27 +1218,27 @@ export default function FunRoom({
 
       {/* persistent status line */}
       <div className="pointer-events-none absolute left-6 top-6 z-20 font-mono text-xs">
-        <div className="flex items-center gap-2.5 border border-white/10 bg-black/45 px-3.5 py-2 backdrop-blur">
+        <div className="flex items-center gap-2.5 border border-snow/10 bg-black/45 px-3.5 py-2 backdrop-blur">
           <span
             className="h-2 w-2 rounded-full"
             style={{ background: feedTone, boxShadow: `0 0 10px ${feedTone}` }}
           />
           <span style={{ color: feedTone }}>{feedLabel}</span>
-          <span className="text-white/35">· genesis · oslo</span>
+          <span className="text-snow/35">· genesis · oslo</span>
         </div>
       </div>
 
       {/* CC0 asset attribution. Poly Haven does not require it, but shipping
           other people's work with no credit is not something to be casual
           about. */}
-      <p className="pointer-events-none absolute bottom-6 right-6 z-20 font-mono text-[10px] text-white/25">
+      <p className="pointer-events-none absolute bottom-6 right-6 z-20 font-mono text-[10px] text-snow/25">
         surfaces &amp; environment: Poly Haven (CC0)
       </p>
 
       {/* exit */}
       <Link
         href="/"
-        className="focus-ring absolute right-6 top-6 z-20 border border-white/10 bg-black/45 px-3.5 py-2 font-mono text-xs text-white/60 backdrop-blur transition-colors hover:text-white"
+        className="focus-ring absolute right-6 top-6 z-20 border border-snow/10 bg-black/45 px-3.5 py-2 font-mono text-xs text-snow/60 backdrop-blur transition-colors hover:text-fg"
       >
         exit
       </Link>
@@ -1283,7 +1283,7 @@ export default function FunRoom({
           purpose. */}
       {phase === "exploring" && !locked && !coarse && !paused && (
         <div className="pointer-events-none absolute bottom-6 left-1/2 z-30 -translate-x-1/2">
-          <p className="border border-white/10 bg-black/45 px-3.5 py-2 font-mono text-[11px] text-white/45 backdrop-blur">
+          <p className="border border-snow/10 bg-black/45 px-3.5 py-2 font-mono text-[11px] text-snow/45 backdrop-blur">
             click to look around · WASD to move
           </p>
         </div>
@@ -1300,7 +1300,7 @@ export default function FunRoom({
         <>
           <TouchStick move={touchMove} />
           <div className="pointer-events-none absolute bottom-8 right-8 z-30 max-w-[46vw]">
-            <p className="border border-white/10 bg-black/45 px-3 py-2 text-right font-mono text-[10px] leading-relaxed text-white/45 backdrop-blur">
+            <p className="border border-snow/10 bg-black/45 px-3 py-2 text-right font-mono text-[10px] leading-relaxed text-snow/45 backdrop-blur">
               drag to look
               <br />
               tap an object to open it

--- a/portfolio/src/components/fun/Hud.tsx
+++ b/portfolio/src/components/fun/Hud.tsx
@@ -20,7 +20,7 @@ export function Key({
 }) {
   return (
     <kbd
-      className={`inline-flex items-center justify-center rounded-[4px] border border-white/25 border-b-white/10 bg-white/[0.12] font-mono text-[10px] font-medium leading-none text-white shadow-[inset_0_-2px_0_rgba(0,0,0,0.35)] ${
+      className={`inline-flex items-center justify-center rounded-[4px] border border-snow/25 border-b-snow/10 bg-snow/[0.12] font-mono text-[10px] font-medium leading-none text-fg shadow-[inset_0_-2px_0_rgba(0,0,0,0.35)] ${
         wide ? "h-[20px] min-w-[34px] px-1.5" : "h-[20px] w-[20px]"
       }`}
     >
@@ -43,7 +43,7 @@ export function Crosshair({ active }: { active: boolean }) {
         {/* centre dot */}
         <span
           className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-all duration-150 ${
-            active ? "h-[5px] w-[5px] bg-accent" : "h-[3px] w-[3px] bg-white/50"
+            active ? "h-[5px] w-[5px] bg-accent" : "h-[3px] w-[3px] bg-snow/50"
           }`}
         />
         {/* ring */}
@@ -51,7 +51,7 @@ export function Crosshair({ active }: { active: boolean }) {
           className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border transition-all duration-200 ${
             active
               ? "h-[26px] w-[26px] border-accent/70 opacity-100"
-              : "h-[12px] w-[12px] border-white/0 opacity-0"
+              : "h-[12px] w-[12px] border-snow/0 opacity-0"
           }`}
         />
         {/* corner ticks, only when something is targetable */}
@@ -93,16 +93,16 @@ export function InteractPrompt({
   if (!prompt) return null;
   return (
     <div className="pointer-events-none absolute left-1/2 top-[calc(50%+30px)] -translate-x-1/2">
-      <div className="max-w-[22rem] rounded-[5px] border border-white/15 bg-black/70 px-3.5 py-2.5 text-center shadow-lg">
+      <div className="max-w-[22rem] rounded-[5px] border border-snow/15 bg-black/70 px-3.5 py-2.5 text-center shadow-lg">
         <p className="font-mono text-[13px] leading-tight text-accent">
           {prompt.label}
         </p>
         {prompt.detail && (
-          <p className="mt-1 font-mono text-[11px] leading-tight text-white/55">
+          <p className="mt-1 font-mono text-[11px] leading-tight text-snow/55">
             {prompt.detail}
           </p>
         )}
-        <p className="mt-2 flex items-center justify-center gap-2 font-mono text-[11px] text-white/70">
+        <p className="mt-2 flex items-center justify-center gap-2 font-mono text-[11px] text-snow/70">
           {touch ? "tap to" : <Key>E</Key>}
           {prompt.verb}
         </p>
@@ -142,32 +142,32 @@ export function InfoPanel({
   if (!card) return null;
   return (
     <div className="absolute inset-0 z-30 grid place-content-center bg-black/55 px-6">
-      <div className="max-h-[80vh] w-[min(34rem,90vw)] overflow-y-auto rounded-[6px] border border-white/15 bg-[#12100d]/95 p-6 shadow-2xl">
-        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/35">
+      <div className="max-h-[80vh] w-[min(34rem,90vw)] overflow-y-auto rounded-[6px] border border-snow/15 bg-[#12100d]/95 p-6 shadow-2xl">
+        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-snow/35">
           {card.kicker}
         </p>
-        <h2 className="mt-2 font-mono text-lg leading-tight text-white">
+        <h2 className="mt-2 font-mono text-lg leading-tight text-fg">
           {card.title}
         </h2>
         {card.subtitle && (
-          <p className="mt-1 font-mono text-xs text-white/50">{card.subtitle}</p>
+          <p className="mt-1 font-mono text-xs text-snow/50">{card.subtitle}</p>
         )}
 
         {card.rows.length > 0 && (
           <dl className="mt-5 space-y-2">
             {card.rows.map((r) => (
               <div key={r.k} className="flex gap-3">
-                <dt className="w-24 shrink-0 font-mono text-[11px] uppercase tracking-wider text-white/35">
+                <dt className="w-24 shrink-0 font-mono text-[11px] uppercase tracking-wider text-snow/35">
                   {r.k}
                 </dt>
-                <dd className="font-mono text-[12px] text-white/80">{r.v}</dd>
+                <dd className="font-mono text-[12px] text-snow/80">{r.v}</dd>
               </div>
             ))}
           </dl>
         )}
 
         {card.body && (
-          <p className="mt-5 text-[13px] leading-relaxed text-white/70">
+          <p className="mt-5 text-[13px] leading-relaxed text-snow/70">
             {card.body}
           </p>
         )}
@@ -177,7 +177,7 @@ export function InfoPanel({
             {card.tags.map((t) => (
               <li
                 key={t}
-                className="rounded-[3px] border border-white/12 px-2 py-1 font-mono text-[10px] text-white/55"
+                className="rounded-[3px] border border-snow/12 px-2 py-1 font-mono text-[10px] text-snow/55"
               >
                 {t}
               </li>
@@ -186,7 +186,7 @@ export function InfoPanel({
         )}
 
         {card.note && (
-          <p className="mt-5 border-t border-white/10 pt-4 font-mono text-[11px] leading-relaxed text-white/40">
+          <p className="mt-5 border-t border-snow/10 pt-4 font-mono text-[11px] leading-relaxed text-snow/40">
             {card.note}
           </p>
         )}
@@ -195,7 +195,7 @@ export function InfoPanel({
           <button
             type="button"
             onClick={onClose}
-            className="focus-ring border border-white/25 px-4 py-2 font-mono text-xs text-white transition-colors hover:border-white/60 hover:bg-white/5"
+            className="focus-ring border border-snow/25 px-4 py-2 font-mono text-xs text-fg transition-colors hover:border-snow/60 hover:bg-snow/5"
           >
             close
           </button>
@@ -224,8 +224,8 @@ export function InfoPanel({
 export function SeatedHint({ touch = false }: { touch?: boolean }) {
   return (
     <div className="pointer-events-none absolute left-1/2 top-[calc(50%+30px)] -translate-x-1/2">
-      <div className="rounded-[5px] border border-white/15 bg-black/70 px-3.5 py-2.5 text-center shadow-lg">
-        <p className="flex items-center justify-center gap-2 font-mono text-[11px] text-white/70">
+      <div className="rounded-[5px] border border-snow/15 bg-black/70 px-3.5 py-2.5 text-center shadow-lg">
+        <p className="flex items-center justify-center gap-2 font-mono text-[11px] text-snow/70">
           {touch ? "tap to" : <Key>E</Key>}
           stand up
         </p>
@@ -261,15 +261,15 @@ export function Keybinds({ visible }: { visible: boolean }) {
         visible ? "opacity-100" : "opacity-0"
       }`}
     >
-      <div className="rounded-[5px] border border-white/12 bg-black/55 px-3.5 py-3">
-        <p className="mb-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/35">
+      <div className="rounded-[5px] border border-snow/12 bg-black/55 px-3.5 py-3">
+        <p className="mb-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-snow/35">
           controls
         </p>
         <ul className="space-y-2">
           {BINDS.map((b) => (
             <li key={b.action} className="flex items-center gap-3">
               {b.keys}
-              <span className="font-mono text-[11px] text-white/60">{b.action}</span>
+              <span className="font-mono text-[11px] text-snow/60">{b.action}</span>
             </li>
           ))}
         </ul>

--- a/portfolio/src/components/fun/Objects.tsx
+++ b/portfolio/src/components/fun/Objects.tsx
@@ -461,7 +461,7 @@ export function SkillPlate({
               <div
                 style={{
                   height: "1px",
-                  background: `${ACCENT.blue}3d`,
+                  background: `${ACCENT.brand}3d`,
                   margin: "12px 0 14px",
                 }}
               />
@@ -516,8 +516,8 @@ export function SkillPlate({
                               position: "absolute",
                               inset: "0 auto 0 0",
                               width: `${s.level}%`,
-                              background: ACCENT.blue,
-                              boxShadow: `0 0 9px ${ACCENT.blue}b3`,
+                              background: ACCENT.brand,
+                              boxShadow: `0 0 9px ${ACCENT.brand}b3`,
                             }}
                           />
                         </span>
@@ -546,9 +546,9 @@ export function SkillPlate({
  * mistake the door and sideboard already taught: it reads as a flat board.
  */
 const SERVICE_TONE: Record<string, string> = {
-  arctic: ACCENT.blue,
-  copper: ACCENT.copper,
-  teal: ACCENT.teal,
+  brand: ACCENT.brand,
+  material: ACCENT.copper,
+  brand2: ACCENT.info,
 };
 
 export function ServiceRack({
@@ -687,7 +687,7 @@ export function ServiceRack({
       >
         <div className="flex h-full w-full" style={{ gap: `${gapPx}px` }}>
           {services.map((svc) => {
-            const tone = SERVICE_TONE[svc.accent] ?? ACCENT.blue;
+            const tone = SERVICE_TONE[svc.accent] ?? ACCENT.brand;
             return (
               <div
                 key={svc.slug}

--- a/portfolio/src/components/fun/Panels.tsx
+++ b/portfolio/src/components/fun/Panels.tsx
@@ -10,11 +10,11 @@ import {
 
 // Accents come from the site tokens so the room reads as the same product.
 export const ACCENT = {
-  blue: "#51a45e",
+  brand: "#65a16e",
+  green: "#65a16e",
   violet: "#9077d4",
-  teal: "#5ca9c3",
+  info: "#5ca9c3",
   copper: "#c9713f",
-  green: "#51a45e",
   amber: "#c09955",
   red: "#d18e83",
 } as const;
@@ -136,7 +136,7 @@ export const PANELS: PanelDef[] = [
   {
     id: "cluster",
     title: "CLUSTER",
-    accent: ACCENT.blue,
+    accent: ACCENT.brand,
     body: ({ status, nodes }) => {
       const allReady = nodes.ready === nodes.total;
       return (
@@ -220,7 +220,7 @@ export const PANELS: PanelDef[] = [
   {
     id: "apps",
     title: "APPLICATIONS",
-    accent: ACCENT.teal,
+    accent: ACCENT.info,
     body: ({ status }) => {
       const apps = status?.apps;
       if (!apps?.length) return <Empty what="No per-application data." />;
@@ -230,7 +230,7 @@ export const PANELS: PanelDef[] = [
       return (
         <>
           <div className="flex items-baseline justify-between">
-            <Big value={apps.length} unit="apps" tone={ACCENT.teal} />
+            <Big value={apps.length} unit="apps" tone={ACCENT.info} />
             {degraded > 0 && (
               <span className="text-[13px]" style={{ color: ACCENT.amber }}>
                 {degraded} need attention
@@ -394,7 +394,7 @@ export const PANELS: PanelDef[] = [
   {
     id: "feed",
     title: "FEED STATUS",
-    accent: ACCENT.blue,
+    accent: ACCENT.brand,
     body: ({ status, feed, stale }) => {
       const tone =
         feed === "snapshot" ? ACCENT.amber : stale ? ACCENT.amber : ACCENT.green;

--- a/portfolio/src/components/fun/Printer.tsx
+++ b/portfolio/src/components/fun/Printer.tsx
@@ -107,7 +107,7 @@ function Switch({
           {/* state lamp beside the switch */}
           <mesh position={[0, 0.002, 0.032]}>
             <planeGeometry args={[0.006, 0.006]} />
-            <meshBasicMaterial color={on ? "#57d98b" : "#3a3f45"} />
+            <meshBasicMaterial color={on ? "#5ec96e" : "#3a3f45"} />
           </mesh>
         </group>
       )}
@@ -331,7 +331,7 @@ export function Printer({
                     padding: "2px 9px",
                     borderRadius: "9px",
                     color: flags[s.key] ? "#07331f" : "#4a5058",
-                    background: flags[s.key] ? "#3ddc97" : "#c3c7cc",
+                    background: flags[s.key] ? "#4dcb60" : "#c3c7cc",
                   }}
                 >
                   {flags[s.key] ? "ON" : "OFF"}
@@ -368,7 +368,7 @@ export function Printer({
             <mesh castShadow position={[0, printing ? -0.001 : 0.002, 0]}>
               <cylinderGeometry args={[0.015, 0.015, 0.008, 20]} />
               <meshStandardMaterial
-                color={printing ? "#2f7d52" : "#3ddc97"}
+                color={printing ? "#34793e" : "#4dcb60"}
                 roughness={0.35}
                 emissive={printing ? "#1d5e3c" : hovered ? "#2aa876" : "#155c3f"}
                 emissiveIntensity={hovered || printing ? 1.4 : 0.55}
@@ -381,7 +381,7 @@ export function Printer({
       {/* status lamp */}
       <mesh position={[-0.17, 0.124, 0.12]} rotation={[-Math.PI / 2, 0, 0]}>
         <planeGeometry args={[0.008, 0.008]} />
-        <meshBasicMaterial color={ready ? (printing ? "#f5b544" : "#57d98b") : "#8a3f3f"} />
+        <meshBasicMaterial color={ready ? (printing ? "#f5b544" : "#5ec96e") : "#8a3f3f"} />
       </mesh>
     </group>
   );

--- a/portfolio/src/components/fun/Room.tsx
+++ b/portfolio/src/components/fun/Room.tsx
@@ -655,7 +655,7 @@ export function Room({
                   className="flex h-full w-full items-center justify-center font-mono"
                   style={{
                     background: "#0b1a12",
-                    color: hovered ? "#7dffbe" : "#3ddc97",
+                    color: hovered ? "#95e4a1" : "#4dcb60",
                     fontSize: "52px",
                     letterSpacing: "0.3em",
                     textIndent: "0.3em",

--- a/portfolio/src/components/fun/Screen.tsx
+++ b/portfolio/src/components/fun/Screen.tsx
@@ -240,7 +240,7 @@ export function Dashboard({
             className="flex items-center justify-between border-b pb-4"
             style={{ borderColor: "#202e23", height: `${HEADER}px` }}
           >
-            <span className="text-[19px] tracking-[0.3em] text-[#51a45e]">
+            <span className="text-[19px] tracking-[0.3em] text-[#65a16e]">
               GENESIS · OBSERVABILITY
             </span>
             <span className="text-[15px] tracking-[0.18em] text-[#465548]">

--- a/portfolio/src/components/fun/Terminal.tsx
+++ b/portfolio/src/components/fun/Terminal.tsx
@@ -30,7 +30,7 @@ import type { ShelfData } from "./shelf";
  * fetch against the real endpoints, so the output is not a mock.
  */
 
-const ACCENT = "#61b86f";
+const ACCENT = "#81b288";
 
 type Line = { kind: "in" | "out" | "err" | "note"; text: string };
 

--- a/portfolio/src/components/fun/Touch.tsx
+++ b/portfolio/src/components/fun/Touch.tsx
@@ -218,12 +218,12 @@ export function TouchStick({ move }: { move: React.RefObject<MoveInput> }) {
       onTouchCancel={release}
     >
       <div
-        className="absolute inset-0 rounded-full border border-white/15 bg-black/30 backdrop-blur"
+        className="absolute inset-0 rounded-full border border-snow/15 bg-black/30 backdrop-blur"
         aria-hidden
       />
       <div
         aria-hidden
-        className="absolute rounded-full border border-white/25 bg-white/15"
+        className="absolute rounded-full border border-snow/25 bg-snow/15"
         style={{
           width: KNOB_R * 2,
           height: KNOB_R * 2,

--- a/portfolio/src/components/primitives/Button.tsx
+++ b/portfolio/src/components/primitives/Button.tsx
@@ -17,8 +17,11 @@ const sizes: Record<Size, string> = {
 const variants: Record<Variant, string> = {
   primary:
     "bg-accent text-accent-ink hover:bg-interactive-hover shadow-[0_0_0_1px_var(--accent)] hover:shadow-[0_0_24px_-6px_var(--accent)]",
-  secondary:
-    "border border-line-2 bg-surface/60 text-fg hover:border-accent/60 hover:text-accent",
+  // Solid brass rather than an outline: green is the primary and stays the
+  // only green control, so the second action needs its own material instead
+  // of a quieter version of the first. --fg, never --fg-2, which measures
+  // 2.65:1 on brass.
+  secondary: "bg-brass text-fg hover:bg-brass-hi",
   ghost: "text-fg-2 hover:text-fg hover:bg-surface/60",
   link: "text-accent hover:text-interactive-hover underline-offset-4 hover:underline px-0 py-0",
 };

--- a/portfolio/src/components/primitives/Callout.tsx
+++ b/portfolio/src/components/primitives/Callout.tsx
@@ -7,7 +7,9 @@ const tones: Record<Tone, { ring: string; ink: string; label: string }> = {
   info: { ring: "border-accent/40 bg-accent/[0.06]", ink: "text-accent", label: "Note" },
   success: { ring: "border-success/40 bg-success/[0.06]", ink: "text-success", label: "Outcome" },
   warn: { ring: "border-warn/40 bg-warn/[0.06]", ink: "text-warn", label: "Watch" },
-  result: { ring: "border-copper/40 bg-copper/[0.06]", ink: "text-copper", label: "Result" },
+  // A filled wood block rather than a tinted one, so Result reads as a
+  // different material from Watch rather than a different shade of it.
+  result: { ring: "border-brass bg-wood", ink: "text-fg", label: "Result" },
 };
 
 export function Callout({

--- a/portfolio/src/components/primitives/Tag.tsx
+++ b/portfolio/src/components/primitives/Tag.tsx
@@ -14,7 +14,7 @@ export function Tag({
       className={cn(
         "inline-flex items-center rounded-full border px-3 py-1 font-mono text-xs tracking-wide",
         variant === "accent" && "border-accent/40 bg-accent/10 text-accent",
-        variant === "warm" && "border-copper/40 bg-copper/10 text-copper",
+        variant === "warm" && "border-brass bg-wood text-fg",
         variant === "muted" && "border-line bg-bg-2/40 text-fg-3",
         variant === "default" && "border-line-2 bg-surface/40 text-fg-2",
         className,

--- a/portfolio/src/components/sections/Hero.tsx
+++ b/portfolio/src/components/sections/Hero.tsx
@@ -128,7 +128,7 @@ export function Hero() {
                 />
                 <span
                   aria-hidden
-                  className="room-feed__sweep pointer-events-none absolute inset-x-0 top-0 h-[38%] bg-gradient-to-b from-transparent via-white/[0.045] to-transparent"
+                  className="room-feed__sweep pointer-events-none absolute inset-x-0 top-0 h-[38%] bg-gradient-to-b from-transparent via-snow/[0.045] to-transparent"
                 />
                 <span
                   aria-hidden

--- a/portfolio/src/components/sections/ServicesGrid.tsx
+++ b/portfolio/src/components/sections/ServicesGrid.tsx
@@ -13,9 +13,9 @@ const iconBySlug: Record<string, React.ReactNode> = {
 };
 
 const accentClasses: Record<NonNullable<Service["accent"]>, { icon: string; ring: string; line: string }> = {
-  arctic: { icon: "text-accent", ring: "hover:border-accent/60", line: "bg-accent" },
-  copper: { icon: "text-copper", ring: "hover:border-copper/60", line: "bg-copper" },
-  teal: { icon: "text-accent-3", ring: "hover:border-accent-3/60", line: "bg-accent-3" },
+  brand: { icon: "text-accent", ring: "hover:border-accent/60", line: "bg-accent" },
+  material: { icon: "text-copper", ring: "hover:border-brass", line: "bg-brass" },
+  brand2: { icon: "text-accent-3", ring: "hover:border-accent-3/60", line: "bg-accent-3" },
 };
 
 export function ServicesGrid() {
@@ -28,7 +28,7 @@ export function ServicesGrid() {
     >
       <div className="grid gap-6 md:grid-cols-3">
         {services.map((s, i) => {
-          const accent = accentClasses[s.accent ?? "arctic"];
+          const accent = accentClasses[s.accent ?? "brand"];
           return (
             <Reveal key={s.slug} delay={i * 0.08}>
               <article

--- a/portfolio/src/content/brand.ts
+++ b/portfolio/src/content/brand.ts
@@ -1,10 +1,22 @@
 /**
  * Brand system tokens — "Eucalyptus Deepened".
  *
- * Hue is locked to 130. Every value was solved against its own ground for a
- * target WCAG ratio rather than picked by hand, so the contrast figures below
- * are measured, not aspirational. The categorical data colours were validated
- * for colour-vision deficiency separately.
+ * Two hues doing two jobs. 130 is the brand and it is ink: links, focus, live
+ * state, the one action that matters on a screen. 32 is the material and it is
+ * surface: buttons, chips, panels, edges. Nothing is ever both, which is what
+ * lets them share a page — solved against the same ground for the same target,
+ * a green and a copper land 1.01:1 apart and read as one colour to anyone with
+ * a colour-vision deficiency. Separating them by layer avoids that entirely.
+ *
+ * The brand's saturation is 24, down from 34. As a solid fill beside the wood
+ * the old value glared. Every green below holds its exact luminance and only
+ * loses saturation, so nothing that was solved has to be re-solved.
+ *
+ * Every value was solved against its own ground for a target WCAG ratio rather
+ * than picked by hand, so the contrast figures below are measured, not
+ * aspirational. The categorical data colours were validated for colour-vision
+ * deficiency separately, and are deliberately left at their original
+ * saturation — re-muting them would invalidate that check.
  *
  * styles/tokens.css ships the dark half of this system verbatim. The light half
  * has no runtime consumer on the site (dark only) and lives on here: the print
@@ -28,6 +40,7 @@ export type SwatchGroup = {
 };
 
 export const brandHue = 130;
+export const materialHue = 32;
 
 export const colorGroups: SwatchGroup[] = [
   {
@@ -78,22 +91,34 @@ export const colorGroups: SwatchGroup[] = [
   {
     title: "Brand",
     intro:
-      "One hue, saturation held at 34. Push it higher and eucalyptus becomes grass. No single value clears AA text contrast on both white and near-black — that is arithmetic, not a hue problem — so there are two steps rather than one.",
+      "One hue, saturation held at 24. Higher and eucalyptus becomes grass, which is what it was doing at 34 once it sat as a solid fill next to the wood. No single value clears AA text contrast on both white and near-black — that is arithmetic, not a hue problem — so there are two steps rather than one.",
     ground: "dark",
     swatches: [
-      { name: "brand", hex: "#51a45e", cr: "6.03:1 on anchor", use: "accent on dark" },
-      { name: "brand-hover", hex: "#65b372", cr: "7.29:1", use: "hover, dark" },
-      { name: "brand-active", hex: "#478f53", cr: "4.71:1", use: "pressed, dark" },
-      { name: "brand-subtle-d", hex: "#1e3322", use: "tinted block, dark" },
+      { name: "brand", hex: "#65a16e", cr: "6.10:1 on anchor", use: "accent on dark" },
+      { name: "brand-hover", hex: "#7cae83", cr: "7.31:1", use: "hover, dark" },
+      { name: "brand-active", hex: "#568d5e", cr: "4.76:1", use: "pressed, dark" },
+      { name: "brand-subtle-d", hex: "#1f3322", use: "tinted block, dark" },
+    ],
+  },
+  {
+    title: "Material",
+    intro:
+      "One material at three depths, not three colours. Brass is the only step that works as a standalone solid: 3.02:1 clears the non-text threshold, so a button's shape is perceivable without a border, and it still carries snow at 5.15:1. Two rules follow from the arithmetic. Brass takes snow only — snow-2 on it measures 2.65:1. And snow-3 never sits on wood, where it measures 2.85:1.",
+    ground: "dark",
+    swatches: [
+      { name: "wood", hex: "#4a3520", cr: "1.61:1 on anchor", use: "panels, wells, table headers" },
+      { name: "brass", hex: "#7f5a2f", cr: "3.02:1", use: "solid fills, card edges, rules" },
+      { name: "brass-hi", hex: "#8a6133", cr: "3.40:1", use: "hover — the lightest brass that still carries snow at AA" },
+      { name: "copper", hex: "#c09955", cr: "7.03:1", use: "the ink end of the ramp, used sparingly" },
     ],
   },
   {
     title: "Brand · on light",
     ground: "light",
     swatches: [
-      { name: "brand-ink", hex: "#378144", cr: "4.61:1 on paper", use: "links, text" },
-      { name: "brand-solid", hex: "#358142", cr: "4.81:1 vs white", use: "filled button" },
-      { name: "brand-subtle", hex: "#ebf4ed", use: "tinted block, light" },
+      { name: "brand-ink", hex: "#4d7d54", cr: "4.61:1 on paper", use: "links, text" },
+      { name: "brand-solid", hex: "#4c7d54", cr: "4.81:1 vs white", use: "filled button" },
+      { name: "brand-subtle", hex: "#ecf3ed", use: "tinted block, light" },
     ],
   },
 ];
@@ -101,12 +126,12 @@ export const colorGroups: SwatchGroup[] = [
 export const semantic = [
   {
     name: "success",
-    light: "#378144",
-    dark: "#51a45e",
-    bgLight: "#ebf4ed",
-    bgDark: "#1e3322",
+    light: "#4d7d54",
+    dark: "#65a16e",
+    bgLight: "#ecf3ed",
+    bgDark: "#1f3322",
     crLight: "4.61:1",
-    crDark: "6.03:1",
+    crDark: "6.10:1",
     note: "Success is the brand green. A green brand plus a separate emerald success would be two greens meaning different things, which is worse than reusing one.",
   },
   {
@@ -117,7 +142,7 @@ export const semantic = [
     bgDark: "#332a17",
     crLight: "4.59:1",
     crDark: "7.01:1",
-    note: "Amber at hue 38, far enough from the brand to never be mistaken for it.",
+    note: "Amber at hue 38, far enough from the brand to never be mistaken for it. It does share a hex with copper, the ink end of the material ramp, so a Result mark and a Watch mark are currently one colour told apart only by their label. Known, tracked, not yet fixed.",
   },
   {
     name: "danger",
@@ -143,7 +168,7 @@ export const semantic = [
 
 /** Fixed order, never cycled. A sixth series folds into Other or becomes small multiples. */
 export const dataSeries = [
-  { name: "series 1", label: "eucalyptus", light: "#2f7d4f", dark: "#4f9e6a" },
+  { name: "series 1", label: "eucalyptus", light: "#4a7952", dark: "#5f9c68" },
   { name: "series 2", label: "plum", light: "#af2c7f", dark: "#c26191" },
   { name: "series 3", label: "blue", light: "#266bba", dark: "#3f8fd0" },
   { name: "series 4", label: "rust", light: "#d15a1f", dark: "#c9713f" },
@@ -239,8 +264,8 @@ export const motion = [
 export const imagery = {
   intro:
     "Covers, OG cards and diagrams share the palette so a generated image never fights the page it sits on. The rule is that images use the field and ink colours only — the accent appears once, if at all.",
-  grounds: ["#142e18", "#0f1410", "#1e3322"],
-  marks: ["#51a45e", "#a1ada3", "#e9ebe9"],
+  grounds: ["#142e18", "#0f1410", "#1f3322"],
+  marks: ["#65a16e", "#a1ada3", "#e9ebe9"],
   rules: [
     "Ground the image on field or anchor. Never a white or light-grey canvas — those read as stock.",
     "One accent element maximum. If the composition needs a second colour, use snow-2 rather than a second hue.",
@@ -250,7 +275,7 @@ export const imagery = {
     "Export at 2400×1260 for OG and 1600×900 for in-post covers. Keep type above 40px at export size so it survives feed downscaling.",
   ],
   prompt:
-    "flat vector composition, deep eucalyptus green ground #142e18, single sage accent #51a45e, geometric forms only (concentric rings, thin rules, isometric blocks), generous negative space, no text, no people, no gradients, no photorealism, high contrast, editorial technical illustration",
+    "flat vector composition, deep eucalyptus green ground #142e18, single sage accent #65a16e, geometric forms only (concentric rings, thin rules, isometric blocks), generous negative space, no text, no people, no gradients, no photorealism, high contrast, editorial technical illustration",
 };
 
 export const a11y = [

--- a/portfolio/src/content/schemas.ts
+++ b/portfolio/src/content/schemas.ts
@@ -13,7 +13,7 @@ export const serviceSchema = z.object({
   blurb: z.string(),
   summary: z.string(),
   bullets: z.array(z.string()),
-  accent: z.enum(["arctic", "copper", "teal"]).default("arctic"),
+  accent: z.enum(["brand", "material", "brand2"]).default("brand"),
   proof: z
     .object({
       label: z.string(),

--- a/portfolio/src/content/services.ts
+++ b/portfolio/src/content/services.ts
@@ -4,7 +4,7 @@ const raw: Service[] = [
   {
     slug: "kubernetes-and-containerization",
     title: "Kubernetes & Containerization",
-    accent: "arctic",
+    accent: "brand",
     proof: {
       label: "Migrated ~30 microservices to AKS · 33M+ requests/day at peak",
       workSlug: "betting-platform-cloud-migration",
@@ -24,7 +24,7 @@ const raw: Service[] = [
   {
     slug: "gitops-and-ansible",
     title: "GitOps & Ansible",
-    accent: "copper",
+    accent: "material",
     proof: {
       label: "Built the GitOps platform on Talos · ArgoCD app-of-apps, 6-node cluster",
       workSlug: "k8s-homelab",
@@ -44,7 +44,7 @@ const raw: Service[] = [
   {
     slug: "technical-consulting",
     title: "Technical Consulting",
-    accent: "teal",
+    accent: "brand2",
     proof: {
       label: ".NET thread-pool starvation RCA · async refactor stabilised production",
       workSlug: "dotnet-thread-pool-rca",

--- a/portfolio/src/styles/tokens.css
+++ b/portfolio/src/styles/tokens.css
@@ -1,10 +1,14 @@
 /* ======================================================================
    Design tokens — Eucalyptus palette
 
-   Hue is locked to 130. Every value was solved against its own ground for
-   a target WCAG ratio rather than picked by hand, so the ratios in the
-   comments are measured against --bg. Full spec and reasoning live at
-   /brand, which renders content/brand.ts.
+   Two hues, and they do different jobs. 130 is the brand and it is ink:
+   links, focus, live state, the one action that matters. 32 is the material
+   and it is surface: buttons, chips, panels, edges. Nothing is both.
+
+   Every value was solved against its own ground for a target WCAG ratio
+   rather than picked by hand, so the ratios in the comments are measured
+   against --bg. Full spec and reasoning live at /brand, which renders
+   content/brand.ts.
 
    Dark only. The theme toggle was removed and layout.tsx forces .dark
    before first paint, so a light ramp here would be unreachable CSS. The
@@ -28,22 +32,46 @@
   --fg-2: #a1ada3;        /*  8.00:1 — body prose */
   --fg-3: #708373;        /*  4.60:1 — labels, captions */
 
-  /* Accents — one hue, three steps. The only colour on the page.
-     Saturation is held at 34; push it higher and eucalyptus becomes grass. */
-  --accent: #51a45e;      /*  6.05:1 — primary */
-  --accent-2: #8ec798;    /*  9.55:1 — lightest step, gradients only */
-  --accent-3: #61b86f;    /*  7.62:1 — middle step */
-  --accent-ink: #0f1410;  /*  6.05:1 on the accent fill */
-  --copper: #c09955;      /*  7.03:1 — sparing warm */
+  /* Accents — one hue, three steps. Green is the primary: links, focus, live
+     state and the one action that matters on any given screen.
+     Saturation is held at 24. It was 34, which glared as a solid fill next to
+     the wood; the steps below hold their exact luminance and only lose
+     saturation, so every ratio the system was solved for survives. */
+  --accent: #65a16e;      /*  6.10:1 — primary */
+  --accent-2: #9ec3a3;    /*  9.57:1 — lightest step, gradients only */
+  --accent-3: #81b288;    /*  7.68:1 — middle step */
+  --accent-ink: #0f1410;  /*  6.10:1 on the accent fill */
+
+  /* Wood and brass — the material layer. Green is ink and never a surface;
+     these are surfaces and never ink. Because the two live in different
+     layers they can share the page without competing, which a second brand
+     colour in the ink layer could not do: solved against this ground for the
+     same target, copper and green land 1.01:1 apart and read as one colour.
+     Brass is the only brown that works as a standalone solid — 3.02:1 clears
+     the non-text threshold so a button's shape is perceivable without a
+     border, and it still carries --fg at 5.15:1. Two rules follow from the
+     arithmetic: brass takes --fg only (--fg-2 on it is 2.65:1), and --fg-3
+     never sits on wood (2.85:1). */
+  --wood: #4a3520;        /*  1.61:1 — panels, wells, table headers */
+  --brass: #7f5a2f;       /*  3.02:1 — solid fills, card edges, rules */
+  --brass-hi: #8a6133;    /*  3.40:1 — hover; the lightest brass that still
+                              carries --fg at AA (4.57:1) */
+  --copper: #c09955;      /*  7.03:1 — the ink end of the same ramp, used
+                              sparingly. wood -> brass -> copper is one
+                              material at three depths, not three colours. */
+
+  /* Shares copper's hex, so a Result mark and a Watch mark are currently one
+     colour told apart only by their label. Pre-existing; see BACKLOG.md. */
   --warn: #c09955;
 
   /* Atmospheric gradient. One hue at low opacity: the old blue/violet/teal
      stack was the clearest generic tell on the page. */
   --grad-hero:
-    radial-gradient(58% 76% at 24% -8%, rgba(81, 164, 94, 0.09), transparent 62%),
+    radial-gradient(58% 76% at 24% -8%, rgba(101, 161, 110, 0.09), transparent 62%),
     linear-gradient(180deg, #0f1410 0%, #090c0a 100%);
 
-  --accent-rgb: 81, 164, 94;
+  --accent-rgb: 101, 161, 110;
+  --fg-rgb: 233, 235, 233;   /* alpha tints of the snow ramp */
   --selection-fg: #0f1410;
 
   --grain-opacity: 0.16;
@@ -52,9 +80,9 @@
   /* Semantic colours. Success is the brand green: a green brand plus a
      separate emerald success would be two greens meaning different things. */
   --interactive: var(--accent);
-  --interactive-hover: #65b372;   /* 7.31:1 */
+  --interactive-hover: #7cae83;   /* 7.31:1 */
   --interactive-ink: var(--accent-ink);
-  --success: #51a45e;             /* 6.05:1 */
+  --success: #65a16e;             /* 6.10:1 */
   --danger: #d18e83;              /* 7.01:1 */
   --info: #5ca9c3;                /* 7.02:1 — teal-blue at 195, far enough
                                      from the brand to never be mistaken


### PR DESCRIPTION
## Why

Green was doing every job on the page — links, focus, live state, every button, every mark — so brown had nowhere to go except the background, where it read for about two seconds and then disappeared. And as a solid fill next to that brown, the green glared.

## What

**A material layer.** `--wood` `#4a3520` for panels, wells and table headers. `--brass` `#7f5a2f` for solid fills, card edges and rules. `--brass-hi` `#8a6133` for hover. `--copper` `#c09955` is now documented as the ink end of the *same* ramp rather than a separate colour — wood to brass to copper is one material at three depths.

Green is ink and never a surface; these are surfaces and never ink. That separation is the whole point: a second brand colour in the ink layer could not work, because solved against this ground for the same target a copper and a green land 1.01:1 apart and read as one colour to a colour-blind reader.

Brass is the only brown that works as a standalone solid. 3.02:1 clears the non-text threshold so a button's shape is perceivable without a border, and it still carries `--fg` at 5.15:1. Two rules follow and are enforced throughout: brass takes `--fg` only, never `--fg-2` (2.65:1 on it), and `--fg-3` never sits on wood (2.85:1).

**Saturation 34 to 24.** `--accent` `#51a45e` becomes `#65a16e`, with the whole family coming down so nothing reads neon beside it. Every step holds its exact luminance and only loses saturation, so all the solved ratios survive: 6.10, 9.57, 7.68, 7.31. The ground is untouched — the hue-130 neutral ramp ships exactly as it was. The paper ramp, print stylesheet and LaTeX CV colour follow, so the CV still matches the site.

**The sweep.** 37 hex literals across 13 files. The command palette comes off Tailwind's default ramp onto the tokens. A new `--fg-rgb` gives the 83 white-alpha utilities in the palette and room HUD somewhere to tint from.

The room's status LEDs needed different treatment: they sat at hues 144–154, plus one at 203. Holding luminance turned them into pale sage, which is wrong for something that has to look lit, so they were hue-shifted onto 129 with saturation eased instead.

**A bug this caught.** Renaming the service accent enum from `arctic|copper|teal` broke `SERVICE_TONE` in the 3D room, which keys off those exact strings and is typed `Record<string, string>` — so typecheck stayed silent and every leaflet on the service rack would have fallen through to the default tone. Fixed, along with `ACCENT.blue`, which had not been blue for some time.

**Deliberately left:** 15 `bg-black/NN` scrims, because a scrim darkens what is behind it and tinting one green would be wrong; the hero monitor's `bg-black`, which is an unlit CRT; and the room's internal screen ramp, measured at hue 129–133 and 8–24% saturation, already in the new family.

## Verification

- `make typecheck` clean, `make lint` 0 errors (same 25 warnings), `make image` builds.
- Greps across `src/`, `scripts/` and `public/` return 0 hits for: old brand hexes, old room neons, Tailwind default-palette classes, white and white-alpha utilities, stale enum names, `ACCENT.blue`/`ACCENT.teal`.
- Browser-verified: home hero, `/brand` including the new Material group, the command palette, and `/fun` after the HUD sweep.