### PR TITLE
seo(blog): add an About page and finish the internal link graph

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -245,6 +245,20 @@ Known gaps the team has agreed to leave for later. Each entry: **what**, **why d
 - **Unblock:** Decide which are worth keeping and add them to `.backup-manifest`. The persona markdown files are ~28K and clearly worth it; the 234M `slackdump_20260602_122707.zip` next to them probably is not, and may not belong on the laptop at all given it is a Slack export.
 - **Where:** `.backup-manifest`, `ai/projects/jarvis/`, `ai/prompts/erlendgpt/`.
 
+## Blog
+
+### Every post renders its title twice as an H1
+- **What:** The Northlight theme emits `<h1 class="article-title">` from the front-matter title, and every post also opens its markdown body with `# Same Title`. All seven posts under `blog/content/blog/**` therefore serve two identical H1 elements. Confirmed on the live site: `curl https://blog.nordbye.it/blog/lawless-waf/ | grep -o "<h1[^>]*>"` returns 2. The new `blog/content/about.md` deliberately omits the markdown heading and serves one.
+- **Why deferred:** Fixing it means deleting the leading `# Title` line from seven published posts, which changes what every one of them looks like (the title stops appearing twice on screen). That is a visible design change across the whole blog rather than a config fix, and it was not part of the agreed scope.
+- **Unblock:** Decide whether the title should render once. If yes, drop the first `# ...` line from each post body and rebuild; nothing else references those headings, though check that no post's table of contents or anchor link points at the removed heading id first.
+- **Where:** `blog/content/blog/*/index.md` (first heading line of each), `blog/themes/northlight/layouts/_partials/article-head.html` for the theme-side H1.
+
+### `content/series/_index.md` is orphaned
+- **What:** The file exists and carries a `noindex` cascade, but `config/_default/config.toml` deliberately does not register a `series` taxonomy (there is a comment saying so), so Hugo generates no series pages for it to apply to. It was added alongside the tag noindex in `c3f5031c`.
+- **Why deferred:** Harmless where it sits, and deleting a file someone added on purpose is a judgement call. It also becomes correct again the day a series is registered.
+- **Unblock:** Either register the `series` taxonomy or delete the file.
+- **Where:** `blog/content/series/_index.md`, `blog/config/_default/config.toml`.
+
 ## Media stack observability (arr-stack)
 
 ### Discord alert rules for the media stack

--- a/blog/config/_default/config.toml
+++ b/blog/config/_default/config.toml
@@ -19,10 +19,11 @@ home = ["HTML", "RSS", "JSON"]
 [taxonomies]
 tag = "tags"
 
+# `changefreq` and `priority` are deliberately unset. Google ignores both, and
+# every URL here claiming a daily change was a claim the crawler can check and
+# find false: none of these posts change after publication.
 [sitemap]
-changefreq = "daily"
 filename = "sitemap.xml"
-priority = 0.5
 
 # -- Related content --
 # Required for params.article.showRelated. Hugo's default indices cover

--- a/blog/config/_default/menus.en.toml
+++ b/blog/config/_default/menus.en.toml
@@ -4,6 +4,11 @@ pageRef = "blog"
 weight = 10
 
 [[main]]
+name = "About"
+pageRef = "about"
+weight = 20
+
+[[main]]
 name = "Portfolio"
 url = "https://nordbye.it/"
 weight = 25

--- a/blog/content/about.md
+++ b/blog/content/about.md
@@ -1,0 +1,32 @@
+---
+title: "About"
+description: "Morten Victor Nordbye, cloud engineer in Oslo. Who writes this blog, the cluster the posts come from, and why any of it should be trusted."
+# The theme only honours showTableOfContents and showHero per page. The rest of
+# the article toggles (author, word count, comments, sharing) are read from site
+# config, so setting them here would be dead front matter.
+showTableOfContents: false
+---
+
+I am Morten Victor Nordbye, a cloud engineer in Oslo. This blog is where the things I have had to work out get written down properly, usually because I could not find a straight answer when I needed one.
+
+## The day job
+
+I work at Orange Business, placed onto customer engagements. Most of 2026 has gone into an Azure migration for a betting platform, where I took over architect responsibility in April, moved around 30 .NET microservices off Windows Server onto AKS, and built the observability stack and production alerting in Terraform. Traffic peaks above 33 million requests a day on betting days.
+
+Part of that migration was moving off ingress-nginx onto Traefik and the Gateway API. Serving several TLS certificates from one listener needed a workaround at the time, so I wrote the upstream patch that taught Gateway API to resolve multiple certificate secrets on a single listener. It shipped in Traefik v3.7.0.
+
+Certifications, if that is what you came for: [CKA](https://nordbye.it/pdf/CKA.pdf), [LFS458](https://nordbye.it/pdf/LFS458.pdf), and Azure Solutions Architect Expert. The full history sits on [nordbye.it](https://nordbye.it/).
+
+## The cluster the posts come from
+
+Almost everything here is written from a homelab rather than from a customer environment, because I can show you the actual files.
+
+It is a Talos Kubernetes cluster running as VMs on Proxmox, provisioned with Terraform and reconciled by ArgoCD. Cilium handles networking and policy, Traefik serves traffic through the Gateway API, and cert-manager, External Secrets Operator and Falco cover certificates, secrets and runtime security. Metrics, logs and traces go to kube-prometheus-stack, Loki and Tempo, read through Grafana. Storage is Proxmox CSI for block and a Synology over NFS for anything shared.
+
+All of it is public in the [Homelab repository](https://github.com/mortennordbye/Homelab), including the manifests that run this blog. When a post shows you a config, that is the config that is running, and you can go and read the rest of the file.
+
+## What gets written about
+
+Kubernetes, networking, observability, and the parts of running infrastructure that are tedious enough that nobody writes them down. Posts tend to come out of something breaking, so they usually include what I got wrong first.
+
+If you want to argue with something here, [LinkedIn](https://www.linkedin.com/in/morten-nordbye-325bb71bb) or an issue on the repo both work.

--- a/blog/content/blog/cilium-network-policy-rollout/index.md
+++ b/blog/content/blog/cilium-network-policy-rollout/index.md
@@ -333,6 +333,8 @@ All pod-to-pod traffic that crosses a node boundary is now WireGuard-encrypted. 
 
 Network policy used to be a thing you put off forever because the failure mode was "the cluster mysteriously stops working." Audit mode plus Hubble flips that. You ship policies you're 80% sure about, watch Hubble for a day, fix the 20% you got wrong, and turn enforcement on with no drama.
 
+The [public Headroom demo](/blog/headroom/) is one of these in production. No login, exposed on the internet, and a policy written this way is most of what keeps it boring.
+
 Default-flat is a Kubernetes convention. It is not a Kubernetes requirement. Lock yours down.
 
 Now go open the Hubble tab.

--- a/blog/content/blog/headroom/index.md
+++ b/blog/content/blog/headroom/index.md
@@ -290,7 +290,7 @@ There is no login, and yet an instance of it sits on the public internet. That w
 
 `DEMO_MODE=1` refuses every non-GET under `/api/`, refuses the whole `/api/bank/*` namespace (its GETs are not safe reads, one proxies to Enable Banking on the instance's own credentials), fills the client from a browser-generated dataset, and skips the background jobs. Enforced server-side in [`server/demo.js`](https://github.com/mortennordbye/headroom/blob/main/server/demo.js).
 
-I did not want that to be the only thing between a stranger and a bank API.
+I did not want that to be the only thing between a stranger and a bank API. A CiliumNetworkPolicy sits under it, rolled out the way I [put policies on the rest of the cluster](/blog/cilium-network-policy-rollout/). Audit mode with Hubble first, then default-deny.
 
 **Full file:** [`k8s/talos/apps/headroom-demo/ciliumnetworkpolicy.yaml`](https://github.com/mortennordbye/Homelab/blob/main/k8s/talos/apps/headroom-demo/ciliumnetworkpolicy.yaml)
 
@@ -339,6 +339,6 @@ I built this for myself, and the surprise was how much of the value sits in the 
 
 Knowing what a decade of my own raises did against CPI changed what I say in February. That 1 560 of my 1 950 hours are the billable ones changed how I read a rate, and that 13 521 of an 18 166 payment is interest changed how I feel about paying extra.
 
-You do not need [Headroom](https://github.com/mortennordbye/headroom) for any of that. You need the numbers in front of you often enough that you stop guessing, and getting there should not cost a monthly fee. The [manifests that run it](https://github.com/mortennordbye/Homelab/tree/main/k8s/talos/apps/headroom) are in the Homelab repo if you want the rest of the setup.
+You do not need [Headroom](https://github.com/mortennordbye/headroom) for any of that. You need the numbers in front of you often enough that you stop guessing, and getting there should not cost a monthly fee. The [manifests that run it](https://github.com/mortennordbye/Homelab/tree/main/k8s/talos/apps/headroom) are in the Homelab repo if you want the rest of the setup, and they reach the cluster the same way [this blog does](/blog/i-have-a-blog/), through GitHub Actions and ArgoCD.
 
 Headroom does the maths school skipped. The volume of a cone is still your problem.

--- a/blog/content/blog/lawless-waf/index.md
+++ b/blog/content/blog/lawless-waf/index.md
@@ -106,4 +106,6 @@ lawless-waf has no application-level login. Access control leans entirely on you
 
 Tuning a WAF is one of those jobs that is easy to postpone because the feedback loop is slow and the logs are expensive to poke at. Point a diagnostic setting at a storage account, move the analysis there, and the cost of looking drops to zero. You look more often, you tune sooner, and the customer who got blocked this morning is unblocked before lunch.
 
+The same trade-off shows up inside a cluster, where I keep [Loki on a 24 hour retention window](/blog/observability-stack/) rather than pay to store logs nobody reads.
+
 The whole thing is Apache-2.0 and [on GitHub](https://github.com/mortennordbye/lawless-waf). Clone it, run the demo, and point it at your own logs.

--- a/blog/content/blog/observability-stack/index.md
+++ b/blog/content/blog/observability-stack/index.md
@@ -277,7 +277,7 @@ The OOM one is the kind of thing you only learn by getting it wrong. The metric 
 
 I have made every one of these.
 
-**Copying my retention numbers without thinking.** 24h of logs and traces suits me because I debug in near-real-time and nothing here is under audit. Under a compliance requirement, or chasing an incident days later, 24h is too short and the line you need is already gone.
+**Copying my retention numbers without thinking.** 24h of logs and traces suits me because I debug in near-real-time and nothing here is under audit. Under a compliance requirement, or chasing an incident days later, 24h is too short and the line you need is already gone. Where the window has to stay long, move the reading somewhere cheap instead, which is the argument behind [querying archived WAF logs straight off a storage account](/blog/lawless-waf/).
 
 **Putting high-write data on network storage.** Logs and traces are written constantly, so point them at NFS and you will feel it. High-write pillars on local block storage, the metrics you want to keep on durable network storage.
 


### PR DESCRIPTION
## Why

Search Console reports 0 of 16 blog URLs indexed, with a single reason: "Crawled - currently not indexed". URL inspection on a post shows crawl allowed, page fetch successful, indexing allowed, and the user-declared canonical matching Google's selected canonical. Nothing technical is blocking it.

What is missing is authority. The Links report for `sc-domain:blog.nordbye.it` shows 0 external and 0 internal links. Cloudflare shows 230 visits over 30 days (LinkedIn 60, GitHub 30, portfolio 10, direct 120) and not one from a search engine. LinkedIn and GitHub both mark outbound links nofollow, which is why real referral traffic coexists with zero recorded links.

This removes the remaining on-site objections. It does not fix the link problem, which is not a code problem.

## What

An About page at `blog/content/about.md`, added to the main menu. Identified authorship, the upstream Gateway API patch released in Traefik v3.7.0, CKA and LFS458 linked to the certificates on nordbye.it, and a description of the cluster the posts come from. The site had no author page.

Five internal links finishing the pass started in c3f5031c. That commit ran on 16 July; `lawless-waf` and `headroom` were published after it, had no outgoing internal links, and nothing linked forward to them. Both directions are now closed.

`changefreq` and `priority` dropped from the sitemap config. Google ignores both, and claiming a daily change on posts that never change is a claim the crawler can check.

Two findings left unfixed and recorded in `BACKLOG.md` under a new Blog section: every post renders its title twice as an H1 (theme plus markdown body), and `content/series/_index.md` is orphaned against a taxonomy config deliberately does not register.

## Verification

Built with the pinned `ghcr.io/gohugoio/hugo:v0.165.0` from the Dockerfile and served locally.

- 84 pages, same as before the change, no build errors
- `/about/` returns 200 with a single `h1`, correct meta description and canonical, and appears in the menu
- all five new internal links resolve to real files; no dead internal hrefs anywhere in the build
- sitemap now carries 10 URLs including `/about/`, with no `changefreq` or `priority`
- `/tags/gitops/` keeps its `noindex, follow`
- `markdownlint-cli2` over `blog/content/**/*.md`: 0 issues, run with the same image CI uses

Checked in a browser: the About page and the edited ending of the Cilium post.