### PR TITLE
feat(reelsmith): allow the TikTok OAuth callback path

### DIFF
--- a/k8s/talos/apps/reelsmith/httproute.yaml
+++ b/k8s/talos/apps/reelsmith/httproute.yaml
@@ -75,6 +75,14 @@ spec:
         - path:
             type: Exact
             value: /terms
+        # TikTok's OAuth redirect target. The portal refuses to register a
+        # redirect URI that is not https, so the consent trip cannot land on a
+        # loopback listener and lands here instead; the page prints the
+        # authorisation code and the operator pastes it back into
+        # scripts/tiktok_authorise.py. Exact, like the three above.
+        - path:
+            type: Exact
+            value: /tiktok/callback
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
## Why

TikTok's developer portal refuses to register an OAuth redirect URI that does not begin with `https://`, and loopback is not an exception. The reelsmith consent trip therefore cannot land on a local listener; it lands on `GET /tiktok/callback` on the gateway, which prints the authorisation code for the operator to paste back into the CLI.

`httproute.yaml` is an allowlist, so a route shipping in the image is not reachable until it is named here. Without this the consent trip lands on a 404 and the authorisation is spent.

## What

One `Exact` match for `/tiktok/callback`, alongside `/`, `/privacy` and `/terms`. `Exact` rather than `PathPrefix` for the same reason those are: a prefix widens the surface on the one file that exists to keep `/admin` and `/metrics` off the public internet.

Pairs with mortennordbye/reelsmith#57, which adds the page.

## Verification

After sync, `https://gate.nordbye.it/tiktok/callback` should answer 200 and `https://gate.nordbye.it/admin` should still answer 404. The second check is the one that proves the allowlist held.