### PR TITLE
feat(tailscale): declarative subnet router and remote access docs

### DIFF
--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,0 +1,73 @@
+# Remote access: Tailscale, with WireGuard as break-glass
+
+Remote access to the homelab runs over Tailscale. Nothing listens on the WAN
+for it: every device makes outbound connections to the tailnet, and a small
+subnet-router VM on Proxmox advertises the LAN. The UniFi gateway's built-in
+WireGuard server is kept as the break-glass path for when Proxmox itself is
+down — it is the only remaining inbound port, and it is used for nothing else.
+
+```
+phone / laptop (anywhere)
+      │  outbound WireGuard, NAT-traversed
+      ▼
+  tailnet nordbye.it ────────────────────▶ tailscale-router VM (10.3.10.40)
+      │                                      Proxmox, vmid 140
+      │ advertises 10.3.10.0/24              outside the k8s cluster
+      ▼
+  UniFi gw .1 · Proxmox nodes .1x · Talos .31-.36 · VIPs .30 / .100-.103
+
+break-glass: WireGuard server on the UniFi gateway (WAN UDP port)
+```
+
+Everything is declared in `terraform/proxmox/hyper-cluster/tailscale/`:
+
+- the router VM itself — Debian 13 genericcloud image, cloud-init installs
+  Tailscale and joins with a single-use auth key minted in the same plan;
+- the entire tailnet policy file (`tailscale_acl`): tag definitions, an
+  `autoApprovers` rule so the advertised route comes up approved with no
+  console click, the access rules, and the Tailscale SSH rule. The resource
+  owns the whole file, so policy changes happen in Terraform — a console edit
+  is drift and gets overwritten on the next apply;
+- split DNS: `local.bigd.no` resolves via the UniFi gateway for tailnet
+  clients, so internal hostnames work remotely.
+
+The VM deliberately lives outside the Kubernetes cluster. The cluster is a
+moving target (Talos upgrades, node rebuilds), and remote access must work
+precisely when it is mid-upgrade or broken. For the same reason the Tailscale
+Kubernetes operator was considered and rejected as the router; it remains an
+option later for exposing individual Services by tailnet name.
+
+## What could not be declared
+
+- The tailnet itself: created interactively at signup (identity
+  `morten@nordbye.it`). Tailscale has no email accounts; the tailnet hangs off
+  an identity provider, so that provider's MFA hygiene is network security.
+- A one-time `tagOwners` bootstrap: `tag:subnet-router` had to exist in the
+  policy before an OAuth client could be scoped to it. After that, the policy
+  was imported (`terraform import tailscale_acl.tailnet acl` — the provider
+  refuses to overwrite a non-default policy) and Terraform owns it.
+- The OAuth client (Trust credentials in the admin console) with write scope
+  on Auth Keys (`tag:subnet-router`), Policy File and DNS. Its id and secret
+  live only in the root's gitignored `terraform.tfvars`.
+- The cloud-init snippet upload goes over SSH, not the Proxmox API, and the
+  bpg provider only takes ssh-agent keys or an explicit password. The hyper
+  nodes do not trust the laptop's key, so `proxmox_ssh_password` is set in
+  `terraform.tfvars`.
+
+An LXC instead of a VM was ruled out: Tailscale needs `/dev/net/tun` passed
+through, which is a raw `lxc.*` config line the bpg provider cannot declare
+(bpg/terraform-provider-proxmox#1801).
+
+## Operations
+
+- Recreating the VM: the join key is single-use and expires after 90 days, so
+  a rebuild needs `terraform apply -replace=tailscale_tailnet_key.router`
+  alongside the VM. Tagged devices themselves never key-expire.
+- The image and snippet live on `nfs-vmstore` (shared, already serves the ISO
+  and Snippets content types), so the VM is not pinned to one node's storage.
+- Break-glass discipline: keep a WireGuard profile installed on the phone and
+  test it occasionally from cellular — a fallback that has rotted is not one.
+- Tailnet lock is not enabled. It would make a hijacked Tailscale account
+  unable to add devices silently, but every Terraform-created node would then
+  need a manual `tailscale lock sign` from a trusted device before it works.
+  Revisit if the tailnet ever gets more users than one.

--- a/terraform/proxmox/hyper-cluster/tailscale/README.md
+++ b/terraform/proxmox/hyper-cluster/tailscale/README.md
@@ -1,0 +1,54 @@
+# Tailscale subnet router
+
+A minimal Debian VM on Proxmox that joins the tailnet and advertises the LAN
+(`10.3.10.0/24`), so phones and laptops on Tailscale reach Proxmox, the UniFi
+console and every cluster VIP without anything installed on those targets.
+
+Deliberately a VM outside the Kubernetes cluster: remote access must survive
+cluster upgrades and outages. The UniFi WireGuard server stays as break-glass
+for when Proxmox itself is down.
+
+This root also owns tailnet-side config declaratively:
+
+- the policy file (`tailscale_acl`): tag definitions, route auto-approval, and
+  the access rules. Console edits drift and get overwritten - change it here.
+- split DNS: `local.bigd.no` resolves via the LAN nameserver for tailnet clients.
+- the single-use auth key the VM consumes on first boot.
+
+## One-time bootstrap
+
+1. In the Tailscale admin console (Access controls), add the tag owner so an
+   OAuth client can be scoped to it:
+
+   ```json
+   "tagOwners": { "tag:subnet-router": ["autogroup:admin"] }
+   ```
+
+2. Create an OAuth client (Settings > Keys) with write scope on
+   Keys: Auth Keys (select `tag:subnet-router`), Policy File, and DNS.
+   Put the id and secret in `terraform.tfvars`.
+
+The cloud image and cloud-init snippet land on `nfs-vmstore`, which already
+serves the ISO image and Snippets content types.
+
+## Apply
+
+```bash
+terraform -chdir=terraform/proxmox/hyper-cluster/tailscale init
+terraform -chdir=terraform/proxmox/hyper-cluster/tailscale plan
+terraform -chdir=terraform/proxmox/hyper-cluster/tailscale apply   # requires explicit approval
+```
+
+First boot takes a few minutes: apt update, Tailscale install, then
+`tailscale up`. The machine appears in the admin console as `tailscale-router`
+with its route already approved.
+
+## Caveats
+
+- The auth key lands in the tfstate and in the cloud-init snippet on Proxmox
+  storage. It is single-use, tag-scoped and expires after 90 days; the state
+  backend already holds far more sensitive material (Talos PKI).
+- Recreating the VM after the key is consumed or expired needs a fresh key:
+  `terraform apply -replace=tailscale_tailnet_key.router` together with the VM.
+- Key expiry for the router's node is disabled by Tailscale automatically for
+  tagged devices, so the device itself never expires.

--- a/terraform/proxmox/hyper-cluster/tailscale/cloud-init.yaml.tftpl
+++ b/terraform/proxmox/hyper-cluster/tailscale/cloud-init.yaml.tftpl
@@ -1,0 +1,16 @@
+#cloud-config
+hostname: tailscale-router
+package_update: true
+packages:
+  - qemu-guest-agent
+  - curl
+write_files:
+  - path: /etc/sysctl.d/99-tailscale.conf
+    content: |
+      net.ipv4.ip_forward = 1
+      net.ipv6.conf.all.forwarding = 1
+runcmd:
+  - systemctl enable --now qemu-guest-agent
+  - sysctl -p /etc/sysctl.d/99-tailscale.conf
+  - ["sh", "-c", "curl -fsSL https://tailscale.com/install.sh | sh"]
+  - ["tailscale", "up", "--authkey=${authkey}", "--advertise-routes=${routes}"]

--- a/terraform/proxmox/hyper-cluster/tailscale/main.tf
+++ b/terraform/proxmox/hyper-cluster/tailscale/main.tf
@@ -1,0 +1,88 @@
+resource "proxmox_download_file" "debian_image" {
+  node_name    = var.proxmox_node
+  content_type = "iso"
+  datastore_id = var.snippets_datastore
+  # The .img extension makes Proxmox accept a qcow2 as an importable disk image.
+  file_name = "debian-13-genericcloud-amd64.img"
+  url       = "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
+  overwrite = false
+
+  lifecycle {
+    ignore_changes = [url] # "latest" moves; the VM keeps the image it booted from
+  }
+}
+
+resource "proxmox_virtual_environment_file" "cloud_init" {
+  node_name    = var.proxmox_node
+  content_type = "snippets"
+  datastore_id = var.snippets_datastore
+
+  source_raw {
+    file_name = "tailscale-router-cloud-init.yaml"
+    data = templatefile("${path.module}/cloud-init.yaml.tftpl", {
+      authkey = tailscale_tailnet_key.router.key
+      routes  = join(",", var.advertised_routes)
+    })
+  }
+}
+
+resource "proxmox_virtual_environment_vm" "tailscale_router" {
+  name        = "tailscale-router"
+  node_name   = var.proxmox_node
+  vm_id       = var.vm_id
+  description = "Tailscale subnet router: advertises the LAN to the tailnet"
+  tags        = ["tailscale"]
+  on_boot     = true
+
+  machine       = "q35"
+  scsi_hardware = "virtio-scsi-single"
+  bios          = "seabios"
+
+  agent {
+    enabled = true
+  }
+
+  cpu {
+    cores = 1
+    type  = "host"
+  }
+
+  memory {
+    dedicated = 1024
+  }
+
+  network_device {
+    bridge = "vmbr0"
+  }
+
+  disk {
+    datastore_id = var.datastore
+    interface    = "scsi0"
+    size         = 10
+    file_format  = "raw"
+    discard      = "on"
+    ssd          = true
+    file_id      = proxmox_download_file.debian_image.id
+  }
+
+  boot_order = ["scsi0"]
+
+  # Debian cloud images log to the serial console.
+  serial_device {}
+
+  operating_system {
+    type = "l26"
+  }
+
+  initialization {
+    datastore_id      = var.datastore
+    user_data_file_id = proxmox_virtual_environment_file.cloud_init.id
+
+    ip_config {
+      ipv4 {
+        address = "${var.router_ip}/${var.network_subnet_mask}"
+        gateway = var.network_gateway
+      }
+    }
+  }
+}

--- a/terraform/proxmox/hyper-cluster/tailscale/providers.tf
+++ b/terraform/proxmox/hyper-cluster/tailscale/providers.tf
@@ -1,0 +1,17 @@
+provider "proxmox" {
+  endpoint  = var.proxmox_endpoint
+  insecure  = var.proxmox_insecure
+  api_token = var.proxmox_api_token
+
+  # Uploading the cloud-init snippet goes over SSH, not the API.
+  ssh {
+    agent    = var.proxmox_ssh_password == "" ? true : false
+    username = var.proxmox_ssh_username
+    password = var.proxmox_ssh_password != "" ? var.proxmox_ssh_password : null
+  }
+}
+
+provider "tailscale" {
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+}

--- a/terraform/proxmox/hyper-cluster/tailscale/tailscale.tf
+++ b/terraform/proxmox/hyper-cluster/tailscale/tailscale.tf
@@ -1,0 +1,55 @@
+# Owns the ENTIRE tailnet policy file. Edits made in the admin console will be
+# overwritten on the next apply; change policy here instead.
+resource "tailscale_acl" "tailnet" {
+  acl = jsonencode({
+    tagOwners = {
+      "tag:subnet-router" = ["autogroup:admin"]
+    }
+
+    # Routes the subnet router advertises come up approved, no console click.
+    autoApprovers = {
+      routes = {
+        for route in var.advertised_routes : route => ["tag:subnet-router"]
+      }
+    }
+
+    # Tailscale's default open policy: every tailnet member reaches everything.
+    # Tighten when non-admin users join (family devices scoped to Home Assistant).
+    grants = [
+      {
+        src = ["*"]
+        dst = ["*"]
+        ip  = ["*"]
+      }
+    ]
+
+    # Default Tailscale SSH rule: members may SSH to their own devices,
+    # with a re-auth check each session.
+    ssh = [
+      {
+        action = "check"
+        src    = ["autogroup:member"]
+        dst    = ["autogroup:self"]
+        users  = ["autogroup:nonroot", "root"]
+      }
+    ]
+  })
+}
+
+resource "tailscale_tailnet_key" "router" {
+  description   = "tailscale-router cloud-init join key"
+  reusable      = false
+  ephemeral     = false
+  preauthorized = true
+  expiry        = 7776000 # 90 days; only consumed once at first boot
+
+  tags = ["tag:subnet-router"]
+
+  # The tag must exist in the policy before a key can carry it.
+  depends_on = [tailscale_acl.tailnet]
+}
+
+resource "tailscale_dns_split_nameservers" "internal" {
+  domain      = var.internal_domain
+  nameservers = [var.internal_dns_server]
+}

--- a/terraform/proxmox/hyper-cluster/tailscale/terraform.tfvars.example
+++ b/terraform/proxmox/hyper-cluster/tailscale/terraform.tfvars.example
@@ -1,0 +1,14 @@
+# Copy to terraform.tfvars and fill in. *.tfvars is gitignored.
+
+# Proxmox Configuration (same token as the talos root)
+proxmox_endpoint     = "https://proxmox.example.local:8006"
+proxmox_api_token    = "terraform-prov@pve!token=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+proxmox_insecure     = true
+proxmox_ssh_username = "root"
+proxmox_ssh_password = "" # empty = use ssh-agent; set to the node's root password otherwise
+
+# Tailscale OAuth client. Create it in the admin console AFTER the one-time
+# tag bootstrap described in the README, with write scope on:
+#   Keys: Auth Keys (tag:subnet-router), Policy File, DNS
+tailscale_oauth_client_id     = ""
+tailscale_oauth_client_secret = ""

--- a/terraform/proxmox/hyper-cluster/tailscale/variables.tf
+++ b/terraform/proxmox/hyper-cluster/tailscale/variables.tf
@@ -1,0 +1,101 @@
+variable "proxmox_endpoint" {
+  description = "Proxmox API URL"
+  type        = string
+}
+
+variable "proxmox_insecure" {
+  description = "Skip TLS verification"
+  type        = bool
+  default     = true
+}
+
+variable "proxmox_api_token" {
+  description = "Proxmox API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_ssh_username" {
+  description = "SSH username for snippet upload"
+  type        = string
+  default     = "root"
+}
+
+variable "proxmox_ssh_password" {
+  description = "SSH password (empty = use agent)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "tailscale_oauth_client_id" {
+  description = "OAuth client with write scope on Keys:Auth Keys (tag:subnet-router), Policy File and DNS. See README for the one-time bootstrap."
+  type        = string
+  sensitive   = true
+}
+
+variable "tailscale_oauth_client_secret" {
+  description = "Secret for the OAuth client above"
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_node" {
+  description = "Proxmox node the router VM runs on"
+  type        = string
+  default     = "hyper1"
+}
+
+variable "vm_id" {
+  description = "Proxmox VM ID. Talos nodes hold 131-136."
+  type        = number
+  default     = 140
+}
+
+variable "datastore" {
+  description = "Datastore for the VM disk"
+  type        = string
+  default     = "local-lvm"
+}
+
+variable "snippets_datastore" {
+  description = "Datastore holding the cloud image and cloud-init snippet. Needs the ISO image and Snippets content types; nfs-vmstore has both."
+  type        = string
+  default     = "nfs-vmstore"
+}
+
+variable "router_ip" {
+  description = "Static LAN IP for the router VM"
+  type        = string
+  default     = "10.3.10.40"
+}
+
+variable "network_gateway" {
+  description = "Gateway IP"
+  type        = string
+  default     = "10.3.10.1"
+}
+
+variable "network_subnet_mask" {
+  description = "Subnet mask"
+  type        = string
+  default     = "24"
+}
+
+variable "advertised_routes" {
+  description = "LAN routes the router advertises to the tailnet. Auto-approved via the ACL's autoApprovers."
+  type        = list(string)
+  default     = ["10.3.10.0/24"]
+}
+
+variable "internal_domain" {
+  description = "Internal DNS zone resolved via split DNS on the tailnet"
+  type        = string
+  default     = "local.bigd.no"
+}
+
+variable "internal_dns_server" {
+  description = "LAN nameserver answering for the internal domain"
+  type        = string
+  default     = "10.3.10.1"
+}

--- a/terraform/proxmox/hyper-cluster/tailscale/version.tf
+++ b/terraform/proxmox/hyper-cluster/tailscale/version.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.111.1"
+    }
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.17"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "rg-tfstate-homelab"
+    storage_account_name = "sttfstatemvnhomelab"
+    container_name       = "tfstate"
+    key                  = "proxmox/hyper-cluster/tailscale.tfstate"
+  }
+}


### PR DESCRIPTION
## Why

Remote access ran over the UniFi WireGuard server, which needs an open WAN UDP port and per-device config files. Tailscale removes the inbound port entirely and scales to more devices and users, but only if the setup stays declarative like the rest of the repo.

## What

- New Terraform root `terraform/proxmox/hyper-cluster/tailscale/`: a Debian cloud-init VM on Proxmox that joins the tailnet with a single-use key minted in the same plan and advertises 10.3.10.0/24. The root also owns the full tailnet policy file (tags, route autoApprovers, access and SSH rules), and split DNS for local.bigd.no. Kept outside the k8s cluster so remote access survives cluster upgrades.
- `docs/remote-access.md`: architecture, the bootstrap steps that could not be declared, and operational notes. The UniFi WireGuard server stays as break-glass.

## Verification

Applied to the cluster: the router VM is live, the route is auto-approved, and LAN targets were reached from a phone on cellular through the tailnet. `terraform fmt -check`, `validate`, and a converged plan after apply.