### PR TITLE
Add Cloudflare Web Analytics to bigd.no and manage all three sites

### DIFF
--- a/k8s/talos/apps/bigd/index.html
+++ b/k8s/talos/apps/bigd/index.html
@@ -222,5 +222,10 @@
     }
   }, 1000);
 </script>
+
+<!-- Cloudflare Web Analytics. The site is terraform/cloudflare/bigd-no/web-analytics.tf;
+     the token is public and identifies the site rather than authorising anything. -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "5ecf17fa1c45428990839c7f29555150"}'></script>
 </body>
 </html>

--- a/terraform/cloudflare/bigd-no/README.md
+++ b/terraform/cloudflare/bigd-no/README.md
@@ -31,6 +31,13 @@ otherwise apply fails with "record already exists":
 terraform import cloudflare_dns_record.ddns <zone_id>/<record_id>
 ```
 
+## Web Analytics
+
+`web-analytics.tf` creates the beacon site for bigd.no. After the first apply,
+`terraform output web_analytics_site_token` gives the token for the snippet in
+`k8s/talos/apps/bigd/index.html`. `auto_install` stays off because the snippet
+is in the page.
+
 ## Notes
 
 - `ddns` content is ignored. The DDNS client owns the address.

--- a/terraform/cloudflare/bigd-no/outputs.tf
+++ b/terraform/cloudflare/bigd-no/outputs.tf
@@ -2,3 +2,8 @@ output "zone_id" {
   description = "Cloudflare zone ID, useful for API calls and imports"
   value       = data.cloudflare_zone.this.zone_id
 }
+
+output "web_analytics_site_token" {
+  description = "Beacon token for the snippet in k8s/talos/apps/bigd/index.html"
+  value       = cloudflare_web_analytics_site.bigd.site_token
+}

--- a/terraform/cloudflare/bigd-no/variables.tf
+++ b/terraform/cloudflare/bigd-no/variables.tf
@@ -1,5 +1,5 @@
 variable "cloudflare_api_token" {
-  description = "API token with Zone:Read, DNS:Edit and Zone Settings:Edit on this zone. The token external-dns and cert-manager share is DNS-only and will not cover the zone setting resource."
+  description = "API token with Zone:Read, DNS:Edit and Zone Settings:Edit on this zone, plus account-level Web Analytics:Edit. The token external-dns and cert-manager share is DNS-only and will not cover the zone setting or Web Analytics resources."
   type        = string
   sensitive   = true
 }

--- a/terraform/cloudflare/bigd-no/web-analytics.tf
+++ b/terraform/cloudflare/bigd-no/web-analytics.tf
@@ -1,0 +1,8 @@
+# The beacon tag is in the page itself (k8s/talos/apps/bigd/index.html), so
+# auto_install stays off: the edge would inject a second copy and double-count
+# every view. Same shape as the two adopted sites in ../nordbye-it.
+resource "cloudflare_web_analytics_site" "bigd" {
+  account_id   = data.cloudflare_zone.this.account.id
+  zone_tag     = data.cloudflare_zone.this.zone_id
+  auto_install = false
+}

--- a/terraform/cloudflare/nordbye-it/README.md
+++ b/terraform/cloudflare/nordbye-it/README.md
@@ -13,7 +13,8 @@ terraform apply
 ```
 
 The token needs Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit,
-in a policy scoped to zones. An account-scoped policy alone does not grant DNS.
+in a policy scoped to zones, plus Web Analytics:Edit in an account-scoped one.
+An account-scoped policy alone does not grant DNS.
 It is the same token external-dns, cert-manager and the Kargo purge step read
 from Bitwarden, so it also carries Cache Purge, which nothing here needs.
 
@@ -37,6 +38,19 @@ The purge step reads a `cloudflare-api-token` Secret in each Kargo Project
 namespace — the shared broad token, not a purge-only one. It resolves the zone
 ID by name at promotion time rather than carrying it, so nothing has to be
 updated here if the zone is ever recreated.
+
+## Web Analytics
+
+`web-analytics.tf` adopts the two beacon sites that back nordbye.it and
+blog.nordbye.it. Their tokens are hardcoded in the pages
+(`portfolio/src/app/layout.tsx`, `blog/config/_default/params.toml`); an
+in-place update leaves those tokens alone.
+
+The two are not the same shape and cannot be made so. nordbye.it is bound to
+the zone (`zone_tag`, orange in the dashboard); blog is a gray-clouded site
+carrying a `host`. Cloudflare only builds that binding when a site is created,
+so converting blog means recreating it, with a new token and no history. The
+difference is cosmetic while the beacon is in the page.
 
 ## Notes
 

--- a/terraform/cloudflare/nordbye-it/outputs.tf
+++ b/terraform/cloudflare/nordbye-it/outputs.tf
@@ -2,3 +2,11 @@ output "zone_id" {
   description = "Cloudflare zone ID, useful for API calls and imports"
   value       = data.cloudflare_zone.this.zone_id
 }
+
+output "web_analytics_site_tokens" {
+  description = "Beacon tokens, matching the tags already embedded in each site's source"
+  value = {
+    portfolio = cloudflare_web_analytics_site.portfolio.site_token
+    blog      = cloudflare_web_analytics_site.blog.site_token
+  }
+}

--- a/terraform/cloudflare/nordbye-it/variables.tf
+++ b/terraform/cloudflare/nordbye-it/variables.tf
@@ -1,5 +1,5 @@
 variable "cloudflare_api_token" {
-  description = "API token with Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit on this zone. The token external-dns and cert-manager share is DNS-only and will not cover the zone setting or ruleset resources."
+  description = "API token with Zone:Read, DNS:Edit, Zone Settings:Edit and Cache Rules:Edit on this zone, plus account-level Web Analytics:Edit. The token external-dns and cert-manager share is DNS-only and will not cover the zone setting, ruleset or Web Analytics resources."
   type        = string
   sensitive   = true
 }

--- a/terraform/cloudflare/nordbye-it/web-analytics.tf
+++ b/terraform/cloudflare/nordbye-it/web-analytics.tf
@@ -1,0 +1,22 @@
+# Adopted, not created: removing a resource here deletes the site and its history.
+#
+# The beacon tag is in each site's own source — portfolio/src/app/layout.tsx and
+# blog/config/_default/params.toml — so auto_install stays off, or the edge
+# injects a second copy and double-counts every view.
+#
+# Declare each site exactly as it already is. Cloudflare builds the zone binding
+# only at creation, so blog cannot be moved from host to zone_tag without a
+# recreate that mints a new site_token, and an omitted host is sent as null,
+# which wipes the site's name.
+
+resource "cloudflare_web_analytics_site" "portfolio" {
+  account_id   = data.cloudflare_zone.this.account.id
+  zone_tag     = data.cloudflare_zone.this.zone_id
+  auto_install = false
+}
+
+resource "cloudflare_web_analytics_site" "blog" {
+  account_id   = data.cloudflare_zone.this.account.id
+  host         = "blog.${var.zone_name}"
+  auto_install = false
+}


### PR DESCRIPTION
## Why

bigd.no had no traffic measurement, while nordbye.it and blog.nordbye.it both carry a Cloudflare Web Analytics beacon. All three analytics sites were created in the dashboard and unmanaged.

## What

Beacon snippet on bigd.no, same shape as the blog theme partial. No CSP middleware on that route, so the script tag is the only manifest change.

`web-analytics.tf` in both zone configs. bigd.no is created; nordbye.it and blog.nordbye.it were adopted with import blocks, which have been removed now that both are in state.

`auto_install` stays off on all three. The injection ruleset is zone wide and its `rules` are read-only in the provider, so on the bigd.no zone it would inject into hub, it-tools, mealie, omni-tools and trek as well, and it stops silently if a hostname is taken off the proxy.

blog.nordbye.it stays a host-only site while the other two are zone bound. `zone_tag` is only honoured at creation, so converting it needs a recreate with a new token and no history.

Token scope notes in both READMEs and both `variables.tf`: the zone-scoped policy now needs account-level Web Analytics:Edit alongside it.

## Verification

Applied. `terraform plan` is clean in both directories.

- bigd-no: 1 added, then `No changes`
- nordbye-it: 2 imported, 0 changed, then `No changes`

Tokens confirmed against the API and unchanged for the two adopted sites, matching what the pages hardcode:

| site | token | source |
| --- | --- | --- |
| bigd.no | 5ecf17fa | k8s/talos/apps/bigd/index.html |
| nordbye.it | 24510296 | portfolio/src/app/layout.tsx |
| blog.nordbye.it | 47962423 | blog/config/_default/params.toml |

Page served from nginxinc/nginx-unprivileged:1.30-alpine, HTTP 200, 7166 bytes out matching the source file, beacon present with the right token.

`kubectl diff -k k8s/talos/apps/bigd --field-manager=argocd-controller` shows only the new ConfigMap and the Deployment volume reference, so the pod rolls on merge.