### PR TITLE
Alert on a reelsmith claim that nothing finished

### DIFF
--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -188,3 +188,32 @@ spec:
               A "no video file" failure specifically means the retention sweep ate a queued
               file: _prune_media sweeps by mtime and db.live_media_names is the exemption
               that should have covered it.
+
+        # The state neither alert above could see. A publish claims its row
+        # before the first Graph call, so a process dying between creating the
+        # container and media_publish leaves it in `claimed` rather than
+        # `failed`: no failure counter is incremented, so ReelsmithPublishFailing
+        # stays quiet, and the row never reaches `failed`, so ReelsmithPostStuck
+        # does not match it either. Queue row 55 sat there nine days with its
+        # container already in ERROR at Meta.
+        #
+        # reelsmith_stale_claims only counts rows held past CLAIM_STALE_AFTER,
+        # an hour, which is an order of magnitude longer than one upload and a
+        # transcode poll. So a non-zero value is already an abandoned claim and
+        # not a publish in progress.
+        #
+        # The gateway will not resolve these on its own, deliberately: Meta may
+        # have accepted the post, and only the account can say. That is exactly
+        # why it has to alert rather than self-heal.
+        - alert: ReelsmithClaimAbandoned
+          expr: reelsmith_stale_claims > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith has {{ $value | printf "%.0f" }} claim(s) nothing finished on {{ $labels.account }}'
+            description: |
+              A publish claimed this row and never came back. It will not retry and will not move
+              without a person, and its media stays exempt from the retention sweep meanwhile.
+              Check the account for the post before deciding: the container may already be a Reel.
+              Queue: https://reelsmith.local.bigd.no/admin/


### PR DESCRIPTION
## Why

A publish claims its queue row before the first Graph call. A process dying between creating the container and `media_publish` therefore leaves the row in `claimed` rather than `failed`, and that state was invisible to both existing alerts:

- no failure counter is incremented, so `ReelsmithPublishFailing` stays quiet
- the row never reaches `failed`, so `ReelsmithPostStuck` does not match it

Queue row 55 (`astrid-runtime/book`) sat that way for nine days. Its container was already in `ERROR` at Meta, the post never went live, and its media stayed exempt from the retention sweep the whole time. Nothing anywhere said so.

## What

One rule, `ReelsmithClaimAbandoned` on `reelsmith_stale_claims > 0`, placed next to `ReelsmithPostStuck` since it is the sibling case.

`reelsmith_stale_claims` counts only rows held past `CLAIM_STALE_AFTER`, which is one hour, an order of magnitude longer than one upload and a transcode poll. A non-zero value is already an abandoned claim rather than a publish in progress, so the `for: 15m` is belt and braces rather than the real filter.

The gateway deliberately does not resolve these by itself, because Meta may have accepted the post and only the account can say. That is what makes this worth alerting on rather than self-healing, and why the description says to check the account before deciding.

## Verification

- YAML parses, ten rules load, the new expression is `reelsmith_stale_claims > 0`.
- The gauge is published for every account including the zeroes, so the alert resolves rather than sticking at its last non-zero value.

Requires reelsmith `b4c2cf8`, which adds the gauge and the `claimed_at` column behind it. Merged and deploying.