### PR TITLE
Copy reelsmith's state backups off the state volume

### DIFF
--- a/k8s/talos/apps/reelsmith/deployment.yaml
+++ b/k8s/talos/apps/reelsmith/deployment.yaml
@@ -68,12 +68,22 @@ spec:
             # Service address.
             - name: GATEWAY_PUBLIC_BASE_URL
               value: "https://gate.nordbye.it"
+            # A second copy of each state backup, off the state volume. The
+            # copies in /state/backups die with the PVC (reclaim policy
+            # Delete); these are on a different NAS share.
+            - name: GATEWAY_BACKUP_OFFSITE_DIR
+              value: /offsite
           envFrom:
             - configMapRef:
                 name: reelsmith-config
           volumeMounts:
             - name: state
               mountPath: /state
+            # Only the gateway-backups directory of the share, not the
+            # render host's private half that sits beside it.
+            - name: offsite
+              mountPath: /offsite
+              subPath: gateway-backups
             # readOnlyRootFilesystem is on; Python still needs a writable /tmp.
             - name: tmp
               mountPath: /tmp
@@ -102,6 +112,12 @@ spec:
         - name: state
           persistentVolumeClaim:
             claimName: reelsmith-state
+        # The same share verksted mounts at /mnt/reelsmith. Inline NFS rather
+        # than a PVC, so deleting anything in this namespace cannot take it.
+        - name: offsite
+          nfs:
+            server: nas.local.bigd.no
+            path: /volume1/shared-data/media/reelsmith
         - name: tmp
           emptyDir: {}
 

--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -115,6 +115,21 @@ spec:
               Usually a full state volume. The copies live beside the database and the newest 14 are kept.
               Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i backup
 
+        # The copy that survives losing the state volume. Same shape as the
+        # rule above; a mount that went away shows here and nowhere else.
+        - alert: ReelsmithOffsiteBackupStale
+          expr: |
+            (time() - reelsmith_backup_offsite_last_success_timestamp > 86400)
+              and (reelsmith_backup_offsite_last_success_timestamp > 0)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith has not copied a backup off its volume in {{ $value | printf "%.0f" }}s'
+            description: |
+              The copies go to /volume1/shared-data/media/reelsmith/gateway-backups on the NAS.
+              Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i offsite
+
         - alert: ReelsmithPublishFailing
           expr: increase(reelsmith_publish_failures_total[1h]) > 0
           for: 5m


### PR DESCRIPTION
## Why
reelsmith's gateway writes `VACUUM INTO` backups every six hours into `/state/backups`, on the same 1 Gi PVC as the database, which reclaims with Delete. Upcoming schema migrations need a copy that survives losing that volume.

## What
- An inline NFS volume on `nas.local.bigd.no:/volume1/shared-data/media/reelsmith`, mounted with `subPath: gateway-backups` at `/offsite`, so the pod sees only that directory and not the render host's private files beside it.
- `GATEWAY_BACKUP_OFFSITE_DIR=/offsite`. The gateway copies each finished backup there and keeps 28 (reelsmith PR adding the setting). An older image ignores the variable.
- `ReelsmithOffsiteBackupStale` alert on `reelsmith_backup_offsite_last_success_timestamp`, same shape as the existing backup alert.

## Verification
- `kubectl kustomize k8s/talos/apps/reelsmith` renders.
- After sync: pod Ready, `/offsite` holds a `state-*.sqlite3` once the new image runs its startup backup.