### PR TITLE
feat(reelsmith): turn on TikTok Direct Post for the audit

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -128,12 +128,26 @@ data:
   # @thenightlybuild is one of them.
   GATEWAY_TIKTOK_ENABLED: "true"
 
-  # Direct Post or the inbox. Direct Post needs an audit that reviews a posting
-  # screen this project does not have, and whose guidelines reject apps
-  # "designed for private/personal use only", so a no is the expected answer.
-  # The inbox path needs no audit and drops the video into the creator's drafts
-  # for one tap, which is the only thing that actually publishes before then.
-  GATEWAY_TIKTOK_DIRECT_POST: "false"
+  # Direct Post or the inbox. On since 2026-08-28, and what changed is that the
+  # posting screen it always needed now exists: the admin panel's queue gained
+  # a Publish now button that morning, which is a user interface performing a
+  # Content Posting API call and therefore something a demo video can be
+  # recorded of. The audit is applied for on that basis.
+  #
+  # **Turning this on is what the demo video has to show.** Recording the inbox
+  # path to justify a video.publish scope would show the reviewer a different
+  # feature from the one being requested.
+  #
+  # Safe before the audit lands only because GATEWAY_TIKTOK_PRIVACY_LEVEL below
+  # is SELF_ONLY. An unaudited client asking for anything more public is
+  # refused with unaudited_client_can_only_post_to_private_accounts. So the
+  # posts this makes are real posts on the profile that only the account can
+  # see: worse than the inbox tap for reach, better for proving the wiring.
+  #
+  # **If the audit is refused, this goes back to "false"**, and video.publish
+  # comes back out of SCOPES in scripts/tiktok_authorise.py, which needs a
+  # fresh consent trip to take effect.
+  GATEWAY_TIKTOK_DIRECT_POST: "true"
 
   # What an unaudited client is allowed to ask for. It also has to be one of
   # the options the creator_info call returns, or the post fails


### PR DESCRIPTION
## Why

TikTok's inbox path costs a manual tap in the mobile app every day, and the audit is the only sanctioned way to remove it. The audit is now applied for, and this flag is the last thing standing between the integration and a direct post.

**What changed is that the posting screen this always needed now exists.** The admin panel's queue gained a **Publish now** button on 2026-08-28 — a user interface performing a real Content Posting API call, and therefore something the demo video TikTok's app review demands can be recorded of. Before that there was no UI at all, which is why `CLAUDE.md` in the reelsmith repo called the sandbox permanent.

**Turning this on is what the demo video has to show.** Recording the inbox path to justify a `video.publish` scope would be showing the reviewer a different feature from the one being requested.

## Already done, so this is the only step left

- Direct Post switched on for **both** the production and the sandbox configurations in TikTok's portal. The sandbox one matters: that is the client key the gateway authenticates as.
- The consent trip ran and TikTok granted `user.info.basic,video.publish,video.list,video.upload` to `@thenightlybuild`. The `open_id` matched the existing account.
- The rotated refresh token is stored and verified against `creator_info`, which answers as the right account.
- The inbox path kept working across all of it, because `video.upload` is still granted.

## Safety

Safe before the audit lands **only because `GATEWAY_TIKTOK_PRIVACY_LEVEL` is `SELF_ONLY`**, which this PR does not touch. An unaudited client asking for anything more public is refused with `unaudited_client_can_only_post_to_private_accounts`.

So the posts this makes are real posts on the profile that **only the account holder can see**: worse than the inbox tap for reach, better for proving the wiring. That trade is deliberate and lasts until the audit is decided.

## If the audit is refused

This goes back to `"false"`, and `video.publish` comes back out of `SCOPES` in `scripts/tiktok_authorise.py` (reelsmith), which needs a fresh consent trip to take effect. The switch and that line move together or the authorisation fails outright — TikTok rejects a request for a scope the app does not hold rather than dropping it quietly.

## Merging this deploys

The gateway picks the configmap up on sync and restarts. Worth keeping out of the 06:10 UTC slot window, per the rule in the reelsmith `CLAUDE.md`.
