### PR TITLE
Name the account on every reelsmith slot, and make room for a third destination

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -27,10 +27,14 @@ data:
   # A line that does not parse fails the pod's startup on purpose, rather than
   # quietly dropping that slot from the schedule.
   #
-  # A line without account= attaches to the one registered Instagram account,
-  # which the gateway resolves and logs rather than guesses if that becomes
-  # ambiguous. A line with account= names its own destination, which is how one
-  # schedule covers both surfaces.
+  # Every line names its own destination. A line without account= attaches to
+  # the one registered Instagram account, and a second Instagram account makes
+  # that ambiguous: until 2026-08-26 that did not merely drop the line, it
+  # deleted the first account's slots at boot and the pod came up healthy with
+  # the feed stopped. The gateway freezes the whole config sweep now rather
+  # than deleting anything it could not attribute, and naming the account keeps
+  # a line out of all of that. See F0 in the reelsmith repo's
+  # docs/multi-destination-audit.md.
   #
   # YouTube runs at one a day against Instagram's three, deliberately. The risk
   # there is not the API, it is the inauthentic content policy, renamed from
@@ -49,9 +53,9 @@ data:
   # dropping it, so this line and the image carrying it have to ship in that
   # order. Adding it ahead of 0.0.29 crashlooped the pod once already.
   GATEWAY_SLOTS: |
-    08:10 Europe/Oslo jitter=15
-    12:40 Europe/Oslo jitter=15
-    19:20 Europe/Oslo jitter=15
+    08:10 Europe/Oslo jitter=15 account=17841441696714445
+    12:40 Europe/Oslo jitter=15 account=17841441696714445
+    19:20 Europe/Oslo jitter=15 account=17841441696714445
     21:05 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
 
   # Named zone, not an offset, so the slots stay at the same local hour across
@@ -74,3 +78,30 @@ data:
   GATEWAY_YOUTUBE_PRIVACY_STATUS: "public"
 
   GATEWAY_ADMIN_ENABLED: "true"
+
+  # The third destination, and off until there is an account to publish to.
+  #
+  # This one flag gates three things: the token refresher, the insights sweep
+  # and publishing. It exists where GATEWAY_YOUTUBE_ENABLED deliberately does
+  # not, because TikTok has a background loop of its own that would call the
+  # API daily on a deployment with no TikTok account, and nothing on the
+  # YouTube path runs unless a slot fires.
+  #
+  # Turning it on needs an OAuth round trip first
+  # (scripts/tiktok_authorise.py in the reelsmith repo), and a queued TikTok
+  # row reaching a slot with this off fails that row rather than retrying.
+  GATEWAY_TIKTOK_ENABLED: "false"
+
+  # Direct Post or the inbox. Direct Post needs an audit that reviews a posting
+  # screen this project does not have, and whose guidelines reject apps
+  # "designed for private/personal use only", so a no is the expected answer.
+  # The inbox path needs no audit and drops the video into the creator's drafts
+  # for one tap, which is the only thing that actually publishes before then.
+  GATEWAY_TIKTOK_DIRECT_POST: "false"
+
+  # What an unaudited client is allowed to ask for. It also has to be one of
+  # the options the creator_info call returns, or the post fails
+  # privacy_level_option_mismatch, which reads like a bad constant and is
+  # actually a stale read. Set explicitly so the pre-audit behaviour is chosen
+  # rather than discovered, the same way GATEWAY_YOUTUBE_PRIVACY_STATUS is.
+  GATEWAY_TIKTOK_PRIVACY_LEVEL: "SELF_ONLY"

--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -139,15 +139,23 @@ spec:
               Usually a full state volume. The copies live beside the database and the newest 14 are kept.
               Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i backup
 
+        # Labelled by platform since 2026-08-26. Unlabelled this fired without
+        # saying where, and a platform that had stopped publishing entirely was
+        # invisible behind the other two still succeeding, which is the failure
+        # actually worth waking up for. The expression is unchanged; what moved
+        # is that there is now one series per platform and the summary says
+        # which.
         - alert: ReelsmithPublishFailing
           expr: increase(reelsmith_publish_failures_total[1h]) > 0
           for: 5m
           labels:
             severity: warning
           annotations:
-            summary: 'reelsmith failed {{ $value | printf "%.0f" }} publish attempt(s) in the last hour'
+            summary: 'reelsmith failed {{ $value | printf "%.0f" }} {{ $labels.platform }} publish attempt(s) in the last hour'
             description: |
-              Meta rejected a publish or the upload did not complete. The queue entry stays for a retry.
+              The platform rejected a publish or the upload did not complete. The queue entry stays for a retry.
+              A platform with no publisher fails its own row rather than being handed to another
+              platform's API, and reports itself here under its own name.
               Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i publish
 
         # The counter above catches the moment and then resolves an hour later
@@ -160,13 +168,19 @@ spec:
         # publish that failed *after* the container existed may already be live
         # on the account, which is why the gateway refuses to retry it on its
         # own and why re-arming it in the admin UI can post the same Reel twice.
+        #
+        # Labelled by account since 2026-08-26, so this fires once per account
+        # rather than once in total. That is the wanted behaviour with three
+        # destinations: a queue that has stopped draining on one of them is
+        # otherwise hidden behind the others still moving. The matcher is
+        # unchanged, since a matcher on a subset of labels still matches.
         - alert: ReelsmithPostStuck
           expr: reelsmith_queue_depth{state="failed"} > 0
           for: 15m
           labels:
             severity: warning
           annotations:
-            summary: 'reelsmith has {{ $value | printf "%.0f" }} queued post(s) stuck in failed'
+            summary: 'reelsmith has {{ $value | printf "%.0f" }} queued post(s) stuck in failed on {{ $labels.account }}'
             description: |
               These have stopped retrying and stay put until someone decides what to do with them.
               Check the account for a duplicate before re-arming: a container may have become a Reel.


### PR DESCRIPTION
Two changes to the ConfigMap and two to the alert rules, all following work in the reelsmith repo rather than leading it.

**Not set to auto-merge.** It touches the live schedule, so it wants a look first.

## Every `GATEWAY_SLOTS` line names its account

A line without `account=` attaches to the one registered Instagram account, and a second Instagram account makes that ambiguous. Until 2026-08-26 that did not merely drop the line: the config sweep then visited the first account with an empty list, `sync_config_slots` replaces rather than merges, and **the first account's slots were deleted at boot**. The pod came up healthy with the feed stopped and one warning line describing a different symptom.

The gateway freezes the whole sweep now rather than deleting anything it could not attribute (reelsmith #36). This is the belt to that fix's braces, and it is worth having whether or not a second account ever exists.

**The slot ids do not move**, which matters because the firing offset is derived from the id and the local date, and a re-rolled offset can let one evening's slot fire twice. `sync_config_slots` keeps a slot whose hour, minute, timezone, jitter and days are unchanged — `account` is not part of that shape, and all four lines resolve to the same account they already did. Checked against the real `parse_slots` and `sync_config_slots`:

```
before: [(1, 8, 10), (2, 12, 40), (3, 19, 20)]
after:  [(1, 8, 10), (2, 12, 40), (3, 19, 20)]
```

## `GATEWAY_TIKTOK_*` is present and off

One flag gates the token refresher, the insights sweep and publishing. It exists where `GATEWAY_YOUTUBE_ENABLED` deliberately does not: TikTok has a background loop of its own that would call the API daily on a deployment with no TikTok account, and nothing on the YouTube path runs unless a slot fires. A flag earns its place when something runs without it.

Turning it on needs an OAuth round trip first (`scripts/tiktok_authorise.py`), so this is the switch being in place rather than the feature arriving. `DIRECT_POST` is off because that path needs an audit whose guidelines reject apps "designed for private/personal use only"; the inbox path needs no audit. `PRIVACY_LEVEL` is `SELF_ONLY`, which is what an unaudited client may ask for, set explicitly so the pre-audit behaviour is chosen rather than discovered — the same way `GATEWAY_YOUTUBE_PRIVACY_STATUS` is.

## Two alerts say which one

`reelsmith_publish_failures_total` now carries a `platform` label and `reelsmith_queue_depth` an `account` label. **Both expressions are unchanged**, since a matcher on a subset of labels still matches, but there is now one series per platform and per account, and the summaries say which.

That is the wanted behaviour: the failure worth waking up for is a platform or an account that has stopped entirely, which was invisible behind the others still succeeding.

`reelsmith_token_days_left` keeps its `ig_user_id` label deliberately, even though the column behind it was renamed to `account_id`, precisely so these rules did not have to change for a rename with no behaviour in it.

## Ordering

The new keys are inert on an older image (`extra="ignore"`) and all three are off, so this can land either side of the image. `account=` has been understood since 0.0.29 and is already used on the YouTube line, so the trap `docs/youtube-handover.md` records does not apply here.