### PR TITLE
Name reelsmith slots by identity, and give the second one a schedule

### DIFF
--- a/k8s/talos/apps/reelsmith/configmap.yaml
+++ b/k8s/talos/apps/reelsmith/configmap.yaml
@@ -31,15 +31,15 @@ data:
   # 12:10 Oslo is the 10:00 UTC group above. The evening slot stays gone. Two
   # populated slots also restore `--cohorts slot`, which has been unable to
   # answer anything since 11 of 13 posts landed in a single slot.
+  #
+  # One line per identity per time. A brand covers every destination it holds,
+  # so registering a fourth platform needs no edit here, and a brand matching
+  # no account freezes the sweep rather than deleting slots. One a day for the
+  # second identity, which has one episode and no measured cadence yet.
   GATEWAY_SLOTS: |
-    08:10 Europe/Oslo jitter=15 account=17841441696714445
-    08:10 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
-    08:10 Europe/Oslo jitter=15 account=-000y6NKYZ3EEbUGgXiyJ9nG66a_xqrF68Me
-    08:10 Europe/Oslo jitter=15 account=1236596692875712
-    12:10 Europe/Oslo jitter=15 account=17841441696714445
-    12:10 Europe/Oslo jitter=20 account=UCH8RDOkbzDna2mDAlq4GaFw
-    12:10 Europe/Oslo jitter=15 account=-000y6NKYZ3EEbUGgXiyJ9nG66a_xqrF68Me
-    12:10 Europe/Oslo jitter=15 account=1236596692875712
+    08:10 Europe/Oslo jitter=15 brand=thenightlybuild
+    12:10 Europe/Oslo jitter=15 brand=thenightlybuild
+    08:10 Europe/Oslo jitter=15 brand=thewholequote
 
   # Named zone, not an offset, so slots keep their local hour across DST.
   GATEWAY_DEFAULT_TIMEZONE: "Europe/Oslo"


### PR DESCRIPTION
## Why

The Whole Quote is registered on YouTube, Instagram and Facebook with nothing scheduled, so none of it publishes.

Adding one more `account=` line would have left this file naming the same thing two ways: eight lines keyed on opaque ids and one keyed on a brand, with nothing on the page explaining why.

## What

Every line is keyed on the identity. Nine lines become three, and registering a fourth platform for either identity needs no edit here, which is the coupling between these two repos that nothing checks.

```
08:10 Europe/Oslo jitter=15 brand=thenightlybuild
12:10 Europe/Oslo jitter=15 brand=thenightlybuild
08:10 Europe/Oslo jitter=15 brand=thewholequote
```

**One behaviour change, and it is small.** Expanded against the live accounts table, the schedule is identical except the YouTube jitter drops from 20 to 15. That 20 was never deliberate: #648 gave the channel its own line and its reasoning is entirely about posting frequency and the inauthentic content policy. 15 is this file's own `GATEWAY_DEFAULT_JITTER_MINUTES`.

Six of account 1's eight rows keep their exact shape, so the sweep keeps their ids and their derived jitter. Only the two YouTube rows are recreated.

A brand matching no registered account freezes the slot sweep rather than deleting anything, so a typo costs a schedule that stays as it was rather than one that disappears at boot.

One slot a day for the second identity, which has one episode rendered and no measured cadence yet.

## Verification

Parsed with the gateway's own `parse_slots`, the function that fails the boot on a bad line, then both versions expanded against `GET /api/accounts`:

```
old: 8 lines -> 8 slots      new: 3 lines -> 11 slots

  dropped: 08:10 jitter=20  youtube/thenightlybuild
  dropped: 12:10 jitter=20  youtube/thenightlybuild
  added  : 08:10 jitter=15  youtube/thenightlybuild
  added  : 12:10 jitter=15  youtube/thenightlybuild
  added  : 08:10 jitter=15  youtube/thewholequote
  added  : 08:10 jitter=15  instagram/thewholequote
  added  : 08:10 jitter=15  facebook/thewholequote
```

The running gateway already understands `brand=`: it shipped in reelsmith #101 and has been deployed since 06:22 today.

## Timing

Not between 09:50 and 10:30 UTC. That is the second slot window and the gateway auto-deploys, so a rollout landing inside it restarts the pod mid publish.