### PR TITLE
feat(reelsmith): route the privacy, terms and index pages

### DIFF
--- a/k8s/talos/apps/reelsmith/httproute.yaml
+++ b/k8s/talos/apps/reelsmith/httproute.yaml
@@ -53,6 +53,28 @@ spec:
         - path:
             type: PathPrefix
             value: /healthz
+        # The privacy policy, the terms, and a page saying what the account is.
+        # Instagram, YouTube and TikTok all hold these URLs on their app
+        # records, and TikTok verified gate.nordbye.it by DNS record in order
+        # to accept them, so a 404 here is three broken app registrations
+        # rather than a missing page.
+        #
+        # **Exact, not PathPrefix, and "/" is why.** A PathPrefix of "/"
+        # matches every path there is, which turns this allowlist into a
+        # catch-all and puts /admin and /metrics back on the public internet.
+        # That is the one thing this file exists to prevent. The other two are
+        # Exact for the same reason rather than by habit: the pages are
+        # self-contained, with no assets served beneath them, so a prefix would
+        # buy nothing and widen the surface.
+        - path:
+            type: Exact
+            value: /
+        - path:
+            type: Exact
+            value: /privacy
+        - path:
+            type: Exact
+            value: /terms
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
## Why

The reelsmith gateway serves `/`, `/privacy` and `/terms` as of 0.0.64, and all three 404 from outside because this HTTPRoute is an allowlist and the paths were never added to it (mortennordbye/reelsmith#55 shipped the pages and missed this file, whose own comment says "Adding a route to the service means adding it here too").

The pod answers all three on `127.0.0.1:8000`, so the image is right and Traefik rejects them first:

```
kubectl -n reelsmith exec deploy/reelsmith-gateway -- python -c "
import urllib.request
for p in ('/','/privacy','/terms'):
    r=urllib.request.urlopen('http://127.0.0.1:8000'+p,timeout=5); print(p,r.status)"
# / 200
# /privacy 200
# /terms 200
```

That matters more than a missing page: Instagram, YouTube and TikTok each hold these URLs on their app records, and TikTok verified `gate.nordbye.it` by DNS record (#767) specifically in order to accept them.

## The one thing to check in review

**`Exact`, not `PathPrefix`, and `/` is the reason.** A `PathPrefix` of `/` matches every path there is, which would turn this allowlist into a catch-all and put `/admin` and `/metrics` back on the public internet — the one thing this file exists to prevent. The other two are `Exact` for the same reason rather than by habit: the pages are self-contained and serve nothing beneath them, so a prefix would buy nothing and widen the surface.

## Verification

- `kubectl apply --dry-run=server` accepts it.
- Parsed the result and asserted no `PathPrefix: /` entry exists, and that neither `/admin` nor `/metrics` appears in the allowlist.
- No image build needed; 0.0.64 is already running.