### PR TITLE
chore(blog): promote 0.0.107 to prod

### DIFF
--- a/k8s/talos/apps/blog/kustomization.yaml
+++ b/k8s/talos/apps/blog/kustomization.yaml
@@ -18,4 +18,4 @@ resources:
 # deployment.yaml.
 images:
 - name: ghcr.io/mortennordbye/homelab/blog
-  newTag: 0.0.106
+  newTag: 0.0.107


### PR DESCRIPTION
## Why

Kargo's own promotion PR #837 has been sitting unmergeable since 2026-09-01. It was cut when blog prod was on `0.0.105` and changes `0.0.105` to `0.0.107`, but main moved to `0.0.106` in #801, so the change no longer applies and GitHub reports it as conflicting.

Blog stage is already on `0.0.107`, so the promotion itself is still the right one. This carries the same end state on a branch that applies cleanly.

## What

Sets the blog prod image tag to `0.0.107`, from `0.0.106`.

## Verification

The resulting `k8s/talos/apps/blog/kustomization.yaml` blob is `412a7df4`, byte for byte the object #837 was trying to produce. The diff against main is the single `newTag` line and nothing else.

`k8s/talos/apps/blog-stage/kustomization.yaml` already reads `0.0.107`, so this only moves prod up to the tag stage has been running.

## Follow-up

#837 should be closed once this merges. Kargo may not mark its own promotion complete, since it watches its PR rather than the branch content, so the next blog promotion may need a fresh Kargo run.