### PR TITLE
Route reelsmith's alerts to Discord regardless of severity

### DIFF
--- a/k8s/talos/infra/kube-prometheus-stack/values.yaml
+++ b/k8s/talos/infra/kube-prometheus-stack/values.yaml
@@ -137,6 +137,16 @@ alertmanager:
       group_interval: 5m
       repeat_interval: 12h
       routes:
+        # reelsmith runs unattended with nobody else watching it, and its
+        # warning-tier alerts (queue starved, backup stale, a post stuck) are
+        # the whole point of gateway/monitoring.yaml: the failure mode they
+        # catch never shows up as a restart or a 500. Dropped at warning like
+        # every other app's, they are silent by construction, which is how
+        # ReelsmithQueueStarved and ReelsmithPostStuck both sat firing for
+        # days unseen. Route the namespace ahead of the severity filter below.
+        - matchers:
+            - namespace = "reelsmith"
+          receiver: discord
         # Only critical alerts reach Discord; everything else is dropped.
         - matchers:
             - severity = "critical"


### PR DESCRIPTION
## Summary

Traced a "no reels in the queue" incident on reelsmith to a pipeline bug
(separate PR: mortennordbye/reelsmith#83) and then asked the obvious next
question: why did nobody find out sooner? `ReelsmithQueueStarved` has been
firing since 06:09 this morning, and `ReelsmithPostStuck` since
**2026-09-02** — five days. Both are `severity: warning`, and the current
route sends everything except `severity=critical` to the `null` receiver, so
neither alert has ever reached Discord.

`gateway/monitoring.yaml` built four warning-tier alerts
(`ReelsmithQueueStarved`, `ReelsmithBackupStale`, `ReelsmithPublishFailing`,
`ReelsmithPostStuck`) specifically because reelsmith runs unattended and
fails by going quiet, not by crashing — its own header comment says as much.
Under the blanket "only critical" policy those alerts are silent by
construction, which defeats the reason they were written.

## Fix

Add a `namespace = "reelsmith"` route ahead of the severity filter, so every
reelsmith alert reaches Discord regardless of severity. Every other
namespace's warning-tier alerts keep dropping to `null` exactly as before —
this doesn't touch the blanket policy anywhere else.

## Test plan

- [x] `yq eval` on the edited values.yaml to confirm it's still valid YAML.
- [ ] After merge, confirm in Alertmanager that `ReelsmithQueueStarved` and
      `ReelsmithPostStuck` (both currently firing) show up in
      `#homelab-alerts` on the next `group_interval`.