### PR TITLE
Mount reelsmith's offsite backup volume in the gateway

### DIFF
--- a/k8s/talos/apps/reelsmith/deployment.yaml
+++ b/k8s/talos/apps/reelsmith/deployment.yaml
@@ -68,12 +68,22 @@ spec:
             # Service address.
             - name: GATEWAY_PUBLIC_BASE_URL
               value: "https://gate.nordbye.it"
+            # A second copy of each state backup, off the state volume. The
+            # copies in /state/backups die with the PVC (reclaim policy
+            # Delete); these are on a retained volume on another NAS share.
+            - name: GATEWAY_BACKUP_OFFSITE_DIR
+              value: /offsite
           envFrom:
             - configMapRef:
                 name: reelsmith-config
           volumeMounts:
             - name: state
               mountPath: /state
+            # Only the gateway-backups directory of the share, not the render
+            # host's private files beside it.
+            - name: offsite
+              mountPath: /offsite
+              subPath: gateway-backups
             # readOnlyRootFilesystem is on; Python still needs a writable /tmp.
             - name: tmp
               mountPath: /tmp
@@ -102,6 +112,11 @@ spec:
         - name: state
           persistentVolumeClaim:
             claimName: reelsmith-state
+        # A claim, not an inline nfs volume: the namespace is PSA restricted,
+        # and an inline nfs volume here took the gateway down (#947, #948).
+        - name: offsite
+          persistentVolumeClaim:
+            claimName: reelsmith-offsite-backups
         - name: tmp
           emptyDir: {}
 

--- a/k8s/talos/apps/reelsmith/monitoring.yaml
+++ b/k8s/talos/apps/reelsmith/monitoring.yaml
@@ -115,6 +115,22 @@ spec:
               Usually a full state volume. The copies live beside the database and the newest 14 are kept.
               Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i backup
 
+        # The copy that survives losing the state volume. Same shape as the
+        # rule above; a mount that went away shows here and nowhere else.
+        - alert: ReelsmithOffsiteBackupStale
+          expr: |
+            (time() - reelsmith_backup_offsite_last_success_timestamp > 86400)
+              and (reelsmith_backup_offsite_last_success_timestamp > 0)
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: 'reelsmith has not copied a backup off its volume in {{ $value | printf "%.0f" }}s'
+            description: |
+              The copies go to /volume1/shared-data/media/reelsmith/gateway-backups on the NAS,
+              through the retained reelsmith-offsite-backups volume.
+              Check: kubectl -n reelsmith logs deploy/reelsmith-gateway | grep -i offsite
+
         - alert: ReelsmithPublishFailing
           expr: increase(reelsmith_publish_failures_total[1h]) > 0
           for: 5m


### PR DESCRIPTION
## Why
Second half of reelsmith's off-volume backup, after #949 added the retained volume. #947 did this with an inline `nfs` volume, which the namespace's Pod Security `restricted` level refuses; #948 reverted it.

## What
- The gateway mounts the `reelsmith-offsite-backups` claim at `/offsite` with `subPath: gateway-backups`, so it sees only that directory of the share.
- `GATEWAY_BACKUP_OFFSITE_DIR=/offsite`. Images without the setting ignore it (reelsmith PR #134 adds it).
- `ReelsmithOffsiteBackupStale` on `reelsmith_backup_offsite_last_success_timestamp`.

## Verification
- A Pod built from this Deployment's pod template passes `kubectl create --dry-run=server` in `reelsmith`. The same Pod with the inline nfs volume from #947 is refused with the error that caused the outage, so the check is real. A server dry run of the Deployment alone accepts both and is not a valid check.
- `kubectl kustomize k8s/talos/apps/reelsmith` renders.
- Before merging: a throwaway pod mounting the claim with this subPath, as uid 10001 under `restricted`, writes and reads a file.