### PR TITLE
Add a retained NFS volume for reelsmith's offsite backups

### DIFF
--- a/k8s/talos/apps/reelsmith/kustomization.yaml
+++ b/k8s/talos/apps/reelsmith/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - externalsecret.yaml
 - configmap.yaml
 - state-pvc.yaml
+- offsite-pv.yaml
 - deployment.yaml
 - httproute.yaml
 - httproute-admin.yaml

--- a/k8s/talos/apps/reelsmith/offsite-pv.yaml
+++ b/k8s/talos/apps/reelsmith/offsite-pv.yaml
@@ -1,0 +1,46 @@
+# Where reelsmith's gateway copies its state backups, off the state volume.
+#
+# reelsmith-state is a dynamically provisioned PVC that reclaims with Delete,
+# and the gateway's VACUUM INTO copies sit beside the database on it, so they
+# do not survive the volume. This is a different NAS share, statically bound.
+#
+# A PersistentVolume rather than an inline nfs volume on the pod: the namespace
+# enforces Pod Security restricted, which refuses inline nfs volumes (that is
+# what took the gateway down on 2026-09-12, reverted in #948). PSA checks the
+# pod's volume types, and a PVC is allowed whatever backs it.
+#
+# The pod mounts this with subPath: gateway-backups, so it sees only that
+# directory and not the render host's private files beside it on the share.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: reelsmith-offsite-backups
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  # Retain: deleting the claim must never take the backups with it, which is
+  # the whole reason this exists.
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  claimRef:
+    namespace: reelsmith
+    name: reelsmith-offsite-backups
+  nfs:
+    server: nas.local.bigd.no
+    path: /volume1/shared-data/media/reelsmith
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: reelsmith-offsite-backups
+  namespace: reelsmith
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  volumeName: reelsmith-offsite-backups
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Why
reelsmith's gateway needs somewhere to copy its state backups that survives losing the state PVC (reclaim Delete). #947 tried an inline `nfs` volume on the pod, which the namespace's Pod Security `restricted` level refuses, and the gateway was down until #948 reverted it.

## What
- `offsite-pv.yaml`: a static PersistentVolume on `nas.local.bigd.no:/volume1/shared-data/media/reelsmith`, reclaim `Retain`, `storageClassName: ""`, pre-bound by `claimRef` to `reelsmith/reelsmith-offsite-backups`, and that PVC.
- Nothing mounts it in this PR, so no pod restarts. The deployment mount follows in a separate PR once a test pod has confirmed the mount works under `restricted`.

## Verification
- `kubectl apply --dry-run=server -f offsite-pv.yaml` accepts both objects.
- `kubectl kustomize k8s/talos/apps/reelsmith` renders.
- After sync: the PVC is Bound and the gateway pod is unchanged.