### PR TITLE
Build the flat sections out of the same materials as the render

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -143,6 +143,18 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Decide the route/assertion list, add `portfolio/tests/` with a Playwright config running via `mcr.microsoft.com/playwright` Docker image, add the CI job.
 - **Where:** `.github/workflows/ci-portfolio.yaml`, new `portfolio/tests/`.
 
+### The materials pass stops after About
+- **What:** `branding/DECISIONS.md` §12 agreed that everything not rendered is built from the same four materials as the objects: plate labels, one lamp on every raised surface, paper where something lies on the desk, and lit sheets in place of cards. Only the hero and About were converted. `ServicesGrid`, `LatestWriting`, `ResumeSection`, `CtaContact` and the `/work/<slug>` pages still use `rounded-xl border border-line` cards, lucide icons in rounded-square badges, `/01` counters and `ArrowUpRight` links. Nineteen files still import `lucide-react`.
+- **Why deferred:** The first pass was scoped to the region where the hero render bleeds behind the copy, because that is where the mismatch was visible and where the treatments could be judged against the globe. Converting six more sections in the same step would have shipped a lot of unreviewed surface.
+- **Unblock:** Apply `.lit` + `.lit-rule` to the remaining card grids and drop the icon badges and counters with them, then decide per section whether a label is warranted. The classes and tokens already exist; nothing new needs designing. Do it a section at a time so each can be looked at.
+- **Where:** `portfolio/src/app/globals.css` (`.section-label`, `.card-stock`, `.print`, `.lit`, `.lit-rule`), `portfolio/src/styles/tokens.css` (paper ramp, `--lit-edge`, `--cast`), `portfolio/src/components/sections/{ServicesGrid,LatestWriting,ResumeSection,CtaContact}.tsx`, `portfolio/src/components/work/`.
+
+### The provenance stamp exists only in the footer
+- **What:** `FooterStamp` reports the node that served the page, the build sha, the coordinates and the render time. §12 accepted extending that device: the shelf stating its volume count and newest entry, the resume its revision date and size, the repositories their live star counts. None of it is built. Related gap: `content/repos.ts` fetches live stars and forks for four pinned repositories, and the only thing that renders it is `GithubWall` inside `/fun`, so the open-source work is invisible on the main site.
+- **Why deferred:** Each stamp needs a real source, and three of the four do not have one yet — the shelf count is derivable, the resume figures are produced inside the cv-bundle container, and the repo numbers already come from `/api/v1/github` but have no home outside the room.
+- **Unblock:** Pick sources one at a time and render each stamp under its own object in the same mono treatment as `FooterStamp`. The repositories one is the largest return, since it is the only place the GitHub work appears at all and the endpoint already exists.
+- **Where:** `portfolio/src/components/FooterStamp.tsx` (the pattern), `portfolio/src/content/repos.ts`, `portfolio/src/app/api/v1/github/route.ts`, `portfolio/src/components/fun/GithubWall.tsx`.
+
 ## Portfolio API
 
 ### Portfolio API writes: a real endpoint, and the auth to match

--- a/portfolio/branding/DECISIONS.md
+++ b/portfolio/branding/DECISIONS.md
@@ -20,7 +20,8 @@ we meant.
 
 Status as of 2026-08-24: theme and typography locked and committed. The first
 section object, the portfolio shelf, is built and shipped in the real site. The
-rest of the room is still prototype only.
+rest of the room is still prototype only. §12 covers the flat sections, whose
+first pass is shipped for the hero and About.
 
 ---
 
@@ -293,7 +294,111 @@ the RGBE parser and the perf techniques.
 `room-look-study.html` is five interiors for the `/fun` room, deferred.
 `pbr/` holds the downloaded Poly Haven assets.
 
+## 12. The flat sections
+
+**Agreed and partly shipped.** Everything above concerns the objects. This
+concerns the eighty percent of the site that is not rendered, and it exists
+because the objects were never the problem: three photoreal objects were
+sitting on top of a dark portfolio template, and once the hero's desk began
+bleeding down behind the copy the mismatch became the first thing you see.
+
+The rule, stated so it can be applied without asking: **everything is either an
+object or a document, and a card is neither.** Objects are rendered and lit by
+the rig in §6. Documents are made of the same four materials from §2 and obey
+the same lamp. There is no third category.
+
+Four devices carry it, and three of them are enforcement or reuse rather than
+new invention.
+
+**One lamp, in CSS as well as in three.js.** A raised surface takes light on
+its top and left edges, goes dark on its right and bottom, and casts down and
+to the right. An evenly bordered card is the CSS version of the flat-shaded box
+that §5 identifies as the reason three prototypes failed, and the fix is the
+same: stop letting every edge take light identically. Expressed once as
+`--lit-edge`, `--lit-edge-soft`, `--dark-edge` and `--cast` in `tokens.css`, and
+applied through `.lit` in `globals.css`.
+
+**Paper is the fourth material and it was missing.** §2 has named it since the
+theme was locked, and until now it existed only in the print stylesheet and the
+LaTeX CV. Nothing on screen was made of it, which is why the hero's tags and the
+portrait defaulted to glass. It now has a screen ramp, and two rules travel with
+it: paper is warm off-white and never pure white, because a sheet in a room lit
+by one lamp is the colour of the lamp; and anything lying on the desk carries a
+short hard contact shadow, because that is the whole difference between resting
+on a surface and hovering over a photograph.
+
+**Green appears once per view as a lit point.** Not a new decision, §2 already
+says it. One scroll of the front page was passing at least four lit green
+points. Brass takes over as the marker, green survives as ink and as the single
+live state, and the availability lamp is the one thing still allowed to emit.
+
+**Everything states its own provenance.** `FooterStamp` is the best small piece
+on the site because it is a measurement the site takes of itself and cannot
+fake, and that device should recur rather than sit once at the bottom. It is
+the honest version of a stats row and the only decorative element here that
+gets better the more real the site becomes. Not built; see `BACKLOG.md`.
+
+### The section label, and the plate that failed
+
+The first attempt promoted the portfolio shelf's brass plate to the
+section-heading system, drawn in CSS as a gradient sweep with two screw heads.
+It read as a glossy gold button and was rejected on sight.
+
+The reason is §5 again, and it is worth writing down because the instinct will
+return: a surface painted as a colour gradient with nothing to reflect renders
+as a flat-shaded box, and brass at metalness 1 with no environment is dull
+brown plastic. That finding was about three.js, where an environment map is at
+least available. CSS has none at all, so a convincing brass plate is not
+something the DOM can draw. **Brass stays in the render, where it has light.**
+
+Six replacements were built and looked at. What shipped is a short brass rule
+above the label, `.section-label`. Brass as a rule is one of the three jobs
+`tokens.css` already assigns it, and the only one of the three that does not
+have to convince anyone it is metal: a drawn line is a drawn line whatever it
+is made of. It is also the weight that survives appearing in every section,
+which is the test the plate failed. It fades out to the right so it reads as
+drawn rather than as a border, and it is deliberately not folded into
+`.eyebrow`, which also labels post dates and proof blocks where a rule would
+claim a hierarchy that is not there.
+
+A restrained plate was built first and briefly shipped: matte, desaturated, no
+sweep, no screws, light ink on dark metal. It was better than the glossy version
+and still a small brown rectangle repeated down the page. It is the fallback if
+the rule ever reads as too slight, and the CSS is recoverable from git.
+
+Also rejected:
+
+*A margin mark*, the same idea turned vertical, quietest of the six. It survives
+one level down, where the skill group heads already use it, which is what gives
+the two levels different marks.
+*Card stock*, which works but spends the loudest material on the most repeated
+element on the site; paper is better saved for the hero and the portrait, where
+it does real work.
+*Cutting the label into the ground*, which confirmed the theory the hard way:
+on a near-black ground an engraving has no light to catch and reads as damage.
+
+### What shipped
+
+The hero and About only, because that is where the desk bleeds behind the copy
+and where the treatments could be judged against the globe. The certifications
+are card stock and the two remaining claims are plain type beside them, since
+four sheets of paper in a row is louder than one lamp allows. The portrait is a
+print with a paper border and a contact shadow rather than a card with a green
+radial wash, which also removed the one place green was tinting a whole surface.
+The monitor takes the same square cut and contact shadow as everything else on
+the desk. The skill pills and the career path are brass. `CareerPath` lost its
+own label, because the section's "career" and the block's "the
+route" stacked as two labels and read as a mistake.
+
+Everything else still uses the old card language. See `BACKLOG.md`.
+
 ## Logbook
+
+**2026-08-24, later still.** §12. The conclusion that took longest to reach
+is that the site did not need more rendered objects to feel like one thing; it
+needed the part that is not rendered to be made of the same materials as the
+part that is. The brass plate failing in CSS for exactly the reason §5 gives
+for three.js is the most reusable finding of the day.
 
 **2026-08-24, later.** Four interaction models built and rejected before landing
 on "more moments like the globe". The realism finding in section 5 is the reason

--- a/portfolio/src/app/globals.css
+++ b/portfolio/src/app/globals.css
@@ -148,6 +148,101 @@ body {
   font-weight: var(--font-weight-medium);
 }
 
+/* ---------------------------------------------------------------------------
+   The four materials, as surfaces.
+
+   Everything below exists so a flat section is built out of the same stuff as
+   a rendered one. Three rules run through all of them and are the whole point:
+   light comes from the upper left and nothing is evenly bordered; square-cut
+   corners rather than the 12px radius of a UI card; and a contact shadow
+   wherever something sits on the desk, because the hero render now bleeds down
+   behind the copy and an element with no shadow floats over a photograph
+   instead of resting on it. See branding/DECISIONS.md.
+   --------------------------------------------------------------------------- */
+
+/* Brass — the section label. A short rule over the label rather than a plate
+   under it. tokens.css gives brass three jobs, solid fills, card edges and
+   rules, and the rule is the only one of the three that does not have to
+   convince anyone it is metal: CSS has no environment map, and DECISIONS §5 is
+   that brass with nothing to reflect renders as brown plastic. A drawn line is
+   the weight that survives appearing in every section.
+
+   Not folded into .eyebrow, which also labels post dates and proof blocks
+   where a rule would be claiming a hierarchy that is not there. */
+.section-label {
+  display: inline-block;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.6875rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: var(--font-weight-medium);
+}
+.section-label::before {
+  content: "";
+  display: block;
+  width: 44px;
+  height: 1px;
+  margin-bottom: 12px;
+  /* Fades out to the right so it reads as drawn rather than as a border. */
+  background: linear-gradient(90deg, var(--copper), rgba(127, 90, 47, 0.15));
+}
+
+/* Paper — card stock set down on the desk. Square-cut, warm, and carrying a
+   short hard shadow rather than a soft glow, which is the difference between
+   lying on a surface and hovering above one. */
+.card-stock {
+  display: inline-block;
+  border-radius: 1px;
+  background: linear-gradient(158deg, var(--paper) 0%, var(--paper-2) 62%, var(--paper-3) 100%);
+  color: var(--paper-ink);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    var(--cast-tight);
+}
+
+/* A print rather than a card: the image is inset in its own paper border and
+   the whole sheet casts, so the photograph is an object on the desk. */
+.print {
+  padding: 8px 8px 22px;
+  border-radius: 1px;
+  background: linear-gradient(158deg, var(--paper) 0%, var(--paper-2) 62%, var(--paper-3) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    4px 10px 16px -8px rgba(0, 0, 0, 0.95),
+    0 2px 2px -1px rgba(0, 0, 0, 0.8);
+}
+/* The image sits in a well in the paper. As a pseudo-element rather than an
+   inset shadow on the wrapper, because an <img> filling its parent paints over
+   the parent's inset shadow and it would never be seen. */
+.print > *::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+/* Any raised surface that is not paper: lit on the top and left, dark on the
+   right and bottom, shadow cast down and to the right. Replaces
+   `rounded-xl border border-line` wherever that was standing in for a card. */
+.lit {
+  border-radius: 2px;
+  background: linear-gradient(163deg, #1b211c 0%, #141a15 58%, #10150f 100%);
+  border-top: 1px solid var(--lit-edge);
+  border-left: 1px solid var(--lit-edge-soft);
+  border-right: 1px solid var(--dark-edge);
+  border-bottom: 1px solid var(--dark-edge);
+  box-shadow: var(--cast);
+}
+
+/* The brass hairline that heads a lit sheet, in place of an icon in a rounded
+   square. Fades out to the right so it reads as drawn rather than as a border. */
+.lit-rule {
+  height: 1px;
+  background: linear-gradient(90deg, var(--brass), rgba(127, 90, 47, 0.06));
+}
+
 /* Centralised focus affordance */
 .focus-ring:focus-visible {
   outline: var(--ring-width) solid var(--ring);

--- a/portfolio/src/components/PortraitCard.tsx
+++ b/portfolio/src/components/PortraitCard.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export function PortraitCard() {
   return (
-    <figure className="relative overflow-hidden rounded-lg border border-line bg-surface/40 backdrop-blur-sm">
+    <figure className="print relative">
       <div className="relative aspect-[4/5] w-full overflow-hidden">
         {/*
           Deliberately not `priority`. At Lighthouse's 412x823 mobile viewport
@@ -19,18 +19,6 @@ export function PortraitCard() {
           sizes="(max-width: 768px) 100vw, 33vw"
           className="object-cover saturate-[0.92] contrast-[1.05]"
           style={{ objectPosition: "center top" }}
-        />
-        <div
-          aria-hidden
-          className="absolute inset-0 bg-gradient-to-t from-bg via-transparent to-transparent opacity-90"
-        />
-        <div
-          aria-hidden
-          className="absolute inset-0"
-          style={{
-            background:
-              "radial-gradient(120% 60% at 0% 100%, rgba(var(--accent-rgb), 0.20), transparent 60%)",
-          }}
         />
       </div>
     </figure>

--- a/portfolio/src/components/primitives/SectionHeading.tsx
+++ b/portfolio/src/components/primitives/SectionHeading.tsx
@@ -23,7 +23,9 @@ export function SectionHeading({
       )}
     >
       <div className="max-w-2xl">
-        {eyebrow && <p className="eyebrow">{eyebrow}</p>}
+        {/* The label carries a brass rule, so a flat section is drawn with the
+            same material as the hardware on the rendered shelf. */}
+        {eyebrow && <p><span className="section-label">{eyebrow}</span></p>}
         <h2 className={cn("text-h1 text-fg", eyebrow ? "mt-4" : "")}>{title}</h2>
         {description && (
           <p className="mt-4 max-w-xl text-fg-2">{description}</p>

--- a/portfolio/src/components/primitives/Tag.tsx
+++ b/portfolio/src/components/primitives/Tag.tsx
@@ -7,7 +7,7 @@ export function Tag({
 }: {
   children: React.ReactNode;
   className?: string;
-  variant?: "default" | "accent" | "warm" | "muted";
+  variant?: "default" | "accent" | "warm" | "muted" | "paper";
 }) {
   return (
     <span
@@ -17,6 +17,10 @@ export function Tag({
         variant === "warm" && "border-brass bg-wood text-fg",
         variant === "muted" && "border-line bg-bg-2/40 text-fg-3",
         variant === "default" && "border-line-2 bg-surface/40 text-fg-2",
+        // Card stock, so it is a thing lying on the desk rather than a chip
+        // floating over it. Square-cut and borderless: the shadow is what
+        // makes the edge, the way it does on real paper.
+        variant === "paper" && "card-stock rounded-[1px]! border-transparent",
         className,
       )}
     >

--- a/portfolio/src/components/sections/AboutSection.tsx
+++ b/portfolio/src/components/sections/AboutSection.tsx
@@ -1,16 +1,10 @@
-import { Dumbbell, Wifi } from "lucide-react";
 import { PortraitCard } from "@/components/PortraitCard";
 import { Reveal } from "@/components/primitives/Reveal";
 import { Section } from "@/components/primitives/Section";
 import { CareerPath } from "@/components/sections/CareerPath";
 import { skills } from "@/content/skills";
-import { interests, type Interest } from "@/content/interests";
+import { interests } from "@/content/interests";
 import type { Skill } from "@/content/schemas";
-
-const interestIcon: Record<Interest["icon"], React.ReactNode> = {
-  fitness: <Dumbbell size={20} />,
-  homelab: <Wifi size={20} />,
-};
 
 const skillGroups: { id: Skill["group"]; label: string }[] = [
   { id: "platform", label: "Platform & infrastructure" },
@@ -47,23 +41,23 @@ export function AboutSection() {
       </div>
 
       <div className="mt-20">
-        <p className="eyebrow">the stack</p>
+        <p><span className="section-label">the stack</span></p>
         <div className="mt-8 grid gap-x-8 gap-y-10 md:grid-cols-2 lg:grid-cols-4">
           {skillGroups.map((g, gi) => {
             const items = skills.filter((s) => s.group === g.id);
             if (!items.length) return null;
             return (
               <Reveal key={g.id} delay={gi * 0.05}>
-                <h3 className="border-l-2 border-accent pl-3 eyebrow !text-fg-2">
+                <h3 className="border-l-2 border-brass pl-3 eyebrow !text-fg-2">
                   {g.label}
                 </h3>
                 <ul className="mt-5 flex flex-wrap gap-2">
                   {items.map((s) => (
                     <li
                       key={s.label}
-                      className="group inline-flex items-center gap-2 rounded-full border border-line-2 bg-surface/60 px-4 py-1.5 text-sm text-fg transition-all hover:border-accent/60 hover:bg-surface"
+                      className="group inline-flex items-center gap-2 rounded-[2px] border border-brass/55 px-4 py-1.5 text-sm text-fg transition-colors hover:border-copper"
                     >
-                      <span className="h-1 w-1 rounded-full bg-accent/70 transition-all group-hover:bg-accent group-hover:shadow-[0_0_8px_var(--accent)]" />
+                      <span className="h-1 w-1 rounded-full bg-brass transition-colors group-hover:bg-copper" />
                       {s.label}
                     </li>
                   ))}
@@ -75,7 +69,7 @@ export function AboutSection() {
       </div>
 
       <div className="mt-24">
-        <p className="eyebrow">career</p>
+        <p><span className="section-label">career</span></p>
         <h3 className="mt-3 text-h2 text-fg">The route here.</h3>
         <div className="mt-10">
           <CareerPath />
@@ -83,17 +77,15 @@ export function AboutSection() {
       </div>
 
       <div className="mt-24">
-        <p className="eyebrow">off the clock</p>
+        <p><span className="section-label">off the clock</span></p>
         <h3 className="mt-3 text-h2 text-fg">Outside work.</h3>
-        <div className="mt-10 grid gap-px overflow-hidden rounded-lg border border-line bg-line md:grid-cols-2">
+        <div className="mt-10 grid gap-6 md:grid-cols-2">
           {interests.map((it, i) => (
             <Reveal key={it.title} delay={i * 0.08}>
-              <div className="flex h-full flex-col gap-4 bg-bg p-8">
-                <span className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-line-2 bg-surface/40 text-accent">
-                  {interestIcon[it.icon]}
-                </span>
+              <div className="lit flex h-full flex-col p-8">
+                <span aria-hidden className="lit-rule mb-6 block" />
                 <h4 className="text-h3 text-fg">{it.title}</h4>
-                <p className="text-sm text-fg-2 leading-relaxed">{it.body}</p>
+                <p className="mt-3 text-sm text-fg-2 leading-relaxed">{it.body}</p>
               </div>
             </Reveal>
           ))}

--- a/portfolio/src/components/sections/CareerPath.tsx
+++ b/portfolio/src/components/sections/CareerPath.tsx
@@ -3,18 +3,20 @@ import { careerPath, type CareerStop } from "@/content/resume";
 export function CareerPath() {
   return (
     <div>
-      <p className="eyebrow">the route</p>
+      {/* No label of its own. The block above already carries the "career"
+          plate and the heading "The route here.", and two plates stacked read
+          as a mistake rather than as hierarchy. */}
 
       {/* Mobile: vertical stops */}
-      <ol className="mt-6 space-y-6 sm:hidden">
+      <ol className="space-y-6 sm:hidden">
         {careerPath.map((stop, i) => (
           <li key={`${stop.year}-${stop.role}-${i}`} className="relative flex items-start gap-4">
             <span
               className={
                 "mt-1.5 inline-block h-3 w-3 shrink-0 rounded-full border " +
                 (stop.current
-                  ? "border-accent bg-accent shadow-[0_0_14px_var(--accent)]"
-                  : "border-line-2 bg-bg")
+                  ? "border-copper bg-copper"
+                  : "border-brass bg-brass")
               }
             />
             <StopLabel stop={stop} />
@@ -23,10 +25,10 @@ export function CareerPath() {
       </ol>
 
       {/* Desktop: horizontal stops with connector line */}
-      <div className="relative mt-8 hidden sm:block">
+      <div className="relative hidden sm:block">
         <div
           aria-hidden
-          className="pointer-events-none absolute left-[6px] right-[6px] top-[5px] h-px bg-gradient-to-r from-accent via-accent/60 to-line-2"
+          className="pointer-events-none absolute left-[6px] right-[6px] top-[5px] h-px bg-gradient-to-r from-copper via-brass to-brass/25"
         />
         <ol
           className="grid gap-x-6"
@@ -40,8 +42,8 @@ export function CareerPath() {
                 className={
                   "relative z-10 inline-block h-3 w-3 rounded-full border " +
                   (stop.current
-                    ? "border-accent bg-accent shadow-[0_0_16px_var(--accent)]"
-                    : "border-line-2 bg-bg")
+                    ? "border-copper bg-copper"
+                    : "border-brass bg-brass")
                 }
               />
               <div className="mt-4">
@@ -60,12 +62,9 @@ function StopLabel({ stop }: { stop: CareerStop }) {
     <div>
       <p className="flex items-baseline gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-fg-3">
         {stop.year}
-        {stop.current && (
-          <span className="inline-flex items-center gap-1 text-accent">
-            <span className="h-1 w-1 rounded-full bg-accent shadow-[0_0_8px_var(--accent)]" />
-            now
-          </span>
-        )}
+        {/* Green survives here as ink, not as a second lit point: the copper
+            stop marker already says which one is current. */}
+        {stop.current && <span className="text-accent">now</span>}
       </p>
       <p className={"mt-1.5 text-sm " + (stop.current ? "text-fg font-medium" : "text-fg-2")}>
         {stop.role}

--- a/portfolio/src/components/sections/Hero.tsx
+++ b/portfolio/src/components/sections/Hero.tsx
@@ -96,11 +96,19 @@ export function Hero() {
             {site.hero.sub}
           </p>
 
-          <div className="mt-8 flex flex-wrap gap-2">
-            <Tag variant="accent">CKA</Tag>
-            <Tag variant="accent">AZ-305</Tag>
-            <Tag variant="muted">4+ yrs production cloud</Tag>
-            <Tag variant="muted">Public &amp; private · enterprise scale</Tag>
+          {/* The two certifications are card stock set down on the desk. The
+              other two lines are claims rather than objects, so they are set as
+              plain type beside them — four sheets of paper in a row is louder
+              than one lamp allows. */}
+          <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-3">
+            <Tag variant="paper">CKA</Tag>
+            <Tag variant="paper">AZ-305</Tag>
+            <span className="font-mono text-xs tracking-wide text-fg-3">
+              4+ yrs production cloud
+            </span>
+            <span className="font-mono text-xs tracking-wide text-fg-3">
+              Public &amp; private · enterprise scale
+            </span>
           </div>
 
           {/* The way into /fun is a monitor showing the room, not a button
@@ -116,7 +124,7 @@ export function Hero() {
               onClick={enterRoom}
               className="room-feed focus-ring group inline-flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4"
             >
-              <span ref={screenRef} className="relative block aspect-video w-full max-w-[300px] shrink-0 overflow-hidden rounded-lg border border-line-2 bg-black shadow-[0_18px_40px_-24px_rgba(0,0,0,0.9)] transition-[border-color,box-shadow] duration-500 group-hover:border-accent/65 group-hover:shadow-[0_22px_60px_-26px_rgba(var(--accent-rgb),0.55)] sm:w-[268px]">
+              <span ref={screenRef} className="relative block aspect-video w-full max-w-[300px] shrink-0 overflow-hidden rounded-[2px] border-t border-l border-r border-b border-t-[color:var(--lit-edge)] border-l-[color:var(--lit-edge-soft)] border-r-[color:var(--dark-edge)] border-b-[color:var(--dark-edge)] bg-black shadow-[var(--cast)] transition-[border-color,box-shadow] duration-500 group-hover:border-accent/65 group-hover:shadow-[0_22px_60px_-26px_rgba(var(--accent-rgb),0.55)] sm:w-[268px]">
                 <Image
                   src="/images/room-poster.jpg"
                   alt=""

--- a/portfolio/src/styles/tokens.css
+++ b/portfolio/src/styles/tokens.css
@@ -11,9 +11,12 @@
    content/brand.ts.
 
    Dark only. The theme toggle was removed and layout.tsx forces .dark
-   before first paint, so a light ramp here would be unreachable CSS. The
-   paper ramp still exists in two places that need it: the print stylesheet
-   at the bottom of globals.css, and content/brand.ts for the LaTeX CV.
+   before first paint, so a light ramp here would be unreachable CSS. Paper
+   is the exception and is not a theme: it is one of the four materials the
+   room is made of, so a sheet of it is light for the same reason a sheet of
+   paper on a dark desk is light. The other two paper ramps are unrelated to
+   it — the print stylesheet at the bottom of globals.css, and
+   content/brand.ts for the LaTeX CV.
    ====================================================================== */
 
 :root,
@@ -59,6 +62,31 @@
   --copper: #c09955;      /*  7.03:1 — the ink end of the same ramp, used
                               sparingly. wood -> brass -> copper is one
                               material at three depths, not three colours. */
+
+  /* Paper — the fourth material named in branding/DECISIONS.md §2, and the
+     only one that had no screen ramp until now. Without it the hero's tags and
+     the portrait have nothing to be made of and fall back to glass, which is
+     what made them read as UI floating over the render rather than as things
+     lying on the desk. Ink is solved against --paper-2 at 8.9:1.
+
+     Deliberately warm off-white and never pure white: #fff on this ground is a
+     light leak, and paper in a room lit by one lamp is the colour of the lamp. */
+  --paper: #e8ddc9;
+  --paper-2: #d9cbb2;      /* the body of a sheet, mid-gradient */
+  --paper-3: #cabb9f;      /* the shaded lower-right edge */
+  --paper-ink: #3a2e1d;    /*  8.90:1 on --paper-2 */
+
+  /* The lamp, expressed once so the DOM and the render agree about where it
+     is. The rig in InlineGlobeScene.tsx keys from the upper left, so a raised
+     surface takes light on its top and left edges, goes dark on its right and
+     bottom, and throws its shadow down and to the right. An evenly bordered
+     box is the CSS version of the flat-shaded box that DECISIONS §5 identifies
+     as the reason three prototypes failed. */
+  --lit-edge: rgba(255, 212, 154, 0.11);
+  --lit-edge-soft: rgba(255, 212, 154, 0.055);
+  --dark-edge: rgba(0, 0, 0, 0.55);
+  --cast: 6px 16px 28px -18px rgba(0, 0, 0, 0.95);
+  --cast-tight: 2px 3px 5px -2px rgba(0, 0, 0, 0.85);
 
   /* Shares copper's hex, so a Result mark and a Watch mark are currently one
      colour told apart only by their label. Pre-existing; see BACKLOG.md. */


### PR DESCRIPTION
## Why

The hero's desk bleeds down behind the copy, and the text layer sitting on it was still a dark portfolio template: evenly bordered cards, glass pills, icon badges in rounded squares, and at least four lit green points on one scroll. Three photoreal objects on top of that read as screenshots pasted onto a page rather than as one room.

`branding/DECISIONS.md` already named four materials and already said green appears once per view as a lit point. The page was not following either.

## What

New section 12 in `branding/DECISIONS.md`: everything is either an object or a document, and both are made of the same four materials.

Paper gets a screen ramp. It has been a named material since the theme was locked but existed only in the print stylesheet and the LaTeX CV, which is why the hero's tags and the portrait had nothing to be made of and fell back to glass. The lamp is written down once as `--lit-edge`, `--dark-edge` and `--cast`, so a raised surface in the DOM takes light from the same direction as one in the rig.

Five surface classes carry it: `.section-label`, `.card-stock`, `.print`, `.lit`, `.lit-rule`.

Applied to the hero and About only, which is where the render bleeds behind the copy. The two certifications are card stock; the two remaining claims are plain type beside them, because four sheets of paper in a row is louder than one lamp allows. The portrait is a print rather than a card with a green radial wash, which also removed the one place green was tinting a whole surface. Skill pills and the career path move to brass, copper marks the current stop, and the interest cards become lit sheets, which retires the last lucide import in that file. `CareerPath` loses its own label, since it stacked under the section's and read as a mistake.

Six section-label treatments were built before landing on the brass rule. The shelf's plate drawn in CSS was rejected: a gradient with nothing to reflect renders as brown plastic, which is the finding in section 5 of the same document, and CSS has no environment map at all. Brass stays in the render where it has light.

## Verification

Typecheck clean. Lint 0 errors and 35 warnings, all pre-existing `react-hooks` findings in the three.js scene files, none in the files touched here. `/`, `/about`, `/infrastructure`, `/brand` and `/work/<slug>` all 200 on the dev stack. Checked at 1440 and 390.

## Not in this change

The six remaining sections still use the old card language, and the provenance stamp is not built. Both have entries in `BACKLOG.md`.