### PR TITLE
Mount the NAS share read-only for verksted's documents

### DIFF
--- a/k8s/talos/apps/verksted/deployment.yaml
+++ b/k8s/talos/apps/verksted/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             # share, which has its own backups.
             - name: VK_BACKUP_DIR
               value: /mnt/backups
+            # The documents the assistant may read: the whole NAS share, mounted
+            # read-only below. The text it extracts is written beside it on the
+            # PVC (DOCS_INDEX_DIR), never onto the share.
+            - name: DOCS_DIR
+              value: /mnt/shared
           # Ready means serving the SPA at /. timeoutSeconds above the 1s
           # default: a failed readiness check pulls the pod from the Service,
           # which drops every open terminal websocket.
@@ -85,6 +90,16 @@ spec:
             - name: shared-data
               mountPath: /mnt/backups
               subPath: backups/verksted
+            # The same share again, whole and read-only, for reading documents.
+            # readOnly is on the mount rather than the volume because the two
+            # mounts above still write; the kernel enforces it, so a delete
+            # under here fails with EROFS whatever an agent session tries. The
+            # container is unprivileged and cannot remount it, and dind does
+            # not mount it at all, so nothing in the pod can reach the share
+            # writably through this path.
+            - name: shared-data
+              mountPath: /mnt/shared
+              readOnly: true
         # Docker daemon for the agent sessions. Privileged is inherent to dind;
         # shares the pod netns so the app reaches it at localhost:2375.
         - name: dind


### PR DESCRIPTION
## Why

verksted's docs feature (search, catalogue, the `docs_*` tools) reads a share and writes the text it extracts to an index on the PVC. Nothing was mounted, so `DOCS_DIR` pointed at a path that did not exist and every call answered "no documents here".

## What

Mounts `shared-data` a second time, whole and read-only, at `/mnt/shared`, and points `DOCS_DIR` at it.

`readOnly` is on the mount rather than the volume because `/mnt/backups` and `/mnt/reelsmith` still write. The kernel enforces it, so a delete under this path fails with EROFS whatever an agent session tries; the verksted container is unprivileged and so cannot remount it; and dind does not mount the share at all, so a `docker run -v` from a session resolves in dind's own filesystem and finds nothing.

## Verification

Manifest change only. After the sync, `GET /api/sources` reports `docs: true` and `GET /api/docs` lists the share's top level. The nightly sweep extracts text to `/data/docs-index`; the share itself is never written to.