### PR TITLE
Revert: copy reelsmith's state backups off the state volume

### DIFF
--- a/k8s/talos/apps/reelsmith/deployment.yaml
+++ b/k8s/talos/apps/reelsmith/deployment.yaml
@@ -68,22 +68,12 @@ spec:
             # Service address.
             - name: GATEWAY_PUBLIC_BASE_URL
               value: "https://gate.nordbye.it"
-            # A second copy of each state backup, off the state volume. The
-            # copies in /state/backups die with the PVC (reclaim policy
-            # Delete); these are on a different NAS share.
-            - name: GATEWAY_BACKUP_OFFSITE_DIR
-              value: /offsite
           envFrom:
             - configMapRef:
                 name: reelsmith-config
           volumeMounts:
             - name: state
               mountPath: /state
-            # Only the gateway-backups directory of the share, not the
-            # render host's private half that sits beside it.
-            - name: offsite
-              mountPath: /offsite
-              subPath: gateway-backups
             # readOnlyRootFilesystem is on; Python still needs a writable /tmp.
             - name: tmp
               mountPath: /tmp
@@ -112,12 +102,6 @@ spec:
         - name: state
           persistentVolumeClaim:
             claimName: reelsmith-state
-        # The same share verksted mounts at /mnt/reelsmith. Inline NFS rather
-        # than a PVC, so deleting anything in this namespace cannot take it.
-        - name: offsite
-          nfs:
-            server: nas.local.bigd.no
-            path: /volume1/shared-data/media/reelsmith
         - name: tmp
           emptyDir: {}
 

--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -115,21 +115,6 @@ spec:
               Usually a full state volume. The copies live beside the database and the newest 14 are kept.
               Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i backup
 
-        # The copy that survives losing the state volume. Same shape as the
-        # rule above; a mount that went away shows here and nowhere else.
-        - alert: ReelsmithOffsiteBackupStale
-          expr: |
-            (time() - reelsmith_backup_offsite_last_success_timestamp > 86400)
-              and (reelsmith_backup_offsite_last_success_timestamp > 0)
-          for: 30m
-          labels:
-            severity: warning
-          annotations:
-            summary: 'reelsmith has not copied a backup off its volume in {{ $value | printf "%.0f" }}s'
-            description: |
-              The copies go to /volume1/shared-data/media/reelsmith/gateway-backups on the NAS.
-              Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i offsite
-
         - alert: ReelsmithPublishFailing
           expr: increase(reelsmith_publish_failures_total[1h]) > 0
           for: 5m


### PR DESCRIPTION
## Why
The gateway pod cannot be created: the reelsmith namespace enforces Pod Security `restricted`, which forbids inline `nfs` volumes (`violates PodSecurity "restricted:latest": restricted volume types (volume "offsite" uses restricted volume type "nfs")`). The gateway is down until this reverts.

## What
Reverts #947.

## Verification
After sync the gateway pod is created and Ready.