### PR TITLE
Reelsmith: restore a second daily slot at 12:10 Oslo

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -19,11 +19,27 @@ data:
   # slot+date, not rolled at runtime, so a restart cannot double-publish.
   # The Facebook id is the Page id from GET /me/accounts, not the number in the
   # Page's profile URL.
+  # Two slots a day per platform since 2026-09-10, restoring cadence without
+  # restoring the slot that was dropped for cause. Measured 2026-08-19 at n=58,
+  # the three slots then running scored 06:00 UTC at 63.6% median skip with 27%
+  # of posts over 500 views, 10:00 UTC at 65.5% and 22%, and 17:00 UTC at 76.3%
+  # and 6%. The cut on 2026-08-27 kept only the first and dropped both others,
+  # including the one that was nearly as good. Per-post views did not improve
+  # afterwards: 132 median on three-post days against 126 on one-post days over
+  # 93 posts, so the cut removed two thirds of the volume and bought nothing.
+  #
+  # 12:10 Oslo is the 10:00 UTC group above. The evening slot stays gone. Two
+  # populated slots also restore `--cohorts slot`, which has been unable to
+  # answer anything since 11 of 13 posts landed in a single slot.
   GATEWAY_SLOTS: |
     08:10 Europe/Oslo jitter=15 account=17841441696714445
     08:10 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
     08:10 Europe/Oslo jitter=15 account=-000y6NKYZ3EEbUGgXiyJ9nG66a_xqrF68Me
     08:10 Europe/Oslo jitter=15 account=1236596692875712
+    12:10 Europe/Oslo jitter=15 account=17841441696714445
+    12:10 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
+    12:10 Europe/Oslo jitter=15 account=-000y6NKYZ3EEbUGgXiyJ9nG66a_xqrF68Me
+    12:10 Europe/Oslo jitter=15 account=1236596692875712
 
   # Named zone, not an offset, so slots keep their local hour across DST.
   GATEWAY_DEFAULT_TIMEZONE: "Europe/Oslo"


### PR DESCRIPTION
## Why

Cadence was cut from three posts a day to one on 2026-08-27, keeping only the 08:10 Oslo slot. Measured over the account's 93 posts with insights, that bought nothing per post:

| Posts that day | Median views per post |
|---|---|
| 3 | 132 |
| 1 | 126 |

So the cut removed two thirds of the volume and left per-post performance unchanged. Total weekly views fell roughly 3x.

## What

Adds a second slot at 12:10 Europe/Oslo for all four platforms. That is the 10:00 UTC group, which at n=58 scored 65.5% median skip with 22% of posts over 500 views, against 63.6% and 27% for the 08:10 slot that survived.

The evening slot stays gone. It scored 76.3% and 6% over 500, and it is the reason the cut was made.

A second populated slot also restores `--cohorts slot`. Since the cut, 11 of 13 posts have landed in a single slot, so the comparison that produced the evening finding can no longer be run against the change that was made because of it.

## Verification

Parses as YAML; 8 slot lines, 2 per account, every line carries an explicit `account=` so the config sweep cannot hit the unattributed-line freeze (F0).

**Do not roll out inside a slot window**, which is now 06:10 and 10:10 UTC, each plus or minus 20 minutes of jitter.

## Paired change, not yet made

Two a day is 60 repos a month against a 30 day cooldown, and three of the last four picks were already repeats. The third discovery query (`_build_queries` in the reelsmith repo) should land before or with this, or supply degrades rather than output increasing.