### PR TITLE
Add the Trek and Headroom demo tiles to hub.bigd.no

### DIFF
--- a/k8s/talos/apps/homepage/values.yaml
+++ b/k8s/talos/apps/homepage/values.yaml
@@ -139,6 +139,10 @@ config:
             icon: mdi-head-cog
             href: https://headroom.local.bigd.no
             description: Self-hosted Headroom instance
+        - Headroom (Demo):
+            icon: mdi-head-cog
+            href: https://headroom.nordbye.it
+            description: Public demo with fictional data
         - Mealie:
             icon: mealie.png
             href: https://mealie.bigd.no
@@ -159,6 +163,10 @@ config:
             icon: si-instagram
             href: https://gate.nordbye.it/healthz
             description: Public endpoint Meta fetches Reels from
+        - Trek:
+            icon: mdi-map-marker-path
+            href: https://trek.bigd.no
+            description: Travel planner
         - BigD:
             icon: mdi-web
             href: https://bigd.no


### PR DESCRIPTION
## Why

Two hostnames the cluster serves had no tile on hub.bigd.no: `trek.bigd.no` (the Trek travel planner, deployed in 6b3bee86) and `headroom.nordbye.it` (the public headroom-demo instance).

## What

Two entries under Public Sites in `k8s/talos/apps/homepage/values.yaml`, placed next to their siblings: Headroom (Demo) after the local Headroom tile, Trek before BigD.

## Verification

Cross-checked every `HTTPRoute` hostname under `k8s/talos/**` against the dashboard config. These were the only two missing. `values.yaml` parses and Public Sites renders 20 entries.

Four tiles point at workloads that no longer exist anywhere in the repo (Readarr, Tdarr, Cleanuparr, Huntarr, plus LogEveryLift (Local) at `logeverylift.local.bigd.no`). Left alone here, worth a follow-up cleanup.