### PR TITLE
ci: format and validate every terraform root

### DIFF
--- a/.github/workflows/ci-terraform.yaml
+++ b/.github/workflows/ci-terraform.yaml
@@ -1,0 +1,52 @@
+name: CI Terraform
+
+# Format and validate every Terraform root. Deliberately credential-free:
+# init runs with -backend=false, so no cloud auth, no state access and
+# nothing for a fork PR to steal. Plans and applies stay local -- the
+# Proxmox and UniFi APIs are LAN-only, and handing CI the state backend
+# would expose every root's state to a leaked workflow credential.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/ci-terraform.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/ci-terraform.yaml"
+
+concurrency:
+  group: ci-terraform-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt-validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Format check
+        run: terraform fmt -check -recursive -diff terraform/
+
+      # Roots are discovered rather than listed so a new root is covered the
+      # commit it lands. validate catches bad references and provider schema
+      # mismatches, which is most of what a local run catches before plan.
+      - name: Validate all roots
+        run: |
+          set -euo pipefail
+          roots=$(find terraform -name '*.tf' -exec dirname {} \; | sort -u)
+          for root in $roots; do
+            echo "::group::$root"
+            terraform -chdir="$root" init -backend=false -input=false > /dev/null
+            terraform -chdir="$root" validate
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Why

Terraform changes (including Renovate provider bumps) merge with no automated check; validation happens only when someone runs the tools locally.

## What

A single credential-free workflow: `terraform fmt -check` repo-wide, then `init -backend=false` and `validate` for every root. Roots are discovered with `find`, so a new root is covered the commit it lands. Triggers on `terraform/**` PRs and pushes to main. No cloud auth and no state access by construction; plans and applies stay local per the repo's safety rules.

## Verification

The exact fmt and validate loop was run locally: fmt clean, all seven roots validate OK.