### PR TITLE
Portfolio: add the DevOps Engineer Expert certification

### DIFF
--- a/portfolio/src/app/layout.tsx
+++ b/portfolio/src/app/layout.tsx
@@ -131,6 +131,12 @@ const jsonLd = {
     },
     {
       "@type": "EducationalOccupationalCredential",
+      name: "Microsoft Certified: DevOps Engineer Expert (AZ-400)",
+      credentialCategory: "certification",
+      recognizedBy: { "@type": "Organization", name: "Microsoft" },
+    },
+    {
+      "@type": "EducationalOccupationalCredential",
       name: "Microsoft Certified: Azure Solutions Architect Expert (AZ-305)",
       credentialCategory: "certification",
       recognizedBy: { "@type": "Organization", name: "Microsoft" },

--- a/portfolio/src/components/sections/Hero.tsx
+++ b/portfolio/src/components/sections/Hero.tsx
@@ -96,13 +96,14 @@ export function Hero() {
             {site.hero.sub}
           </p>
 
-          {/* The two certifications are card stock set down on the desk. The
+          {/* The certifications are card stock set down on the desk. The
               other two lines are claims rather than objects, so they are set as
               plain type beside them — four sheets of paper in a row is louder
               than one lamp allows. */}
           <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-3">
             <Tag variant="paper">CKA</Tag>
             <Tag variant="paper">AZ-305</Tag>
+            <Tag variant="paper">AZ-400</Tag>
             <span className="font-mono text-xs tracking-wide text-fg-3">
               4+ yrs production cloud
             </span>

--- a/portfolio/src/content/resume.ts
+++ b/portfolio/src/content/resume.ts
@@ -9,6 +9,12 @@ import {
 
 const certsRaw: Cert[] = [
   {
+    title: "Microsoft Certified: DevOps Engineer Expert",
+    issuer: "Microsoft",
+    date: "Sep 2026",
+    credentialId: "F8616ED44F1AA2F4",
+  },
+  {
     title: "GitHub Actions Certification",
     issuer: "GitHub (Microsoft)",
     date: "Jul 2026",


### PR DESCRIPTION
## Why

New certification earned Sep 2026: Microsoft Certified: DevOps Engineer Expert.

## What

- `resume.ts`: new entry at the top of `certsRaw`. Everything downstream derives from it (resume sheet, cert counts, `/api/v1/profile`, the `ls certs` shelf, the LaTeX CV).
- `Hero.tsx`: third card-stock chip, `AZ-400`, beside CKA and AZ-305. The row's rule (branding/DECISIONS.md) caps paper at three sheets, so this sits at the ceiling.
- `layout.tsx`: added to the Person JSON-LD `hasCredential` list as AZ-400.

## Verification

- `make typecheck` and `make lint` clean (48 pre-existing warnings, 0 errors).
- Dev stack loaded in a browser: hero chips stay on one line at 1280 and 390; the resume sheet renders the entry with issuer and credential ID.