### PR TITLE
feat(cloudflare): verify gate.nordbye.it for the reelsmith TikTok app

### DIFF
--- a/terraform/cloudflare/nordbye-it/dns.tf
+++ b/terraform/cloudflare/nordbye-it/dns.tf
@@ -145,6 +145,23 @@ resource "cloudflare_dns_record" "google_verification_2" {
   ttl     = 3600
 }
 
+# TikTok verifies the domain a Content Posting API app publishes from, and
+# gate.nordbye.it is that host: the reelsmith gateway hands TikTok a
+# PULL_FROM_URL pointing at its own /media/{name}, and TikTok refuses the fetch
+# with url_ownership_unverified until this record exists. The same verification
+# covers the app's privacy policy, terms and website URLs, which the gateway
+# also serves, because a verified domain carries every URL beneath it.
+#
+# Deleting this un-verifies the property, which stops TikTok publishing and
+# invalidates the three URLs on the app record at the same time.
+resource "cloudflare_dns_record" "tiktok_verification_gate" {
+  zone_id = data.cloudflare_zone.this.zone_id
+  name    = "gate.${var.zone_name}"
+  type    = "TXT"
+  content = "\"tiktok-developers-site-verification=eohRkSSPmh7bhifAuN7feJ5Wx6kzITAL\""
+  ttl     = 3600
+}
+
 # Azure App Service custom domain verification ID.
 resource "cloudflare_dns_record" "asuid" {
   zone_id = data.cloudflare_zone.this.zone_id


### PR DESCRIPTION
## Why

The reelsmith gateway hands TikTok a `PULL_FROM_URL` pointing at its own `/media/{name}`, and TikTok refuses the fetch with `url_ownership_unverified` until the domain is verified by DNS record.

One record covers more than the media. TikTok also demands a privacy policy, a terms of service and a website URL on a verified domain, and refuses a GitHub URL for the obvious reason that nobody can put a record on `github.com`. A verified domain carries every URL beneath it, so the gateway serving those three pages at `gate.nordbye.it` (mortennordbye/reelsmith#55) means this record verifies all four at once.

Deleting it un-verifies the property, which stops TikTok publishing and invalidates the three URLs on the app record at the same time.

## Heads up: unrelated drift in this directory

`terraform plan` here shows **1 to add, 1 to change**. The change is not from this PR: it is the cache rule from #742, committed but never applied to Cloudflare.

```
~ description = "Cache HTML at the edge, excluding the infra API"
             -> "... and build assets"
~ expression  = ... and not starts_with(http.request.uri.path, "/_next/")
```

So apply this one with `-target` rather than a bare apply, unless you also want that cache change to go out now:

```
cd terraform/cloudflare/nordbye-it
terraform apply -target=cloudflare_dns_record.tiktok_verification_gate
```