### PR TITLE
feat(reelsmith): allow /facebook/callback through the public route

### DIFF
--- a/k8s/talos/apps/reelsmith/httproute.yaml
+++ b/k8s/talos/apps/reelsmith/httproute.yaml
@@ -54,9 +54,9 @@ spec:
             type: PathPrefix
             value: /healthz
         # The privacy policy, the terms, and a page saying what the account is.
-        # Instagram, YouTube and TikTok all hold these URLs on their app
-        # records, and TikTok verified gate.nordbye.it by DNS record in order
-        # to accept them, so a 404 here is three broken app registrations
+        # Instagram, YouTube, TikTok and Facebook all hold these URLs on their
+        # app records, and TikTok verified gate.nordbye.it by DNS record in
+        # order to accept them, so a 404 here is four broken app registrations
         # rather than a missing page.
         #
         # **Exact, not PathPrefix, and "/" is why.** A PathPrefix of "/"
@@ -83,6 +83,18 @@ spec:
         - path:
             type: Exact
             value: /tiktok/callback
+        # Facebook's OAuth redirect target, added 2026-08-27 with the Page
+        # publishing path. Facebook does allow a localhost redirect while an
+        # app is in development, and the app that publishes these Reels is
+        # live, so the Page consent trip lands here alongside TikTok's.
+        #
+        # This line is the whole reason the trip 404s without it, and the
+        # reelsmith CLAUDE.md already recorded that trap from the TikTok
+        # rollout. Adding a route to the service means adding it here too, as
+        # the header of this file says.
+        - path:
+            type: Exact
+            value: /facebook/callback
       backendRefs:
         - group: ""
           kind: Service


### PR DESCRIPTION
## Why

The reelsmith gateway gained a Facebook Page publishing path
(mortennordbye/reelsmith#67), now deployed as `0.0.77`. Its OAuth redirect
target is `/facebook/callback`, and the allowlist in `httproute.yaml` does not
carry it, so the consent trip 404s at Traefik before reaching the pod.

This is the same trap the TikTok rollout hit, and the reelsmith `CLAUDE.md`
already records it: "The httproute allowlist has to carry the path or the
consent trip lands on a 404." The header of `httproute.yaml` says the same
thing in general terms.

## What

One `Exact` match beside the TikTok one, with a comment explaining why it
exists. `Exact` rather than `PathPrefix`, for the reason the file already
gives: a prefix widens the surface for nothing, and the whole point of this
allowlist is keeping `/admin` and `/metrics` off the public internet.

Also corrects the comment above the legal pages, which said three platforms
hold those URLs on file. It is four now.

## Verification

The manifest parses and the resulting path list is the nine existing entries
plus `Exact /facebook/callback`. Nothing else changes: same backend, same
hostname, same parentRef.

Publishing does not depend on this. Registration goes to `/api`, which is
already allowed, and the authorisation code arrives in the address bar whether
the page renders or not. What this fixes is the page meant to display it.
