### PR TITLE
feat(reelsmith): give the Facebook Page a publishing slot

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -74,10 +74,19 @@ data:
   # and parse_slots fails the boot on a line it cannot read rather than
   # dropping it, so this line and the image carrying it have to ship in that
   # order. Adding it ahead of 0.0.29 crashlooped the pod once already.
+  # Facebook is one a day for none of the three reasons above. There is no
+  # policy pressure and the documented ceiling is 30 API posts per 24 hours.
+  # It is one a day because it is the same identity showing the same video to
+  # the same audience, and the cadence decision of 2026-08-27 applies to every
+  # surface rather than being argued per platform.
+  #
+  # The Page id, not the number on the Page's own profile URL. A Page shows
+  # two, and /{page-id}/video_reels wants the one GET /me/accounts returns.
   GATEWAY_SLOTS: |
     08:10 Europe/Oslo jitter=15 account=17841441696714445
     08:10 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
     08:10 Europe/Oslo jitter=15 account=-000y6NKYZ3EEbUGgXiyJ9nG66a_xqrF68Me
+    08:10 Europe/Oslo jitter=15 account=1236596692875712
 
   # Named zone, not an offset, so the slots stay at the same local hour across
   # a daylight saving change.


### PR DESCRIPTION
## Why

The gateway's Facebook publishing path shipped in mortennordbye/reelsmith#67
and is deployed as `0.0.77`. Without a slot the Page is registered and fed by
the fan-out but nothing ever publishes it.

## What

One line, `08:10 Europe/Oslo jitter=15 account=1236596692875712`, matching the
other three. One a day for none of the three reasons the comments above already
give: there is no policy pressure here and the documented ceiling is 30 API
posts per 24 hours. It is one a day because it is the same identity showing the
same video to the same audience, and the cadence decision of 2026-08-27 applies
to every surface rather than being argued per platform.

The id is the one `GET /me/accounts` returns. A Page shows two, and the number
on its own profile URL is not the one `/{page-id}/video_reels` accepts.

## Verification

The ConfigMap parses and yields four slot lines, each naming an account.

Deliberately safe to merge before the account is registered with the gateway,
which is still outstanding:

- Every line carries `account=`, so nothing is unresolved and the F0 freeze
  that this file's comments describe does not trigger.
- `schedule_slots.ig_user_id` is plain TEXT with no foreign key, so the row
  inserts cleanly.
- `scheduler.tick_once` iterates `active_accounts` and then each account's
  slots, so a slot belonging to an account that does not exist yet is never
  visited. It begins firing when the registration lands.
